### PR TITLE
feat: web3store preparation for prices and balances

### DIFF
--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -85,6 +85,9 @@ export interface Web3StoreState {
     receiveAddress: string | null;
   };
 
+  tokenBalancesByWallet: Record<string, Record<string, string>>; // chainId_walletAddress -> tokenAddress -> balance
+  tokenPricesUsd: Record<string, string>; // chainId_tokenAddress -> USD price
+
   // Wallet actions
   addWallet: (wallet: WalletInfo) => void;
   removeWallet: (walletType: WalletType) => void;
@@ -105,16 +108,19 @@ export interface Web3StoreState {
 
   // Token data actions
   loadTokens: () => Promise<void>;
-  getWalletTokens: () => Token[];
-  getAllTokens: () => Token[];
   getTokensForChain: (chainId: number) => Token[];
-  getTokenById: (compositeKey: string) => Token | undefined;
-  getTokenByAddress: (address: string, chainId: number) => Token | undefined;
-  findTokenByAddressAnyChain: (address: string) => Token | undefined;
 
   // Transaction details actions
   setSlippageValue: (value: "auto" | string) => void;
   setReceiveAddress: (address: string | null) => void;
+
+  updateTokenBalances: (
+    chainId: number,
+    userAddress: string,
+    balances: TokenBalance[],
+  ) => void;
+  updateTokenPrices: (priceResults: TokenPriceResult[]) => void;
+  setTokensLoading: (loading: boolean) => void;
 }
 
 export enum Network {


### PR DESCRIPTION
branched off https://github.com/altverseweb3/site/pull/13, https://github.com/altverseweb3/site/pull/14

This PR involves changes to the `Web3Store` state and the `web3Store` implementation in preparation for prices and balances loading.

**Removed (as they were unused):**
- `getWalletTokens`
- `getAllTokens`
- `getTokenById`
- `getTokenByAddress`
- `findTokenByAddressAnyChain`

**Added:**
- `tokenBalancesByWallet`: used for internal calculations and tracking inside web3Store when updating balances for a wallet
- `tokenPricesUsd`: used for internal calculations and tracking inside web3Store when updating prices for tokens
- `updateTokenBalances`: function to update token balances with data received from Lambda API
- `updateTokenPrices`: function to update token prices with data received from Lambda API
- `setTokensLoading`: variable used to track the balance/prices loading state for other components (such as `SelectTokenButton.tsx`

### Functions explained
#### `updateTokenBalances`
- Creates a wallet-specific key from chainId and user address
- Stores token balances in a wallet-specific collection
- Updates token objects with user balance information
- Calculates USD value of balances when price data is available
- Converts hex balances to decimal format
- Marks tokens with balances as "isWalletToken: true"
- Updates all derived token collections (by composite key, chainId, address)
- Preserves existing balances for tokens not included in the update

#### `updateTokenPrices`
- Processes price data for tokens
- Stores prices in a composite-key indexed collection (chainId-tokenAddress)
- Updates token objects with price information (priceUsd field)
- Calculates USD value of user balances when both price and balance exist
- Handles conversion of hex balances to decimal format
- Logs errors for failed price lookups or missing chain configurations
- Updates all derived token collections after price updates
- Preserves existing token data for tokens not included in price results

#### `updateTokenCollections`
- **this is a helper function for `web3Store`, utilised by `updateTokenBalances` and `updateTokenPrices`, but not part of the storage context**
- Creates three optimized access patterns for token data
- Indexes tokens by composite key (chainId-address string)
- Groups tokens by chainId for chain-specific operations
- Creates a two-level lookup by chainId and address
- Normalizes token addresses to lowercase for consistent access
- Handles initialization of empty collections for new chains
- Returns reorganized collections without modifying the store directly - this will instead be done safely by the caller
- Supports efficient token lookups by various criteria (key, chain, address)
