### PR TITLE
feat: added idle timeout for fetching balances at 2 mins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-fast-marquee": "^1.6.5",
+        "react-idle-timer": "^5.7.2",
         "react-social-icons": "^6.22.0",
         "sonner": "^1.7.4",
         "tailwind-merge": "^3.0.1",
@@ -7279,6 +7280,16 @@
       "peerDependencies": {
         "react": ">= 16.8.0 || ^18.0.0",
         "react-dom": ">= 16.8.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-idle-timer": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/react-idle-timer/-/react-idle-timer-5.7.2.tgz",
+      "integrity": "sha512-+BaPfc7XEUU5JFkwZCx6fO1bLVK+RBlFH+iY4X34urvIzZiZINP6v2orePx3E6pAztJGE7t4DzvL7if2SL/0GQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-fast-marquee": "^1.6.5",
+    "react-idle-timer": "^5.7.2",
     "react-social-icons": "^6.22.0",
     "sonner": "^1.7.4",
     "tailwind-merge": "^3.0.1",

--- a/src/components/meta/TokensInitializer.tsx
+++ b/src/components/meta/TokensInitializer.tsx
@@ -1,12 +1,14 @@
 // src/components/TokenInitializer.tsx
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { useIdleTimer } from "react-idle-timer";
 import useWeb3Store from "@/store/web3Store";
 import { getPricesAndBalancesForActiveWallet } from "@/utils/tokenApiMethods";
 
 /**
  * Component that initializes token data on dApp startup.
+ * Includes idle detection to pause polling when user is inactive.
  */
 const TokenInitializer: React.FC = () => {
   // Use separate selectors to avoid object reference changes
@@ -15,21 +17,40 @@ const TokenInitializer: React.FC = () => {
   const destinationChain = useWeb3Store((state) => state.destinationChain);
   const activeWallet = useWeb3Store((state) => state.activeWallet);
 
+  // Track whether the user is active or idle
+  const [isIdle, setIsIdle] = useState(false);
+
+  // Set up idle timer with 2 minute timeout
+  useIdleTimer({
+    timeout: 1000 * 60 * 2,
+    onIdle: () => setIsIdle(true),
+    onActive: () => setIsIdle(false),
+    debounce: 500,
+  });
+
   useEffect(() => {
     // Fetch prices and balances for the active wallet
     if (sourceChain && destinationChain && tokenCount && activeWallet) {
-      // Initial fetch when dependencies change
+      // Function to fetch data
+      const fetchData = () => {
+        if (!isIdle) {
+          console.log("Fetching token data - user is active");
+          getPricesAndBalancesForActiveWallet();
+        } else {
+          console.log("Skipping token data fetch - user is idle");
+        }
+      };
+
+      // Initial fetch when dependencies change (regardless of idle state)
       getPricesAndBalancesForActiveWallet();
 
       // Set up interval to run every 10 seconds
-      const intervalId = setInterval(() => {
-        getPricesAndBalancesForActiveWallet();
-      }, 10000); // 10 seconds in milliseconds
+      const intervalId = setInterval(fetchData, 10000); // 10 seconds
 
       // Clean up interval when component unmounts or dependencies change
       return () => clearInterval(intervalId);
     }
-  }, [sourceChain, destinationChain, tokenCount, activeWallet]);
+  }, [sourceChain, destinationChain, tokenCount, activeWallet, isIdle]);
 
   return null;
 };


### PR DESCRIPTION
Uses the `react-idle-timer` package to stop Alchemy calls after 2 minutes of idle time. Immediately after user becomes active, refreshing continues as normal.