### PR TITLE
chore: source and destination amounts in USD

### DIFF
--- a/src/app/(dapp)/swap/page.tsx
+++ b/src/app/(dapp)/swap/page.tsx
@@ -20,8 +20,6 @@ const SwapComponent: React.FC = () => {
     totalFeeUsd,
     protocolFeeUsd,
     relayerFeeUsd,
-    sourceAmountUsd,
-    destinationAmountUsd,
   } = useTokenTransfer({
     type: "swap",
     onSuccess: (amount, sourceToken, destinationToken) => {
@@ -49,8 +47,6 @@ const SwapComponent: React.FC = () => {
       protocolFeeUsd={protocolFeeUsd ?? undefined}
       relayerFeeUsd={relayerFeeUsd ?? undefined}
       totalFeeUsd={totalFeeUsd ?? undefined}
-      sourceAmountUsd={sourceAmountUsd ?? undefined}
-      destinationAmountUsd={destinationAmountUsd ?? undefined}
     />
   );
 };

--- a/src/components/meta/TokensInitializer.tsx
+++ b/src/components/meta/TokensInitializer.tsx
@@ -32,7 +32,7 @@ const TokenInitializer: React.FC = () => {
 
   useEffect(() => {
     // Fetch prices and balances for the active wallet
-    if (sourceChain && destinationChain && tokenCount && activeWallet) {
+    if (sourceChain && destinationChain && tokenCount) {
       // Function to fetch data
       const fetchData = () => {
         if (!isIdle) {

--- a/src/components/meta/TokensInitializer.tsx
+++ b/src/components/meta/TokensInitializer.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from "react";
 import { useIdleTimer } from "react-idle-timer";
 import useWeb3Store from "@/store/web3Store";
-import { getPricesAndBalancesForActiveWallet } from "@/utils/tokenApiMethods";
+import { getPricesAndBalances } from "@/utils/tokenApiMethods";
 
 /**
  * Component that initializes token data on dApp startup.
@@ -37,14 +37,14 @@ const TokenInitializer: React.FC = () => {
       const fetchData = () => {
         if (!isIdle) {
           console.log("Fetching token data - user is active");
-          getPricesAndBalancesForActiveWallet();
+          getPricesAndBalances();
         } else {
           console.log("Skipping token data fetch - user is idle");
         }
       };
 
       // Initial fetch when dependencies change (regardless of idle state)
-      getPricesAndBalancesForActiveWallet();
+      getPricesAndBalances();
 
       // Set up interval to run every 10 seconds
       const intervalId = setInterval(fetchData, 10000); // 10 seconds

--- a/src/components/meta/TokensInitializer.tsx
+++ b/src/components/meta/TokensInitializer.tsx
@@ -16,6 +16,8 @@ const TokenInitializer: React.FC = () => {
   const sourceChain = useWeb3Store((state) => state.sourceChain);
   const destinationChain = useWeb3Store((state) => state.destinationChain);
   const activeWallet = useWeb3Store((state) => state.activeWallet);
+  const destinationToken = useWeb3Store((state) => state.destinationToken);
+  const sourceToken = useWeb3Store((state) => state.sourceToken);
 
   // Track whether the user is active or idle
   const [isIdle, setIsIdle] = useState(false);
@@ -50,7 +52,15 @@ const TokenInitializer: React.FC = () => {
       // Clean up interval when component unmounts or dependencies change
       return () => clearInterval(intervalId);
     }
-  }, [sourceChain, destinationChain, tokenCount, activeWallet, isIdle]);
+  }, [
+    sourceChain,
+    destinationChain,
+    tokenCount,
+    activeWallet,
+    isIdle,
+    destinationToken,
+    sourceToken,
+  ]);
 
   return null;
 };

--- a/src/components/ui/TokenAmountInput.tsx
+++ b/src/components/ui/TokenAmountInput.tsx
@@ -50,14 +50,11 @@ export function TokenAmountInput({
   }, [tokenBalance, sourceToken?.userBalance]);
 
   useEffect(() => {
-    if (variant === "destination") {
-      debugger;
-      // Update the displayed amount in USD when the amount changes
-      setDisplayedAmountUsd(
-        dollarValue > 0 ? `$${dollarValue.toFixed(2)}` : "$~",
-      );
-    }
-  }, [dollarValue, variant]);
+    // Update the displayed amount in USD when the amount changes
+    setDisplayedAmountUsd(
+      dollarValue > 0 ? `$${dollarValue.toFixed(2)}` : "$-",
+    );
+  }, [dollarValue]);
 
   // Helper function to format balance nicely with abbreviations for large numbers
   const formatBalance = (balance: string): string => {
@@ -132,12 +129,9 @@ export function TokenAmountInput({
         readOnly={readOnly}
       />
       <div className="w-full flex flex-col">
-        {variant === "destination" && (
-          <span className="text-zinc-400 text-sm numeric-input">
-            {displayedAmountUsd}
-          </span>
-        )}
-
+        <span className="text-zinc-400 text-sm numeric-input">
+          {displayedAmountUsd}
+        </span>
         {variant === "source" && (
           <div className="flex justify-end w-full mt-2 gap-2">
             {/* Balance display */}

--- a/src/components/ui/TokenAmountInput.tsx
+++ b/src/components/ui/TokenAmountInput.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import { Wallet } from "lucide-react";
 import PersistentAmountDisplay from "@/components/ui/PersistentAmountDisplay";
 import useWeb3Store, { useSourceToken } from "@/store/web3Store";
@@ -24,6 +24,7 @@ export function TokenAmountInput({
 }: TokenAmountInputProps) {
   const isLoading = isLoadingQuote && readOnly;
   const sourceToken = useSourceToken();
+  const [displayedAmountUsd, setDisplayedAmountUsd] = useState("$~");
 
   // Create a more specific subscription to track token balance changes
   const tokenAddress = sourceToken?.address?.toLowerCase();
@@ -47,6 +48,16 @@ export function TokenAmountInput({
   const currentBalance = useMemo(() => {
     return tokenBalance || sourceToken?.userBalance || "0";
   }, [tokenBalance, sourceToken?.userBalance]);
+
+  useEffect(() => {
+    if (variant === "destination") {
+      debugger;
+      // Update the displayed amount in USD when the amount changes
+      setDisplayedAmountUsd(
+        dollarValue > 0 ? `$${dollarValue.toFixed(2)}` : "$~",
+      );
+    }
+  }, [dollarValue, variant]);
 
   // Helper function to format balance nicely with abbreviations for large numbers
   const formatBalance = (balance: string): string => {
@@ -123,7 +134,7 @@ export function TokenAmountInput({
       <div className="w-full flex flex-col">
         {variant === "destination" && (
           <span className="text-zinc-400 text-sm numeric-input">
-            ${(Math.round(dollarValue * 100) / 100).toFixed(2)}
+            {displayedAmountUsd}
           </span>
         )}
 

--- a/src/components/ui/TokenTransfer.tsx
+++ b/src/components/ui/TokenTransfer.tsx
@@ -9,6 +9,7 @@ import { BrandedButton } from "@/components/ui/BrandedButton";
 import { AvailableIconName } from "@/types/ui";
 import { swapChains } from "@/utils/chainMethods";
 import useWeb3Store from "@/store/web3Store";
+import { Token } from "@/types/web3";
 
 interface TokenTransferProps {
   amount: string;
@@ -75,30 +76,29 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
   }, [hasSourceToken, hasDestinationToken, showDestinationTokenSelector]);
 
   useEffect(() => {
-    const sourceCompositeKey = `${sourceToken?.chainId}-${sourceToken?.address}`;
-    const destinationCompositeKey = `${destinationToken?.chainId}-${destinationToken?.address}`;
-    const sourceTokenValue = tokensByCompositeKey[sourceCompositeKey];
-    const destinationTokenValue = tokensByCompositeKey[destinationCompositeKey];
-    if (destinationTokenValue) {
-      const destinationTokenPrice = destinationTokenValue?.priceUsd;
-      const amountInUsd = Number(receiveAmount) * Number(destinationTokenPrice);
-      setDestinationAmountValue(amountInUsd);
-    } else {
-      setDestinationAmountValue(0);
-    }
-    if (sourceTokenValue) {
-      const sourceTokenPrice = sourceTokenValue?.priceUsd;
-      const amountInUsd = Number(amount) * Number(sourceTokenPrice);
-      setSourceAmountValue(amountInUsd);
-    } else {
-      setSourceAmountValue(0);
-    }
+    // Helper function to calculate USD value for a token and amount
+    const calculateUsdValue = (token: Token | null, amount: string) => {
+      if (!token?.chainId || !token?.address) return 0;
+
+      const compositeKey = `${token.chainId}-${token.address}`;
+      const tokenValue = tokensByCompositeKey[compositeKey];
+
+      if (!tokenValue?.priceUsd) return 0;
+
+      return Number(amount) * Number(tokenValue.priceUsd);
+    };
+
+    // Calculate and set values in one go
+    setSourceAmountValue(calculateUsdValue(sourceToken, amount));
+    setDestinationAmountValue(
+      calculateUsdValue(destinationToken, receiveAmount),
+    );
   }, [
     tokensByCompositeKey,
-    destinationToken,
     sourceToken,
-    receiveAmount,
+    destinationToken,
     amount,
+    receiveAmount,
   ]);
 
   const defaultSettingsButton = (

--- a/src/components/ui/TokenTransfer.tsx
+++ b/src/components/ui/TokenTransfer.tsx
@@ -56,12 +56,16 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
   relayerFeeUsd = 0,
   totalFeeUsd = 0,
   sourceAmountUsd = 0,
-  destinationAmountUsd = 0,
 }) => {
   // State to track if the input should be enabled
   const [isInputEnabled, setIsInputEnabled] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
-  const swapChains = useWeb3Store((state) => state.swapChains);
+  const [destinationAmountValue, setDestinationAmountValue] = useState(0);
+  const [theThing, setTheThing] = useState(0);
+  const tokensByCompositeKey = useWeb3Store(
+    (state) => state.tokensByCompositeKey,
+  );
+  const destinationToken = useWeb3Store((state) => state.destinationToken);
 
   useEffect(() => {
     const shouldBeEnabled =
@@ -70,6 +74,19 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
 
     setIsInputEnabled(shouldBeEnabled);
   }, [hasSourceToken, hasDestinationToken, showDestinationTokenSelector]);
+
+  useEffect(() => {
+    debugger;
+    const compositeKey = `${destinationToken?.chainId}-${destinationToken?.address}`;
+    const destinationTokenValue = tokensByCompositeKey[compositeKey];
+    if (destinationTokenValue) {
+      const destinationTokenPrice = destinationTokenValue?.priceUsd;
+      const amountInUsd = Number(receiveAmount) * Number(destinationTokenPrice);
+      setDestinationAmountValue(amountInUsd);
+    } else {
+      setDestinationAmountValue(0);
+    }
+  }, [theThing]);
 
   const defaultSettingsButton = (
     <button onClick={() => setShowDetails(!showDetails)}>
@@ -139,7 +156,8 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
 
       <TokenSwitch
         onClick={() => {
-          swapChains();
+          setTheThing((prev) => prev + 1);
+          // swapChains();
         }}
       />
 
@@ -155,7 +173,7 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
           readOnly={true}
           showSelectToken={showDestinationTokenSelector}
           isLoadingQuote={isLoadingQuote}
-          dollarValue={destinationAmountUsd}
+          dollarValue={destinationAmountValue}
         />
       </AssetBox>
     </>

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -187,22 +187,63 @@ const useWeb3Store = create<Web3StoreState>()(
       },
 
       swapChains: () => {
-        set((state) => ({
-          sourceChain: state.destinationChain,
-          destinationChain: state.sourceChain,
-          // Swap tokens along with chains
-          sourceToken: state.destinationToken,
-          destinationToken: state.sourceToken,
-        }));
+        set((state) => {
+          const newSourceToken = state.destinationToken
+            ? {
+                ...state.destinationToken,
+                alwaysLoadPrice: true,
+              }
+            : null;
+
+          const newDestinationToken = state.sourceToken
+            ? {
+                ...state.sourceToken,
+                alwaysLoadPrice: true,
+              }
+            : null;
+
+          return {
+            sourceChain: state.destinationChain,
+            destinationChain: state.sourceChain,
+            sourceToken: newSourceToken,
+            destinationToken: newDestinationToken,
+          };
+        });
       },
 
       // Token selection actions
       setSourceToken: (token: Token | null) => {
         console.log("Setting source token:", token ? token.name : "null");
         set({ sourceToken: token });
+        // Update token collections to set source token to have alwaysLoadPrice to true
+        if (token) {
+          set((state) => {
+            const updatedToken = {
+              ...token,
+              alwaysLoadPrice: true,
+            };
+            const newTokensList = state.allTokensList.map((t) =>
+              t.address === token.address && t.chainId === token.chainId
+                ? updatedToken
+                : t,
+            );
+            const {
+              tokensByCompositeKey: updatedByCompositeKey,
+              tokensByChainId: updatedByChainId,
+              tokensByAddress: updatedByAddress,
+            } = updateTokenCollections(newTokensList);
+            return {
+              allTokensList: newTokensList,
+              tokensByCompositeKey: updatedByCompositeKey,
+              tokensByChainId: updatedByChainId,
+              tokensByAddress: updatedByAddress,
+            };
+          });
+        }
       },
 
       setDestinationToken: (token: Token | null) => {
+        // debugger;
         console.log("Setting destination token:", token ? token.name : "null");
         set({ destinationToken: token });
         // Update token collections to set destination token to have alwaysLoadPrice to true
@@ -290,13 +331,66 @@ const useWeb3Store = create<Web3StoreState>()(
           const currentSourceToken = get().sourceToken;
           const currentDestinationToken = get().destinationToken;
 
-          // Find the full token objects from the loaded tokens if they exist
+          // Create a copy of allTokensList that we can modify
+          const updatedTokensList = [...structuredTokens.allTokensList];
+          let needsCollectionUpdate = false;
+
+          // Find and update source token if it exists
+          if (currentSourceToken) {
+            const sourceTokenIndex = updatedTokensList.findIndex(
+              (token) =>
+                token.address.toLowerCase() ===
+                  currentSourceToken.address.toLowerCase() &&
+                token.chainId === currentSourceToken.chainId,
+            );
+
+            if (sourceTokenIndex !== -1) {
+              updatedTokensList[sourceTokenIndex] = {
+                ...updatedTokensList[sourceTokenIndex],
+                alwaysLoadPrice: true,
+              };
+              needsCollectionUpdate = true;
+            }
+          }
+
+          // Find and update destination token if it exists
+          if (currentDestinationToken) {
+            const destTokenIndex = updatedTokensList.findIndex(
+              (token) =>
+                token.address.toLowerCase() ===
+                  currentDestinationToken.address.toLowerCase() &&
+                token.chainId === currentDestinationToken.chainId,
+            );
+
+            if (destTokenIndex !== -1) {
+              updatedTokensList[destTokenIndex] = {
+                ...updatedTokensList[destTokenIndex],
+                alwaysLoadPrice: true,
+              };
+              needsCollectionUpdate = true;
+            }
+          }
+
+          // If we updated any tokens, update the derived collections
+          let tokensByCompositeKey = structuredTokens.byCompositeKey;
+          let tokensByChainId = structuredTokens.byChainId;
+          let tokensByAddress = structuredTokens.byChainIdAndAddress;
+
+          if (needsCollectionUpdate) {
+            const updatedCollections =
+              updateTokenCollections(updatedTokensList);
+            tokensByCompositeKey = updatedCollections.tokensByCompositeKey;
+            tokensByChainId = updatedCollections.tokensByChainId;
+            tokensByAddress = updatedCollections.tokensByAddress;
+          }
+
+          // Now get the full token objects with alwaysLoadPrice set
           let fullSourceToken = null;
           let fullDestinationToken = null;
 
           if (currentSourceToken) {
             fullSourceToken =
-              structuredTokens.allTokensList.find(
+              updatedTokensList.find(
                 (token) =>
                   token.address.toLowerCase() ===
                     currentSourceToken.address.toLowerCase() &&
@@ -306,7 +400,7 @@ const useWeb3Store = create<Web3StoreState>()(
 
           if (currentDestinationToken) {
             fullDestinationToken =
-              structuredTokens.allTokensList.find(
+              updatedTokensList.find(
                 (token) =>
                   token.address.toLowerCase() ===
                     currentDestinationToken.address.toLowerCase() &&
@@ -315,11 +409,10 @@ const useWeb3Store = create<Web3StoreState>()(
           }
 
           set({
-            tokensByCompositeKey: structuredTokens.byCompositeKey,
-            tokensByChainId: structuredTokens.byChainId,
-            tokensByAddress: structuredTokens.byChainIdAndAddress,
-            allTokensList: structuredTokens.allTokensList,
-            // Rehydrate full token objects from the loaded token list
+            tokensByCompositeKey: tokensByCompositeKey,
+            tokensByChainId: tokensByChainId,
+            tokensByAddress: tokensByAddress,
+            allTokensList: updatedTokensList,
             sourceToken: fullSourceToken,
             destinationToken: fullDestinationToken,
             tokensLoading: false,
@@ -541,6 +634,7 @@ const useWeb3Store = create<Web3StoreState>()(
             userBalance: token.userBalance,
             userBalanceUsd: token.userBalanceUsd,
             isWalletToken: token.isWalletToken,
+            alwaysLoadPrice: token.alwaysLoadPrice,
           };
         };
         return {

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -205,6 +205,31 @@ const useWeb3Store = create<Web3StoreState>()(
       setDestinationToken: (token: Token | null) => {
         console.log("Setting destination token:", token ? token.name : "null");
         set({ destinationToken: token });
+        // Update token collections to set destination token to have alwaysLoadPrice to true
+        if (token) {
+          set((state) => {
+            const updatedToken = {
+              ...token,
+              alwaysLoadPrice: true,
+            };
+            const newTokensList = state.allTokensList.map((t) =>
+              t.address === token.address && t.chainId === token.chainId
+                ? updatedToken
+                : t,
+            );
+            const {
+              tokensByCompositeKey: updatedByCompositeKey,
+              tokensByChainId: updatedByChainId,
+              tokensByAddress: updatedByAddress,
+            } = updateTokenCollections(newTokensList);
+            return {
+              allTokensList: newTokensList,
+              tokensByCompositeKey: updatedByCompositeKey,
+              tokensByChainId: updatedByChainId,
+              tokensByAddress: updatedByAddress,
+            };
+          });
+        }
       },
 
       addCustomToken: (token: Token) => {

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -38,6 +38,7 @@ export type Token = {
   priceUsd?: string;
   isWalletToken?: boolean;
   customToken?: boolean;
+  alwaysLoadPrice?: boolean;
 };
 
 export type Chain = {

--- a/src/utils/tokenApiMethods.ts
+++ b/src/utils/tokenApiMethods.ts
@@ -52,7 +52,7 @@ function formatTokenBalance(balanceStr: string, decimals: number): string {
   }
 }
 
-export async function getPricesAndBalancesForActiveWallet(): Promise<boolean> {
+export async function getPricesAndBalances(): Promise<boolean> {
   const store = useWeb3Store.getState();
   const activeWallet = store.activeWallet;
 
@@ -62,12 +62,12 @@ export async function getPricesAndBalancesForActiveWallet(): Promise<boolean> {
     const [sourceResult, destinationResult] = await Promise.allSettled([
       getPricesAndBalancesForChain(
         store.sourceChain.chainId,
-        activeWallet?.address, // Now passing undefined if no wallet
+        activeWallet?.address,
         "source",
       ),
       getPricesAndBalancesForChain(
         store.destinationChain.chainId,
-        activeWallet?.address, // Now passing undefined if no wallet
+        activeWallet?.address,
         "destination",
       ),
     ]);
@@ -333,7 +333,7 @@ export async function getPricesAndBalancesForChain(
     return false;
   }
 
-  // This return will never be reached but satisfies TypeScript
+  // This return is unreachable but added for TypeScript type safety
   return false;
 }
 

--- a/src/utils/tokenApiMethods.ts
+++ b/src/utils/tokenApiMethods.ts
@@ -309,10 +309,6 @@ export async function getPricesAndBalancesForChain(
       `Unhandled error fetching prices and balances for ${chainType} chain ${chainId}:`,
       error,
     );
-    // Attempt to clear balances in store on catastrophic failure? Optional.
-    // if (userAddress && chainId) {
-    //    useWeb3Store.getState().updateTokenBalances(chainId, userAddress, []);
-    // }
     return false;
   }
 }

--- a/src/utils/tokenApiMethods.ts
+++ b/src/utils/tokenApiMethods.ts
@@ -309,6 +309,10 @@ export async function getPricesAndBalancesForChain(
       `Unhandled error fetching prices and balances for ${chainType} chain ${chainId}:`,
       error,
     );
+    // Attempt to clear balances in store on catastrophic failure? Optional.
+    // if (userAddress && chainId) {
+    //    useWeb3Store.getState().updateTokenBalances(chainId, userAddress, []);
+    // }
     return false;
   }
 }

--- a/src/utils/tokenApiMethods.ts
+++ b/src/utils/tokenApiMethods.ts
@@ -162,8 +162,15 @@ export async function getPricesAndBalancesForChain(
     );
 
     // Filter unique addresses in case the balance API returns duplicates (unlikely but safe)
-    const uniqueAddresses = [...new Set(addressesWithBalance)];
-
+    const alwaysLoadPriceAddresses = useWeb3Store
+      .getState()
+      .allTokensList.filter(
+        (token) => token.chainId === chainId && token.alwaysLoadPrice,
+      );
+    const uniqueAddresses = [
+      ...new Set(addressesWithBalance),
+      ...alwaysLoadPriceAddresses.map((token) => token.address.toLowerCase()),
+    ];
     const tokenAddressesForPriceFetch: TokenAddressInfo[] = uniqueAddresses.map(
       (address) => ({
         network: networkName,

--- a/src/utils/tokenApiMethods.ts
+++ b/src/utils/tokenApiMethods.ts
@@ -56,23 +56,18 @@ export async function getPricesAndBalancesForActiveWallet(): Promise<boolean> {
   const store = useWeb3Store.getState();
   const activeWallet = store.activeWallet;
 
-  if (!activeWallet) {
-    console.warn("No active wallet to fetch prices and balances for");
-    return false;
-  }
-
   store.setTokensLoading(true);
 
   try {
     const [sourceResult, destinationResult] = await Promise.allSettled([
       getPricesAndBalancesForChain(
         store.sourceChain.chainId,
-        activeWallet.address,
+        activeWallet?.address, // Now passing undefined if no wallet
         "source",
       ),
       getPricesAndBalancesForChain(
         store.destinationChain.chainId,
-        activeWallet.address,
+        activeWallet?.address, // Now passing undefined if no wallet
         "destination",
       ),
     ]);
@@ -97,12 +92,12 @@ export async function getPricesAndBalancesForActiveWallet(): Promise<boolean> {
 
 export async function getPricesAndBalancesForChain(
   chainId: number,
-  userAddress: string,
+  userAddress?: string,
   chainType: "source" | "destination" = "source",
 ): Promise<boolean> {
   try {
     console.log(
-      `Starting balance and price fetch for ${chainType} chain (ID: ${chainId}), user: ${userAddress}`,
+      `Starting ${userAddress ? "balance and " : ""}price fetch for ${chainType} chain (ID: ${chainId})${userAddress ? `, user: ${userAddress}` : ""}`,
     );
 
     // 1. Get Chain Info
@@ -113,73 +108,94 @@ export async function getPricesAndBalancesForChain(
       );
       return false;
     }
-    const networkName = chain.alchemyNetworkName; // Use consistent network name
+    const networkName = chain.alchemyNetworkName;
 
-    // 2. Fetch Balances First
+    // 2. Fetch Balances only if userAddress is provided
+    let addressesWithBalance: string[] = [];
     let balanceData: TokenBalance[] | null = null;
-    try {
-      console.log(
-        `Workspaceing balances for address ${userAddress} on ${chainType} chain (${networkName})`,
-      );
-      const balanceResponse = await evmTokenApi.getBalances({
-        network: networkName,
-        userAddress,
-      });
 
-      if (balanceResponse.error || !balanceResponse.data) {
-        console.error(
-          `Error fetching token balances for ${chainType} chain:`,
-          balanceResponse.error,
-        );
-        // Update store with empty balances for this user/chain to clear old data
-        useWeb3Store.getState().updateTokenBalances(chainId, userAddress, []);
-        return false; // Indicate failure if balances can't be fetched
-      }
-
-      balanceData = balanceResponse.data;
-
-      if (!balanceData || balanceData.length === 0) {
+    if (userAddress) {
+      try {
         console.log(
-          `No token balances found for ${userAddress} on ${chainType} chain ${chainId}.`,
+          `Fetching balances for address ${userAddress} on ${chainType} chain (${networkName})`,
         );
-        // Update store with empty balances
+        const balanceResponse = await evmTokenApi.getBalances({
+          network: networkName,
+          userAddress,
+        });
+
+        if (balanceResponse.error || !balanceResponse.data) {
+          console.error(
+            `Error fetching token balances for ${chainType} chain:`,
+            balanceResponse.error,
+          );
+          // Update store with empty balances for this user/chain to clear old data
+          useWeb3Store.getState().updateTokenBalances(chainId, userAddress, []);
+          // Continue to fetch alwaysLoadPrice tokens even if balance fetch fails
+        } else {
+          balanceData = balanceResponse.data;
+
+          if (!balanceData || balanceData.length === 0) {
+            console.log(
+              `No token balances found for ${userAddress} on ${chainType} chain ${chainId}.`,
+            );
+            // Update store with empty balances
+            useWeb3Store
+              .getState()
+              .updateTokenBalances(chainId, userAddress, []);
+          } else {
+            console.log(
+              `Found ${balanceData.length} token balances for ${userAddress} on ${chainType} chain.`,
+            );
+
+            // Extract addresses with balance
+            addressesWithBalance = balanceData.map((balance) =>
+              balance.contractAddress.toLowerCase(),
+            );
+          }
+        }
+      } catch (error) {
+        console.error(`Error fetching balances for ${chainType} chain:`, error);
+        // Update store with empty balances on error
         useWeb3Store.getState().updateTokenBalances(chainId, userAddress, []);
-        return true; // Successfully determined there are no balances
+        // Continue to fetch alwaysLoadPrice tokens even if balance fetch fails
       }
+    } else {
       console.log(
-        `Found ${balanceData.length} token balances for ${userAddress} on ${chainType} chain.`,
+        `No wallet connected. Fetching only prices for tokens with alwaysLoadPrice on ${chainType} chain.`,
       );
-    } catch (error) {
-      console.error(`Error fetching balances for ${chainType} chain:`, error);
-      // Update store with empty balances on error
-      useWeb3Store.getState().updateTokenBalances(chainId, userAddress, []);
-      return false;
     }
 
-    // 3. Prepare Addresses for Price Fetching (Only those with balances)
-    const addressesWithBalance = balanceData.map((balance) =>
-      balance.contractAddress.toLowerCase(),
-    );
-
-    // Filter unique addresses in case the balance API returns duplicates (unlikely but safe)
+    // 3. Prepare Addresses for Price Fetching
+    // Get tokens with alwaysLoadPrice
     const alwaysLoadPriceAddresses = useWeb3Store
       .getState()
       .allTokensList.filter(
         (token) => token.chainId === chainId && token.alwaysLoadPrice,
-      );
+      )
+      .map((token) => token.address.toLowerCase());
+
+    // Combine and deduplicate addresses
     const uniqueAddresses = [
-      ...new Set(addressesWithBalance),
-      ...alwaysLoadPriceAddresses.map((token) => token.address.toLowerCase()),
+      ...new Set([...addressesWithBalance, ...alwaysLoadPriceAddresses]),
     ];
+
+    if (uniqueAddresses.length === 0) {
+      console.log(
+        `No tokens to fetch prices for on ${chainType} chain ${chainId}.`,
+      );
+      return true; // Successfully determined there are no tokens to fetch prices for
+    }
+
     const tokenAddressesForPriceFetch: TokenAddressInfo[] = uniqueAddresses.map(
       (address) => ({
         network: networkName,
-        address: address, // Ensure correct casing if API is sensitive, though usually lowercase is fine
+        address: address,
       }),
     );
 
     console.log(
-      `Workspaceing prices for ${tokenAddressesForPriceFetch.length} tokens with balances on ${chainType} chain`,
+      `Fetching prices for ${tokenAddressesForPriceFetch.length} tokens on ${chainType} chain`,
     );
 
     // 4. Fetch Prices in Batches
@@ -223,89 +239,87 @@ export async function getPricesAndBalancesForChain(
 
     // 5. Update Token Prices in the Store
     if (allFetchedPrices.length > 0) {
-      // Get the latest state before updating to potentially avoid race conditions
-      // Although less critical now as balance processing waits for prices
       useWeb3Store.getState().updateTokenPrices(allFetchedPrices);
       console.log(
         `Updated ${allFetchedPrices.length} token prices in the store for ${chainType} chain.`,
       );
     }
 
-    // 6. Process Balances (using fetched prices)
-    // Get potentially updated token info from the store (which now includes latest prices)
-    const updatedTokens = useWeb3Store.getState().getTokensForChain(chainId);
-    const tokensByAddress: Record<string, Token> = {};
-    updatedTokens.forEach((token) => {
-      tokensByAddress[token.address.toLowerCase()] = token;
-    });
+    // 6. Process Balances only if userAddress is provided and we have balance data
+    if (userAddress && balanceData && balanceData.length > 0) {
+      // Get potentially updated token info from the store (which now includes latest prices)
+      const updatedTokens = useWeb3Store.getState().getTokensForChain(chainId);
+      const tokensByAddress: Record<string, Token> = {};
+      updatedTokens.forEach((token) => {
+        tokensByAddress[token.address.toLowerCase()] = token;
+      });
 
-    const processedBalances = balanceData.map((balance) => {
-      const tokenAddress = balance.contractAddress.toLowerCase();
-      const token = tokensByAddress[tokenAddress]; // Get token info (includes price)
+      const processedBalances = balanceData.map((balance) => {
+        const tokenAddress = balance.contractAddress.toLowerCase();
+        const token = tokensByAddress[tokenAddress]; // Get token info (includes price)
 
-      if (token && token.decimals !== undefined) {
-        const formattedBalance = formatTokenBalance(
-          balance.tokenBalance,
-          token.decimals,
-        );
+        if (token && token.decimals !== undefined) {
+          const formattedBalance = formatTokenBalance(
+            balance.tokenBalance,
+            token.decimals,
+          );
 
-        let balanceUsd: string | undefined = undefined;
-        // Use the price fetched and stored in the token object
-        if (token.priceUsd) {
-          try {
-            const numBalance = parseFloat(formattedBalance);
-            // Ensure price is treated as a number
-            const price =
-              typeof token.priceUsd === "string"
-                ? parseFloat(token.priceUsd)
-                : token.priceUsd;
-            if (!isNaN(numBalance) && !isNaN(price)) {
-              balanceUsd = (numBalance * price).toFixed(2);
-            } else {
-              console.warn(
-                `Invalid number for USD calculation: balance=${formattedBalance}, price=${token.priceUsd} for token ${token.ticker || tokenAddress}`,
+          let balanceUsd: string | undefined = undefined;
+          // Use the price fetched and stored in the token object
+          if (token.priceUsd) {
+            try {
+              const numBalance = parseFloat(formattedBalance);
+              // Ensure price is treated as a number
+              const price =
+                typeof token.priceUsd === "string"
+                  ? parseFloat(token.priceUsd)
+                  : token.priceUsd;
+              if (!isNaN(numBalance) && !isNaN(price)) {
+                balanceUsd = (numBalance * price).toFixed(2);
+              } else {
+                console.warn(
+                  `Invalid number for USD calculation: balance=${formattedBalance}, price=${token.priceUsd} for token ${token.ticker || tokenAddress}`,
+                );
+              }
+            } catch (e) {
+              console.error(
+                `Error calculating USD balance for ${token.ticker || tokenAddress} on ${chainType} chain:`,
+                e,
               );
             }
-          } catch (e) {
-            console.error(
-              `Error calculating USD balance for ${token.ticker || tokenAddress} on ${chainType} chain:`,
-              e,
+          } else {
+            // Log if price is missing after attempting to fetch it
+            console.warn(
+              `Price missing for token ${token.ticker || tokenAddress} (address: ${tokenAddress}) on ${chainType} chain after fetch.`,
             );
           }
+
+          return {
+            ...balance, // Spread original balance data
+            tokenBalance: formattedBalance, // Overwrite with formatted balance
+            balanceUsd, // Add calculated USD value
+          };
         } else {
-          // Log if price is missing after attempting to fetch it
+          // Handle cases where token info might be missing in the store
           console.warn(
-            `Price missing for token ${token.ticker || tokenAddress} (address: ${tokenAddress}) on ${chainType} chain after fetch.`,
+            `Token info or decimals missing for address ${tokenAddress} on chain ${chainId}. Cannot format balance or calculate USD value.`,
           );
+          return {
+            ...balance, // Return original balance data
+            tokenBalance: balance.tokenBalance, // Keep raw balance
+            balanceUsd: undefined,
+          };
         }
+      });
 
-        return {
-          ...balance, // Spread original balance data
-          tokenBalance: formattedBalance, // Overwrite with formatted balance
-          balanceUsd, // Add calculated USD value
-        };
-      } else {
-        // Handle cases where token info might be missing in the store
-        // or decimals are somehow undefined
-        console.warn(
-          `Token info or decimals missing for address ${tokenAddress} on chain ${chainId}. Cannot format balance or calculate USD value.`,
-        );
-        return {
-          ...balance, // Return original balance data
-          tokenBalance: balance.tokenBalance, // Keep raw balance
-          balanceUsd: undefined,
-        };
-      }
-    });
-
-    // 7. Update Token Balances in the Store
-    // Get the latest state before updating to avoid race conditions
-    useWeb3Store
-      .getState()
-      .updateTokenBalances(chainId, userAddress, processedBalances);
-    console.log(
-      `Updated ${processedBalances.length} processed token balances in the store for user ${userAddress} on ${chainType} chain ${chainId}.`,
-    );
+      // 7. Update Token Balances in the Store
+      useWeb3Store
+        .getState()
+        .updateTokenBalances(chainId, userAddress, processedBalances);
+      console.log(
+        `Updated ${processedBalances.length} processed token balances in the store for user ${userAddress} on ${chainType} chain ${chainId}.`,
+      );
+    }
 
     console.log(
       `Successfully completed fetch for ${chainType} chain (ID: ${chainId})`,
@@ -318,6 +332,9 @@ export async function getPricesAndBalancesForChain(
     );
     return false;
   }
+
+  // This return will never be reached but satisfies TypeScript
+  return false;
 }
 
 /**


### PR DESCRIPTION
This PR adds functionality to get the source and destination amount in USD. The displayed USD amounts are instantly responsive to both changes in the quote, as well as pricing data received.

### Approach
Here is the approach I have gone with:
1. The `Token` type has a new property `alwaysLoadPrice`, which when `true`, will always have the price loaded regardless of the balance status.
2. When a user sets a source or destination token, `alwaysLoadPrice` will be set to `true`. This value will also be persisted in the storage context, so if the site is closed/reloaded then they will not have to re-select the `alwaysLoadPrice` value.
3. Upon loading the storage context, only the stored source and destination token will have the `alwaysLoadPrice` value set to `true`.
4. The source and destination amount in USD is simply calculated with the following logic:
  `source amount in USD = amount * source token price`
  `destination amount in USD = receive amount (from quote) * destination token price`
5. When either the price or quote is yet to be loaded, the stored/receive amount in USD will just display `$ -`

### Why have I gone with this approach?
1. Using quote data on its own is simply not stable enough. There are many pairs which both fail to give us a `price` (the exchange rate between the source and destination token), as well as the `toTokenPrice`. Without either of these values, it is impossible to calculate the source and destination price in USD.
2. We should be sourcing USD values consistently - since we source the USD values of our balance tokens using Alchemy, it only makes sense that we do the same for the quote inputs/outputs, otherwise there would be potential inconsistencies with both what the user sees, and what they send and receive.
3. I believe that our token stores in `web3Storage` should be a single point where token prices can be accessed across the whole dApp. By adding the `alwaysLoadPrice` value, this ensures that we do not waste the price fetch by only using it for the quote USD value calculation, and that this price value can be used anywhere throughout the dApp.
4. Following on from 3. by setting the `alwaysLoadPrice` value, we are not effectively increasing the number of calls to the `/prices`  endpoint since we are only adding those tokens to the already existing batches. Unless the user has a number of tokens in their balance that sits around a multiple of 25, then adding these tokens to the request will not increase the number of calls.

> [!NOTE]  
> There is still some leftover logic in the `fetchQuote` hook which calculates USD values using the quote which is now unused. I will clean that up in a secondary PR as I want to keep this PR as short as possible.