### PR TITLE
feat: added fees from quote, source/destination prices

### DIFF
--- a/src/app/(dapp)/swap/page.tsx
+++ b/src/app/(dapp)/swap/page.tsx
@@ -17,6 +17,9 @@ const SwapComponent: React.FC = () => {
     sourceToken,
     destinationToken,
     estimatedTimeSeconds,
+    totalFeeUsd,
+    protocolFeeUsd,
+    relayerFeeUsd,
   } = useTokenTransfer({
     type: "swap",
     onSuccess: (amount, sourceToken, destinationToken) => {
@@ -41,6 +44,9 @@ const SwapComponent: React.FC = () => {
       hasSourceToken={!!sourceToken}
       hasDestinationToken={!!destinationToken}
       estimatedTimeSeconds={estimatedTimeSeconds}
+      protocolFeeUsd={protocolFeeUsd ?? undefined}
+      relayerFeeUsd={relayerFeeUsd ?? undefined}
+      totalFeeUsd={totalFeeUsd ?? undefined}
     />
   );
 };

--- a/src/app/(dapp)/swap/page.tsx
+++ b/src/app/(dapp)/swap/page.tsx
@@ -20,6 +20,8 @@ const SwapComponent: React.FC = () => {
     totalFeeUsd,
     protocolFeeUsd,
     relayerFeeUsd,
+    sourceAmountUsd,
+    destinationAmountUsd,
   } = useTokenTransfer({
     type: "swap",
     onSuccess: (amount, sourceToken, destinationToken) => {
@@ -47,6 +49,8 @@ const SwapComponent: React.FC = () => {
       protocolFeeUsd={protocolFeeUsd ?? undefined}
       relayerFeeUsd={relayerFeeUsd ?? undefined}
       totalFeeUsd={totalFeeUsd ?? undefined}
+      sourceAmountUsd={sourceAmountUsd ?? undefined}
+      destinationAmountUsd={destinationAmountUsd ?? undefined}
     />
   );
 };

--- a/src/components/ui/SwapInterface.tsx
+++ b/src/components/ui/SwapInterface.tsx
@@ -16,11 +16,10 @@ interface SwapInterfaceProps {
     disabled?: boolean;
   };
   className?: string;
-  // Transaction details props
-  exchangeRate?: string;
-  exchangeValue?: string;
-  gasFee?: string;
-  estimatedTime?: string | number | null; // Allow null for estimated time
+  protocolFeeUsd?: number;
+  relayerFeeUsd?: number;
+  totalFeeUsd?: number;
+  estimatedTime?: number | null; // Allow null for estimated time
   enforceSourceChain?: boolean;
   renderActionButton?: () => ReactNode;
   detailsOpen?: boolean;
@@ -31,9 +30,9 @@ export function SwapInterface({
   children,
   actionButton,
   className = "",
-  exchangeRate,
-  exchangeValue,
-  gasFee,
+  protocolFeeUsd,
+  relayerFeeUsd,
+  totalFeeUsd,
   estimatedTime,
   enforceSourceChain = true,
   renderActionButton,
@@ -189,9 +188,9 @@ export function SwapInterface({
         </div>
 
         <TransactionDetails
-          exchangeRate={exchangeRate}
-          exchangeValue={exchangeValue}
-          gasFee={gasFee}
+          protocolFeeUsd={protocolFeeUsd}
+          relayerFeeUsd={relayerFeeUsd}
+          totalFeeUsd={totalFeeUsd}
           estimatedTime={estimatedTime} // Pass number or string
           isOpen={detailsOpen}
           onToggle={onDetailsToggle}

--- a/src/components/ui/TokenAmountInput.tsx
+++ b/src/components/ui/TokenAmountInput.tsx
@@ -4,7 +4,7 @@ import { NumberTicker } from "@/components/ui/NumberTicker";
 interface TokenAmountInputProps {
   amount: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  dollarValue?: string;
+  dollarValue?: number;
   readOnly?: boolean;
   placeholder?: string;
   isLoadingQuote?: boolean;
@@ -14,7 +14,7 @@ interface TokenAmountInputProps {
 export function TokenAmountInput({
   amount,
   onChange,
-  dollarValue = "$0.00",
+  dollarValue = 0,
   readOnly = false,
   placeholder = "0",
   isLoadingQuote = false,
@@ -56,7 +56,9 @@ export function TokenAmountInput({
           disabled={readOnly}
         />
       )}
-      <span className="text-zinc-400 text-sm numeric-input">{dollarValue}</span>
+      <span className="text-zinc-400 text-sm numeric-input">
+        ${(Math.round(dollarValue * 100) / 100).toFixed(2)}
+      </span>
     </div>
   );
 }

--- a/src/components/ui/TokenInputGroup.tsx
+++ b/src/components/ui/TokenInputGroup.tsx
@@ -7,7 +7,7 @@ interface TokenInputGroupProps {
   amount: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   showSelectToken: boolean;
-  dollarValue?: string;
+  dollarValue?: number;
   readOnly?: boolean;
   isLoadingQuote?: boolean;
   isEnabled?: boolean; // New prop to control if input is enabled
@@ -18,7 +18,7 @@ export function TokenInputGroup({
   amount,
   onChange,
   showSelectToken,
-  dollarValue = "$0.00",
+  dollarValue = 0,
   readOnly = false,
   isLoadingQuote = false,
   isEnabled = true, // Default to true

--- a/src/components/ui/TokenTransfer.tsx
+++ b/src/components/ui/TokenTransfer.tsx
@@ -23,14 +23,13 @@ interface TokenTransferProps {
   settingsComponent?: ReactNode;
   receiveAmount?: string;
   isLoadingQuote?: boolean;
-  // Transaction details props
-  exchangeRate?: string;
-  exchangeValue?: string;
-  gasFee?: string;
   estimatedTimeSeconds?: number | null;
   // Token selection state
   hasSourceToken?: boolean;
   hasDestinationToken?: boolean;
+  protocolFeeUsd?: number;
+  relayerFeeUsd?: number;
+  totalFeeUsd?: number;
 }
 
 export const TokenTransfer: React.FC<TokenTransferProps> = ({
@@ -47,14 +46,13 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
   settingsComponent,
   receiveAmount = "",
   isLoadingQuote = false,
-  // Transaction details props
-  exchangeRate = "1 USDC = 0.000362352 ETH",
-  exchangeValue = "$1.00",
-  gasFee = "<$0.01",
   estimatedTimeSeconds = null,
   // Token selection state
   hasSourceToken = false,
   hasDestinationToken = false,
+  protocolFeeUsd = 0,
+  relayerFeeUsd = 0,
+  totalFeeUsd = 0,
 }) => {
   // State to track if the input should be enabled
   const [isInputEnabled, setIsInputEnabled] = useState(false);
@@ -168,11 +166,10 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
           actionButton={actionButton}
           enforceSourceChain={hasActiveWallet}
           renderActionButton={renderButtonOrModal}
-          // Pass transaction details props to SwapInterface
-          exchangeRate={exchangeRate}
-          exchangeValue={exchangeValue}
-          gasFee={gasFee}
           estimatedTime={estimatedTimeSeconds} // Pass the ETA from quote
+          protocolFeeUsd={protocolFeeUsd}
+          relayerFeeUsd={relayerFeeUsd}
+          totalFeeUsd={totalFeeUsd}
           detailsOpen={showDetails}
           onDetailsToggle={() => setShowDetails(!showDetails)}
         >

--- a/src/components/ui/TokenTransfer.tsx
+++ b/src/components/ui/TokenTransfer.tsx
@@ -30,6 +30,8 @@ interface TokenTransferProps {
   protocolFeeUsd?: number;
   relayerFeeUsd?: number;
   totalFeeUsd?: number;
+  sourceAmountUsd?: number;
+  destinationAmountUsd?: number;
 }
 
 export const TokenTransfer: React.FC<TokenTransferProps> = ({
@@ -53,6 +55,8 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
   protocolFeeUsd = 0,
   relayerFeeUsd = 0,
   totalFeeUsd = 0,
+  sourceAmountUsd = 0,
+  destinationAmountUsd = 0,
 }) => {
   // State to track if the input should be enabled
   const [isInputEnabled, setIsInputEnabled] = useState(false);
@@ -131,6 +135,7 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
           onChange={onAmountChange}
           showSelectToken={true}
           isEnabled={isInputEnabled}
+          dollarValue={sourceAmountUsd}
         />
       </AssetBox>
 
@@ -152,6 +157,7 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
           readOnly={true}
           showSelectToken={showDestinationTokenSelector}
           isLoadingQuote={isLoadingQuote}
+          dollarValue={destinationAmountUsd}
         />
       </AssetBox>
     </>

--- a/src/components/ui/TransactionDetails.tsx
+++ b/src/components/ui/TransactionDetails.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import {
-  Fuel,
   Clock,
   ChevronDown,
   ChevronUp,
@@ -15,9 +14,9 @@ import useWeb3Store, {
 } from "@/store/web3Store";
 
 interface TransactionDetailsProps {
-  exchangeRate?: string;
-  exchangeValue?: string;
-  gasFee?: string;
+  protocolFeeUsd?: number;
+  relayerFeeUsd?: number;
+  totalFeeUsd?: number;
   estimatedTime?: string | number | null; // Allow number for seconds or null
   className?: string;
   isOpen?: boolean;
@@ -25,9 +24,7 @@ interface TransactionDetailsProps {
 }
 
 export function TransactionDetails({
-  exchangeRate = "1 USDC = 0.000362352 ETH",
-  exchangeValue = "$1.00",
-  gasFee = "<$0.01",
+  totalFeeUsd = 0,
   estimatedTime = "~",
   isOpen,
   onToggle,
@@ -267,13 +264,9 @@ export function TransactionDetails({
         onClick={toggleDetails}
       >
         <div className="text-left">
-          {exchangeRate} ({exchangeValue})
+          {!isDetailsExpanded ? "expand for details" : "transaction details"}
         </div>
         <div className="flex items-center space-x-2">
-          <div className="flex items-center space-x-1">
-            <Fuel size={14} />
-            <span>{gasFee}</span>
-          </div>
           <div className="flex items-center space-x-1">
             <Clock size={14} />
             <span>{formatEstimatedTime(estimatedTime)}</span>
@@ -350,16 +343,15 @@ export function TransactionDetails({
             </div>
 
             <div className="text-left text-zinc-400">fee</div>
-            <div className="text-right numeric-input text-zinc-200">$5.29</div>
-
-            <div className="text-left text-zinc-400">relayer fees</div>
-            <div className="text-right numeric-input text-zinc-200">$1.87</div>
+            <div className="text-right numeric-input text-zinc-200">
+              ${(Math.round(totalFeeUsd * 100) / 100).toFixed(2)}
+            </div>
           </div>
 
           <div className="mt-2">
             <div className="flex items-center justify-between">
-              <div className="text-left text-amber-500 text-[12px]">
-                receiving
+              <div className="text-left text-amber-500 text-[12px] w-[100px]">
+                receiving addr.
               </div>
 
               {isEditingReceiveAddress ? (


### PR DESCRIPTION
- Removed the exchange rate and gas price (gas price may be added back in the future)
- Calculated the protocol and relayer fee in USD and stored in the TransactionDetails
- Displayed both fees to users
- Adds the `price` and `toTokenPrice` to the displayed prices in the swap interface as a quote is received