### PR TITLE
chore: improved typing for evmTokenApi

### DIFF
--- a/src/api/evmTokenApi.ts
+++ b/src/api/evmTokenApi.ts
@@ -1,5 +1,11 @@
 // src/api/evmTokenApi.ts
-import { Network } from "@/types/web3";
+import {
+  Network,
+  TokenAddressInfo,
+  TokenBalance,
+  TokenMetadata,
+  TokenPriceResult,
+} from "@/types/web3";
 
 // Unified API Response type
 export interface ApiResponse<T> {
@@ -11,33 +17,6 @@ export interface ApiResponse<T> {
 // Core request type that all requests extend from
 export interface BaseRequest {
   network: Network;
-}
-
-// Token-related types
-export interface TokenBalance {
-  contractAddress: string;
-  tokenBalance: string;
-}
-
-export interface TokenMetadata {
-  name: string;
-  symbol: string;
-  decimals: number;
-  logo?: string;
-  totalSupply?: string;
-}
-
-export interface TokenPrice {
-  currency: string;
-  value: string;
-  lastUpdatedAt: string;
-}
-
-export interface TokenPriceResult {
-  network: Network;
-  address: string;
-  prices: TokenPrice[];
-  error: string | null;
 }
 
 // Endpoint-specific request types
@@ -54,11 +33,6 @@ export interface AllowanceRequest extends BaseRequest {
 
 export interface MetadataRequest extends BaseRequest {
   contractAddress: string;
-}
-
-export interface TokenAddressInfo {
-  network: Network;
-  address: string;
 }
 
 export interface PricesRequest {

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -35,6 +35,7 @@ export type Token = {
   chainId: number;
   userBalance?: string;
   userBalanceUsd?: string;
+  priceUsd?: string;
   isWalletToken?: boolean;
 };
 
@@ -203,4 +204,35 @@ export enum Network {
   DEGEN_MAINNET = "degen-mainnet",
   INK_MAINNET = "ink-mainnet",
   INK_SEPOLIA = "ink-sepolia",
+}
+
+export interface TokenBalance {
+  contractAddress: string;
+  tokenBalance: string;
+}
+
+export interface TokenMetadata {
+  name: string;
+  symbol: string;
+  decimals: number;
+  logo?: string;
+  totalSupply?: string;
+}
+
+export interface TokenPrice {
+  currency: string;
+  value: string;
+  lastUpdatedAt: string;
+}
+
+export interface TokenAddressInfo {
+  network: Network;
+  address: string;
+}
+
+export interface TokenPriceResult {
+  network: Network;
+  address: string;
+  prices: TokenPrice[];
+  error: string | null;
 }


### PR DESCRIPTION
Moved some type definitions out of `evmTokenApi` and into `types/web3.ts` where they belong.