### PR TITLE
chore: cleanup token transfer

### DIFF
--- a/src/utils/tokenApiMethods.ts
+++ b/src/utils/tokenApiMethods.ts
@@ -330,10 +330,6 @@ export async function getPricesAndBalancesForChain(
       `Unhandled error fetching prices and balances for ${chainType} chain ${chainId}:`,
       error,
     );
-    // Attempt to clear balances in store on catastrophic failure? Optional.
-    // if (userAddress && chainId) {
-    //    useWeb3Store.getState().updateTokenBalances(chainId, userAddress, []);
-    // }
     return false;
   }
 

--- a/src/utils/tokenApiMethods.ts
+++ b/src/utils/tokenApiMethods.ts
@@ -330,6 +330,10 @@ export async function getPricesAndBalancesForChain(
       `Unhandled error fetching prices and balances for ${chainType} chain ${chainId}:`,
       error,
     );
+    // Attempt to clear balances in store on catastrophic failure? Optional.
+    // if (userAddress && chainId) {
+    //    useWeb3Store.getState().updateTokenBalances(chainId, userAddress, []);
+    // }
     return false;
   }
 

--- a/src/utils/walletMethods.ts
+++ b/src/utils/walletMethods.ts
@@ -408,12 +408,6 @@ interface TokenTransferState {
   relayerFeeUsd: number | null;
   totalFeeUsd: number | null;
 
-  sourceTokenPrice: number | null;
-  destinationTokenPrice: number | null;
-
-  sourceAmountUsd: number | null; // USD value of input amount
-  destinationAmountUsd: number | null; // USD value of output amount
-
   handleTransfer: () => Promise<void>;
 }
 
@@ -445,15 +439,6 @@ export function useTokenTransfer(
   const [relayerFeeUsd, setRelayerFeeUsd] = useState<number | null>(null);
   const [totalFeeUsd, setTotalFeeUsd] = useState<number | null>(null);
 
-  const [sourceTokenPrice, setSourceTokenPrice] = useState<number | null>(null);
-  const [destinationTokenPrice, setDestinationTokenPrice] = useState<
-    number | null
-  >(null);
-  const [sourceAmountUsd, setSourceAmountUsd] = useState<number | null>(null);
-  const [destinationAmountUsd, setDestinationAmountUsd] = useState<
-    number | null
-  >(null);
-
   // Get relevant state from the web3 store
   const activeWallet = useWeb3Store((state) => state.activeWallet);
   const sourceChain = useWeb3Store((state) => state.sourceChain);
@@ -478,10 +463,6 @@ export function useTokenTransfer(
     setProtocolFeeUsd(null);
     setRelayerFeeUsd(null);
     setTotalFeeUsd(null);
-    setSourceTokenPrice(null);
-    setDestinationTokenPrice(null);
-    setSourceAmountUsd(null);
-    setDestinationAmountUsd(null);
   };
 
   // Convert slippage from string (e.g., "3.00%") to basis points (e.g., 300) or "auto"
@@ -503,7 +484,7 @@ export function useTokenTransfer(
 
   // Convert gasDrop from store (number) or default to 0
   const getGasDrop = useCallback((): number => {
-    // if it isn’t set or isn’t a number, fall back to 0
+    // if it isn't set or isn't a number, fall back to 0
     if (
       transactionDetails.gasDrop === undefined ||
       typeof transactionDetails.gasDrop !== "number"
@@ -658,7 +639,7 @@ export function useTokenTransfer(
             setRelayerFeeUsd(null);
           }
 
-          // Calculate total fee - the difference between input and expected output
+          // Calculate total fee - the difference between input and output
           const totalFee = inputAmount - outputAmount;
 
           if (!isNaN(totalFee)) {
@@ -666,73 +647,6 @@ export function useTokenTransfer(
             console.log(`Total fee: ${totalFee.toFixed(6)} USD`);
           } else {
             setTotalFeeUsd(null);
-          }
-
-          // Extract token prices and calculate USD values
-          // Source token price from the price field
-          if (quote.price !== undefined) {
-            // Source token price is always from the price field
-            setSourceTokenPrice(quote.price);
-            console.log(`Source token price: ${quote.price}`);
-
-            // Calculate USD value of source amount
-            if (!isNaN(inputAmount)) {
-              const sourceAmountUsdValue = inputAmount * quote.price;
-              setSourceAmountUsd(parseFloat(sourceAmountUsdValue.toFixed(2)));
-              console.log(
-                `Source amount in USD: ${sourceAmountUsdValue.toFixed(2)}`,
-              );
-            } else {
-              setSourceAmountUsd(null);
-            }
-
-            // For destination token price, check if same chain or if toTokenPrice exists
-            const isSameChain = quote.fromChain === quote.toChain;
-
-            if (isSameChain || quote.toTokenPrice === undefined) {
-              // If same chain or toTokenPrice missing, use quote.price for destination token too
-              setDestinationTokenPrice(quote.price);
-              console.log(
-                `Destination token price (using source price): ${quote.price}`,
-              );
-
-              // Calculate USD value of destination amount using the same price
-              if (!isNaN(outputAmount)) {
-                const destinationAmountUsdValue = outputAmount * quote.price;
-                setDestinationAmountUsd(
-                  parseFloat(destinationAmountUsdValue.toFixed(2)),
-                );
-                console.log(
-                  `Destination amount in USD: ${destinationAmountUsdValue.toFixed(2)}`,
-                );
-              } else {
-                setDestinationAmountUsd(null);
-              }
-            } else {
-              // Different chains and toTokenPrice exists, use toTokenPrice for destination
-              setDestinationTokenPrice(quote.toTokenPrice);
-              console.log(`Destination token price: ${quote.toTokenPrice}`);
-
-              // Calculate USD value of destination amount
-              if (!isNaN(outputAmount)) {
-                const destinationAmountUsdValue =
-                  outputAmount * quote.toTokenPrice;
-                setDestinationAmountUsd(
-                  parseFloat(destinationAmountUsdValue.toFixed(2)),
-                );
-                console.log(
-                  `Destination amount in USD: ${destinationAmountUsdValue.toFixed(2)}`,
-                );
-              } else {
-                setDestinationAmountUsd(null);
-              }
-            }
-          } else {
-            // No price information available
-            setSourceTokenPrice(null);
-            setSourceAmountUsd(null);
-            setDestinationTokenPrice(null);
-            setDestinationAmountUsd(null);
           }
 
           // For bridging, we use the source token's decimals
@@ -756,10 +670,6 @@ export function useTokenTransfer(
             protocolBps: quote.protocolBps,
             relayerFee: relayerFee,
             totalFee: totalFee,
-            sourceTokenPrice: sourceTokenPrice,
-            destinationTokenPrice: destinationTokenPrice,
-            sourceAmountUsd: sourceAmountUsd,
-            destinationAmountUsd: destinationAmountUsd,
           });
         } else {
           failQuote();
@@ -985,10 +895,6 @@ export function useTokenTransfer(
     protocolFeeUsd,
     relayerFeeUsd,
     totalFeeUsd,
-    sourceTokenPrice,
-    destinationTokenPrice,
-    sourceAmountUsd,
-    destinationAmountUsd,
 
     // Actions
     handleTransfer,


### PR DESCRIPTION
This PR simply removes redundant price calculation code from the `fetchQuote` hook, as this is now done using the fetched prices elsewhere.

This PR does not include correcting of the fee calculation - that will be done in the next PR.