### PR TITLE
feat: allow same chain swap

### DIFF
--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -161,10 +161,7 @@ const useWeb3Store = create<Web3StoreState>()(
       setSourceChain: (chain: Chain) => {
         set((state) => ({
           sourceChain: chain,
-          destinationChain:
-            state.destinationChain.id === chain.id
-              ? state.sourceChain
-              : state.destinationChain,
+          destinationChain: state.destinationChain,
           // Reset source token when changing chains
           sourceToken: null,
         }));

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -170,10 +170,7 @@ const useWeb3Store = create<Web3StoreState>()(
       setDestinationChain: (chain: Chain) => {
         set((state) => ({
           destinationChain: chain,
-          sourceChain:
-            state.sourceChain.id === chain.id
-              ? state.destinationChain
-              : state.sourceChain,
+          sourceChain: state.sourceChain,
           // Reset destination token when changing chains
           destinationToken: null,
         }));

--- a/src/utils/chainMethods.ts
+++ b/src/utils/chainMethods.ts
@@ -15,18 +15,12 @@ export function handleChainChange(
   const store = useWeb3Store.getState();
   const isSource = type === "source";
 
-  // Get current chains
-  const sourceChain = store.sourceChain;
-  const destinationChain = store.destinationChain;
-
   // Get the appropriate setters
   const setSourceChain = store.setSourceChain;
   const setDestinationChain = store.setDestinationChain;
 
   // Determine which chains we're working with
-  const oppositeChain = isSource ? destinationChain : sourceChain;
   const setCurrentChain = isSource ? setSourceChain : setDestinationChain;
-  const setOppositeChain = isSource ? setDestinationChain : setSourceChain;
 
   // Log the change
   console.log(
@@ -36,14 +30,6 @@ export function handleChainChange(
 
   // Update the current chain
   setCurrentChain(chain);
-
-  // If same chain selected, find a different one for the opposite side
-  if (chain.id === oppositeChain.id) {
-    const differentChain = Object.values(chains).find((c) => c.id !== chain.id);
-    if (differentChain) {
-      setOppositeChain(differentChain);
-    }
-  }
 }
 
 /**

--- a/src/utils/walletMethods.ts
+++ b/src/utils/walletMethods.ts
@@ -645,43 +645,66 @@ export function useTokenTransfer(
           // Extract token prices and calculate USD values
           // Source token price from the price field
           if (quote.price !== undefined) {
+            // Source token price is always from the price field
             setSourceTokenPrice(quote.price);
-            console.log(`Source token price: $${quote.price}`);
+            console.log(`Source token price: ${quote.price}`);
 
             // Calculate USD value of source amount
             if (!isNaN(inputAmount)) {
               const sourceAmountUsdValue = inputAmount * quote.price;
               setSourceAmountUsd(parseFloat(sourceAmountUsdValue.toFixed(2)));
               console.log(
-                `Source amount in USD: $${sourceAmountUsdValue.toFixed(2)}`,
+                `Source amount in USD: ${sourceAmountUsdValue.toFixed(2)}`,
               );
             } else {
               setSourceAmountUsd(null);
             }
-          } else {
-            setSourceTokenPrice(null);
-            setSourceAmountUsd(null);
-          }
 
-          // Destination token price from toTokenPrice field (using ExtendedQuote)
-          if (quote.toTokenPrice !== undefined) {
-            setDestinationTokenPrice(quote.toTokenPrice);
-            console.log(`Destination token price: $${quote.toTokenPrice}`);
+            // For destination token price, check if same chain or if toTokenPrice exists
+            const isSameChain = quote.fromChain === quote.toChain;
 
-            // Calculate USD value of destination amount
-            if (!isNaN(outputAmount)) {
-              const destinationAmountUsdValue =
-                outputAmount * quote.toTokenPrice;
-              setDestinationAmountUsd(
-                parseFloat(destinationAmountUsdValue.toFixed(2)),
-              );
+            if (isSameChain || quote.toTokenPrice === undefined) {
+              // If same chain or toTokenPrice missing, use quote.price for destination token too
+              setDestinationTokenPrice(quote.price);
               console.log(
-                `Destination amount in USD: $${destinationAmountUsdValue.toFixed(2)}`,
+                `Destination token price (using source price): ${quote.price}`,
               );
+
+              // Calculate USD value of destination amount using the same price
+              if (!isNaN(outputAmount)) {
+                const destinationAmountUsdValue = outputAmount * quote.price;
+                setDestinationAmountUsd(
+                  parseFloat(destinationAmountUsdValue.toFixed(2)),
+                );
+                console.log(
+                  `Destination amount in USD: ${destinationAmountUsdValue.toFixed(2)}`,
+                );
+              } else {
+                setDestinationAmountUsd(null);
+              }
             } else {
-              setDestinationAmountUsd(null);
+              // Different chains and toTokenPrice exists, use toTokenPrice for destination
+              setDestinationTokenPrice(quote.toTokenPrice);
+              console.log(`Destination token price: ${quote.toTokenPrice}`);
+
+              // Calculate USD value of destination amount
+              if (!isNaN(outputAmount)) {
+                const destinationAmountUsdValue =
+                  outputAmount * quote.toTokenPrice;
+                setDestinationAmountUsd(
+                  parseFloat(destinationAmountUsdValue.toFixed(2)),
+                );
+                console.log(
+                  `Destination amount in USD: ${destinationAmountUsdValue.toFixed(2)}`,
+                );
+              } else {
+                setDestinationAmountUsd(null);
+              }
             }
           } else {
+            // No price information available
+            setSourceTokenPrice(null);
+            setSourceAmountUsd(null);
             setDestinationTokenPrice(null);
             setDestinationAmountUsd(null);
           }


### PR DESCRIPTION
branch off https://github.com/altverseweb3/site/pull/29

Allows for same chain swaps. Removed prior logic to force different chains, and slightly updated logic to calculate send/receive USD values to support when a same chain quote is used, as `toTokenPrice` will not be included in the quote returned from Mayan.