### PR TITLE
feat: auto quote

### DIFF
--- a/src/components/ui/NumberTicker.tsx
+++ b/src/components/ui/NumberTicker.tsx
@@ -36,6 +36,13 @@ export function NumberTicker({
   });
   const isInView = useInView(ref, { once: true, margin: "0px" });
 
+  const formatNumber = (num: number) => {
+    return Intl.NumberFormat("en-US", {
+      minimumFractionDigits: decimalPlaces,
+      maximumFractionDigits: decimalPlaces,
+    }).format(Number(num.toFixed(decimalPlaces)));
+  };
+
   useEffect(() => {
     if (isInView) {
       const timer = setTimeout(() => {
@@ -49,15 +56,13 @@ export function NumberTicker({
     () =>
       springValue.on("change", (latest) => {
         if (ref.current) {
-          ref.current.textContent = Intl.NumberFormat("en-US", {
-            minimumFractionDigits: decimalPlaces,
-            maximumFractionDigits: decimalPlaces,
-          }).format(Number(latest.toFixed(decimalPlaces)));
+          ref.current.textContent = formatNumber(latest);
         }
       }),
     [springValue, decimalPlaces],
   );
 
+  // Important: Format the initial value too
   return (
     <span
       ref={ref}
@@ -67,7 +72,7 @@ export function NumberTicker({
       )}
       {...props}
     >
-      {startValue}
+      {formatNumber(startValue)}
     </span>
   );
 }

--- a/src/components/ui/PersistentAmountDisplay.tsx
+++ b/src/components/ui/PersistentAmountDisplay.tsx
@@ -1,0 +1,74 @@
+// Component wrapper that manages the persistent value
+import { ChangeEvent, useEffect, useState } from "react";
+import { NumberTicker } from "./NumberTicker"; // Adjust import path as needed
+
+interface PersistentAmountDisplayProps {
+  isLoading: boolean;
+  amount: number | string;
+  variant: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  shouldApplyDisabledStyle?: boolean;
+  readOnly?: boolean;
+}
+
+const PersistentAmountDisplay: React.FC<PersistentAmountDisplayProps> = ({
+  isLoading,
+  amount,
+  variant,
+  onChange,
+  placeholder,
+  shouldApplyDisabledStyle,
+  readOnly,
+}) => {
+  // State to track the last displayed value for smooth transitions
+  const [lastDisplayedAmount, setLastDisplayedAmount] = useState(0);
+
+  // Update the last displayed value when amount changes and not loading
+  useEffect(() => {
+    if (!isLoading && amount) {
+      // Round to 3 decimal places using parseFloat and toFixed
+      setLastDisplayedAmount(parseFloat(Number(amount).toFixed(3)));
+    }
+  }, [amount, isLoading]);
+
+  // Common class for both states
+  const commonClass = `w-full bg-transparent text-3xl focus:outline-none text-right numeric-input [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
+    shouldApplyDisabledStyle ? "opacity-70" : ""
+  }`;
+
+  if (variant === "destination") {
+    // For destination variant, we keep the same NumberTicker component,
+    // but conditionally add the pulse animation class to its wrapper
+    return (
+      <div className={isLoading ? "animate-pulse" : ""}>
+        <NumberTicker
+          value={Number(amount)}
+          startValue={lastDisplayedAmount}
+          decimalPlaces={3}
+          stiffness={500}
+          damping={90}
+          className={commonClass}
+        />
+      </div>
+    );
+  } else if (variant !== "destination") {
+    // For the input variant
+    return (
+      <input
+        type="number"
+        value={amount}
+        onChange={onChange ?? (() => {})}
+        placeholder={placeholder}
+        className={commonClass}
+        readOnly={readOnly}
+        disabled={readOnly}
+      />
+    );
+  }
+
+  // Fallback return (shouldn't reach here)
+  return null;
+};
+
+export default PersistentAmountDisplay;

--- a/src/components/ui/SwapInterface.tsx
+++ b/src/components/ui/SwapInterface.tsx
@@ -24,6 +24,7 @@ interface SwapInterfaceProps {
   renderActionButton?: () => ReactNode;
   detailsOpen?: boolean;
   onDetailsToggle?: () => void;
+  isLoadingQuote?: boolean; // Add this prop to track quote loading
 }
 
 export function SwapInterface({
@@ -191,7 +192,7 @@ export function SwapInterface({
           protocolFeeUsd={protocolFeeUsd}
           relayerFeeUsd={relayerFeeUsd}
           totalFeeUsd={totalFeeUsd}
-          estimatedTime={estimatedTime} // Pass number or string
+          estimatedTime={estimatedTime}
           isOpen={detailsOpen}
           onToggle={onDetailsToggle}
         />

--- a/src/components/ui/TokenAmountInput.tsx
+++ b/src/components/ui/TokenAmountInput.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { NumberTicker } from "@/components/ui/NumberTicker";
-
+import PersistentAmountDisplay from "@/components/ui/PersistentAmountDisplay";
 interface TokenAmountInputProps {
   amount: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -28,34 +27,15 @@ export function TokenAmountInput({
 
   return (
     <div className="flex-1 flex flex-col items-end">
-      {isLoading ? (
-        <div className="w-full animate-pulse text-3xl text-right text-zinc-400">
-          loading...
-        </div>
-      ) : variant === "destination" ? (
-        <NumberTicker
-          value={Number(amount)}
-          decimalPlaces={3}
-          // Add these parameters for much faster animation
-          stiffness={500}
-          damping={90}
-          className={`w-full bg-transparent text-3xl focus:outline-none text-right numeric-input [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-            shouldApplyDisabledStyle ? "opacity-70" : ""
-          }`}
-        />
-      ) : (
-        <input
-          type="number"
-          value={amount}
-          onChange={onChange}
-          placeholder={placeholder}
-          className={`w-full bg-transparent text-3xl focus:outline-none text-right numeric-input [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
-            shouldApplyDisabledStyle ? "opacity-70" : ""
-          }`}
-          readOnly={readOnly}
-          disabled={readOnly}
-        />
-      )}
+      <PersistentAmountDisplay
+        isLoading={isLoading}
+        amount={amount}
+        variant={variant}
+        onChange={onChange || (() => {})}
+        placeholder={placeholder}
+        shouldApplyDisabledStyle={shouldApplyDisabledStyle}
+        readOnly={readOnly}
+      />
       <span className="text-zinc-400 text-sm numeric-input">
         ${(Math.round(dollarValue * 100) / 100).toFixed(2)}
       </span>

--- a/src/components/ui/TokenTransfer.tsx
+++ b/src/components/ui/TokenTransfer.tsx
@@ -7,7 +7,7 @@ import { TokenSwitch } from "@/components/ui/TokenSwitch";
 import { ConnectWalletModal } from "@/components/ui/ConnectWalletModal";
 import { BrandedButton } from "@/components/ui/BrandedButton";
 import { AvailableIconName } from "@/types/ui";
-import useWeb3State from "@/store/web3Store";
+import useWeb3Store from "@/store/web3Store";
 
 interface TokenTransferProps {
   amount: string;
@@ -61,7 +61,7 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
   // State to track if the input should be enabled
   const [isInputEnabled, setIsInputEnabled] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
-  const swapChains = useWeb3State((state) => state.swapChains);
+  const swapChains = useWeb3Store((state) => state.swapChains);
 
   useEffect(() => {
     const shouldBeEnabled =
@@ -89,9 +89,7 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
 
   const iconName = hasActiveWallet ? actionIcon || defaultIconName : "Wallet";
 
-  // Make sure button is disabled during quote loading
-  const calculatedIsDisabled =
-    isButtonDisabled ?? (isLoadingQuote || !amount || amount === "0");
+  const calculatedIsDisabled = isButtonDisabled ?? (!amount || amount === "0");
 
   const actionButton = hasActiveWallet
     ? {
@@ -172,12 +170,13 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
           actionButton={actionButton}
           enforceSourceChain={hasActiveWallet}
           renderActionButton={renderButtonOrModal}
-          estimatedTime={estimatedTimeSeconds} // Pass the ETA from quote
+          estimatedTime={estimatedTimeSeconds}
           protocolFeeUsd={protocolFeeUsd}
           relayerFeeUsd={relayerFeeUsd}
           totalFeeUsd={totalFeeUsd}
           detailsOpen={showDetails}
           onDetailsToggle={() => setShowDetails(!showDetails)}
+          isLoadingQuote={isLoadingQuote} // Pass the loading state to SwapInterface
         >
           {transferContent}
         </SwapInterface>

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -161,10 +161,7 @@ const useWeb3Store = create<Web3StoreState>()(
       setSourceChain: (chain: Chain) => {
         set((state) => ({
           sourceChain: chain,
-          destinationChain:
-            state.destinationChain.id === chain.id
-              ? state.sourceChain
-              : state.destinationChain,
+          destinationChain: state.destinationChain,
           // Reset source token when changing chains
           sourceToken: null,
         }));

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -170,10 +170,7 @@ const useWeb3Store = create<Web3StoreState>()(
       setDestinationChain: (chain: Chain) => {
         set((state) => ({
           destinationChain: chain,
-          sourceChain:
-            state.sourceChain.id === chain.id
-              ? state.destinationChain
-              : state.sourceChain,
+          sourceChain: state.sourceChain,
           // Reset destination token when changing chains
           destinationToken: null,
         }));

--- a/src/utils/chainMethods.ts
+++ b/src/utils/chainMethods.ts
@@ -15,18 +15,12 @@ export function handleChainChange(
   const store = useWeb3Store.getState();
   const isSource = type === "source";
 
-  // Get current chains
-  const sourceChain = store.sourceChain;
-  const destinationChain = store.destinationChain;
-
   // Get the appropriate setters
   const setSourceChain = store.setSourceChain;
   const setDestinationChain = store.setDestinationChain;
 
   // Determine which chains we're working with
-  const oppositeChain = isSource ? destinationChain : sourceChain;
   const setCurrentChain = isSource ? setSourceChain : setDestinationChain;
-  const setOppositeChain = isSource ? setDestinationChain : setSourceChain;
 
   // Log the change
   console.log(
@@ -36,14 +30,6 @@ export function handleChainChange(
 
   // Update the current chain
   setCurrentChain(chain);
-
-  // If same chain selected, find a different one for the opposite side
-  if (chain.id === oppositeChain.id) {
-    const differentChain = Object.values(chains).find((c) => c.id !== chain.id);
-    if (differentChain) {
-      setOppositeChain(differentChain);
-    }
-  }
 }
 
 /**

--- a/src/utils/walletMethods.ts
+++ b/src/utils/walletMethods.ts
@@ -645,43 +645,66 @@ export function useTokenTransfer(
           // Extract token prices and calculate USD values
           // Source token price from the price field
           if (quote.price !== undefined) {
+            // Source token price is always from the price field
             setSourceTokenPrice(quote.price);
-            console.log(`Source token price: $${quote.price}`);
+            console.log(`Source token price: ${quote.price}`);
 
             // Calculate USD value of source amount
             if (!isNaN(inputAmount)) {
               const sourceAmountUsdValue = inputAmount * quote.price;
               setSourceAmountUsd(parseFloat(sourceAmountUsdValue.toFixed(2)));
               console.log(
-                `Source amount in USD: $${sourceAmountUsdValue.toFixed(2)}`,
+                `Source amount in USD: ${sourceAmountUsdValue.toFixed(2)}`,
               );
             } else {
               setSourceAmountUsd(null);
             }
-          } else {
-            setSourceTokenPrice(null);
-            setSourceAmountUsd(null);
-          }
 
-          // Destination token price from toTokenPrice field (using ExtendedQuote)
-          if (quote.toTokenPrice !== undefined) {
-            setDestinationTokenPrice(quote.toTokenPrice);
-            console.log(`Destination token price: $${quote.toTokenPrice}`);
+            // For destination token price, check if same chain or if toTokenPrice exists
+            const isSameChain = quote.fromChain === quote.toChain;
 
-            // Calculate USD value of destination amount
-            if (!isNaN(outputAmount)) {
-              const destinationAmountUsdValue =
-                outputAmount * quote.toTokenPrice;
-              setDestinationAmountUsd(
-                parseFloat(destinationAmountUsdValue.toFixed(2)),
-              );
+            if (isSameChain || quote.toTokenPrice === undefined) {
+              // If same chain or toTokenPrice missing, use quote.price for destination token too
+              setDestinationTokenPrice(quote.price);
               console.log(
-                `Destination amount in USD: $${destinationAmountUsdValue.toFixed(2)}`,
+                `Destination token price (using source price): ${quote.price}`,
               );
+
+              // Calculate USD value of destination amount using the same price
+              if (!isNaN(outputAmount)) {
+                const destinationAmountUsdValue = outputAmount * quote.price;
+                setDestinationAmountUsd(
+                  parseFloat(destinationAmountUsdValue.toFixed(2)),
+                );
+                console.log(
+                  `Destination amount in USD: ${destinationAmountUsdValue.toFixed(2)}`,
+                );
+              } else {
+                setDestinationAmountUsd(null);
+              }
             } else {
-              setDestinationAmountUsd(null);
+              // Different chains and toTokenPrice exists, use toTokenPrice for destination
+              setDestinationTokenPrice(quote.toTokenPrice);
+              console.log(`Destination token price: ${quote.toTokenPrice}`);
+
+              // Calculate USD value of destination amount
+              if (!isNaN(outputAmount)) {
+                const destinationAmountUsdValue =
+                  outputAmount * quote.toTokenPrice;
+                setDestinationAmountUsd(
+                  parseFloat(destinationAmountUsdValue.toFixed(2)),
+                );
+                console.log(
+                  `Destination amount in USD: ${destinationAmountUsdValue.toFixed(2)}`,
+                );
+              } else {
+                setDestinationAmountUsd(null);
+              }
             }
           } else {
+            // No price information available
+            setSourceTokenPrice(null);
+            setSourceAmountUsd(null);
             setDestinationTokenPrice(null);
             setDestinationAmountUsd(null);
           }


### PR DESCRIPTION
Automatically fetches quote every 5 seconds provided all necessary input values have been set.

Additionally, the functionality to display "loading..." during a quote load is no longer included - we instead just pulse the previous value. This has been done through the introduction of `PersistentAmountDisplay.tsx`, which tracks previous values and ensures consistent formatting.

@machineboyy I recall we had a conversation about formatting of values with regards to decimal places and commas. Please note that in this PR I have not addressed those points as I cannot recall the exact decision we made on that. I will resolve that in another PR once this has been merged and we have reached a conclusion on formatting and displayed values.