### PR TITLE
fix: custom tokens do not cause new tokens to use HelpCircle

### DIFF
--- a/src/components/ui/TokenImage.tsx
+++ b/src/components/ui/TokenImage.tsx
@@ -15,58 +15,59 @@ export const TokenImage: React.FC<TokenImageProps> = ({
   chain,
   size = "md",
 }) => {
-  const [hasError, setHasError] = useState(false);
+  const [hasLoadError, setHasLoadError] = useState(false);
 
-  // Size classes
   const sizeClasses = {
     sm: "w-5 h-5",
     md: "w-8 h-8",
     lg: "w-12 h-12",
   };
-
-  // Sizes prop for Next.js Image optimization
   const sizesProp = {
     sm: "20px",
     md: "32px",
     lg: "48px",
   };
-
-  // Question mark colors based on size
   const questionMarkSizes = {
     sm: 16,
     md: 24,
     lg: 32,
   };
 
-  // Handle any image loading error
-  const handleImageError = () => {
-    setHasError(true);
-  };
-
-  // Determine the image source based on whether the token is native or not
   const getImageSrc = () => {
+    if (!token.icon || token.icon === "unknown.png") {
+      return null;
+    }
+
     if (token.native) {
       return `/tokens/native/pngs/${token.icon}`;
     }
     return `/tokens/${chain.id}/pngs/${token.icon}`;
   };
 
-  // If there was an error, show the question mark icon
-  if (hasError) {
+  const imageSrc = getImageSrc();
+
+  const handleImageError = () => {
+    console.warn(
+      `Failed to load image for token ${token.name} at path: ${imageSrc}`,
+    );
+    setHasLoadError(true);
+  };
+
+  if (!imageSrc || hasLoadError) {
     return (
       <div
         className={`${sizeClasses[size]} flex-shrink-0 flex items-center justify-center bg-zinc-800 rounded-full`}
+        aria-label={`Missing icon for ${token.name}`}
       >
         <HelpCircle size={questionMarkSizes[size]} className="text-zinc-400" />
       </div>
     );
   }
 
-  // Otherwise, try to load the image
   return (
     <div className={`relative ${sizeClasses[size]} flex-shrink-0`}>
       <Image
-        src={getImageSrc()}
+        src={imageSrc}
         alt={token.name}
         fill
         sizes={sizesProp[size]}


### PR DESCRIPTION
This PR prevents custom tokens which loaded from forcing newly selected tokens from the top 100 to keep using the Lucide `HelpCircle` icon and instead allows them to render their icon png, if available, as expected.