### PR TITLE
feat: reown integration for evm

### DIFF
--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { Button } from "@/components/ui/Button";
 import { useState, useEffect } from "react";
 import useWeb3Store from "@/store/web3Store";
-import { disconnectMetamask, truncateAddress } from "@/utils/walletMethods";
+import { truncateAddress } from "@/utils/walletMethods";
 import { toast } from "sonner";
 import {
   Sheet,
@@ -18,10 +18,16 @@ import { Menu } from "lucide-react";
 import BrandedButton from "@/components/ui/BrandedButton";
 import { ConnectWalletModal } from "@/components/ui/ConnectWalletModal";
 import Link from "next/link";
+import { useWalletConnection } from "@/utils/walletMethods";
 
 export function SiteHeader() {
   const [isOpen, setIsOpen] = useState(false);
+
   const activeWallet = useWeb3Store((state) => state.activeWallet);
+
+  const { disconnectWallet, getWalletDisplayInfo } = useWalletConnection();
+
+  const walletDisplay = activeWallet ? getWalletDisplayInfo() : null;
 
   useEffect(() => {
     const handleResize = () => {
@@ -43,7 +49,9 @@ export function SiteHeader() {
   const handleDisconnect = async () => {
     if (activeWallet) {
       try {
-        await disconnectMetamask();
+        // Use our new disconnectWallet function from the hook
+        await disconnectWallet();
+        toast.success("Wallet disconnected");
         setIsOpen(false); // Close the sheet after disconnecting
       } catch (error) {
         toast.error("Failed to disconnect wallet.");
@@ -54,6 +62,16 @@ export function SiteHeader() {
 
   const handleSheetClose = () => {
     setIsOpen(false);
+  };
+
+  const getWalletButtonText = () => {
+    if (!activeWallet) return "connect wallet";
+
+    if (walletDisplay) {
+      return walletDisplay.address;
+    }
+
+    return truncateAddress(activeWallet.address);
   };
 
   return (
@@ -121,7 +139,7 @@ export function SiteHeader() {
                     iconClassName="h-4 w-4"
                     onClick={handleDisconnect}
                     iconName="Wallet"
-                    buttonText={truncateAddress(activeWallet.address)}
+                    buttonText={getWalletButtonText()}
                   />
                 ) : (
                   <ConnectWalletModal
@@ -147,7 +165,7 @@ export function SiteHeader() {
               iconClassName="h-4 w-4"
               onClick={handleDisconnect}
               iconName="Wallet"
-              buttonText={truncateAddress(activeWallet.address)}
+              buttonText={getWalletButtonText()}
             />
           ) : (
             <ConnectWalletModal

--- a/src/components/meta/WalletContext.tsx
+++ b/src/components/meta/WalletContext.tsx
@@ -4,7 +4,6 @@ import { createAppKit } from "@reown/appkit/react";
 import { BaseWalletAdapter, SolanaAdapter } from "@reown/appkit-adapter-solana";
 import { EthersAdapter } from "@reown/appkit-adapter-ethers";
 import { AppKitNetwork } from "@reown/appkit-common";
-
 import { solana } from "@reown/appkit/networks";
 import {
   mainnet,
@@ -13,8 +12,8 @@ import {
   base,
   optimism,
   polygon,
+  bsc,
 } from "@reown/appkit/networks";
-
 import { PhantomWalletAdapter } from "@solana/wallet-adapter-wallets";
 
 const networks: [AppKitNetwork, ...AppKitNetwork[]] = [
@@ -25,6 +24,7 @@ const networks: [AppKitNetwork, ...AppKitNetwork[]] = [
   optimism,
   polygon,
   solana,
+  bsc,
 ];
 
 // 0. Create the Ethers adapter

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -7,7 +7,8 @@ export interface WalletInfo {
 }
 
 export enum WalletType {
-  REOWN = "REOWN",
+  REOWN_EVM = "REOWN_EVM",
+  REOWN_SOL = "REOWN_SOL",
   SUI = "SUI",
 }
 
@@ -249,3 +250,45 @@ export interface TokenPriceResult {
   prices: TokenPrice[];
   error: string | null;
 }
+
+// you can thank our linting for this...
+type EthereumMethod =
+  | "eth_chainId"
+  | "eth_accounts"
+  | "eth_requestAccounts"
+  | "eth_sendTransaction"
+  | "eth_sign"
+  | "eth_signTransaction"
+  | "eth_signTypedData"
+  | "eth_signTypedData_v4"
+  | "wallet_switchEthereumChain"
+  | "wallet_addEthereumChain"
+  | "personal_sign"
+  | "net_version"
+  | "eth_getBalance"
+  | string;
+
+type EthereumParam =
+  | string
+  | number
+  | boolean
+  | null
+  | Array<string | number | boolean | null | Record<string, unknown>>
+  | Record<string, unknown>;
+
+type EthereumResult =
+  | string
+  | string[]
+  | boolean
+  | number
+  | Record<string, unknown>
+  | null;
+
+export interface Eip1193Provider {
+  request(args: {
+    method: EthereumMethod;
+    params?: EthereumParam[];
+  }): Promise<EthereumResult>;
+}
+
+export type ChainNamespace = "eip155" | "solana" | "polkadot" | "bip122";

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,8 +1,41 @@
-import type { MetaMaskInpageProvider } from "@metamask/providers";
+// Define more specific types for RPC methods and parameters
+type EthereumRpcMethod =
+  | "eth_chainId"
+  | "eth_accounts"
+  | "eth_requestAccounts"
+  | "eth_sendTransaction"
+  | "wallet_switchEthereumChain"
+  | "wallet_addEthereumChain";
 
+// Define common return types for Ethereum RPC methods
+type EthereumRpcResult =
+  | string
+  | string[]
+  | boolean
+  | Record<string, unknown>
+  | null;
+
+// Define a more specific provider interface
+interface PartialProvider {
+  request?: (args: {
+    method: EthereumRpcMethod;
+    params?: (string | number | boolean | Record<string, unknown>)[];
+  }) => Promise<EthereumRpcResult>;
+
+  // For other possible properties that might exist on providers
+  isMetaMask?: boolean;
+  isConnected?: () => boolean;
+  on?: (event: string, callback: (result: unknown) => void) => void;
+  removeListener?: (event: string, callback: (result: unknown) => void) => void;
+
+  // Still need an index signature but with a more specific type
+  [key: string]: unknown;
+}
+
+// Extend the Window interface
 declare global {
   interface Window {
-    ethereum?: MetaMaskInpageProvider;
+    ethereum?: PartialProvider;
   }
 }
 

--- a/src/utils/providerUtils.ts
+++ b/src/utils/providerUtils.ts
@@ -1,0 +1,83 @@
+import { Eip1193Provider } from "@/types/web3";
+
+// Define possible wallet provider structures
+interface DirectProvider {
+  request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+  [key: string]: unknown;
+}
+
+interface NestedProviderContainer {
+  provider: DirectProvider;
+  [key: string]: unknown;
+}
+
+interface EthereumContainer {
+  ethereum: DirectProvider;
+  [key: string]: unknown;
+}
+
+// Union type for all possible provider structures
+type PossibleWalletProvider =
+  | DirectProvider
+  | NestedProviderContainer
+  | EthereumContainer
+  | unknown;
+
+// Function to safely check and use Reown wallet provider
+export function getSafeProvider(
+  walletProvider: PossibleWalletProvider,
+): Eip1193Provider {
+  // Try different possible locations for the actual provider
+  let validProvider: Eip1193Provider | null = null;
+
+  // Direct check
+  if (
+    walletProvider &&
+    typeof walletProvider === "object" &&
+    "request" in walletProvider &&
+    typeof (walletProvider as DirectProvider).request === "function"
+  ) {
+    validProvider = walletProvider as unknown as Eip1193Provider;
+  }
+  // Nested in .provider
+  else if (
+    walletProvider &&
+    typeof walletProvider === "object" &&
+    "provider" in walletProvider &&
+    typeof walletProvider.provider === "object" &&
+    walletProvider.provider !== null &&
+    "request" in walletProvider.provider &&
+    typeof (walletProvider as NestedProviderContainer).provider.request ===
+      "function"
+  ) {
+    validProvider = (walletProvider as NestedProviderContainer)
+      .provider as unknown as Eip1193Provider;
+  }
+  // Nested in .ethereum
+  else if (
+    walletProvider &&
+    typeof walletProvider === "object" &&
+    "ethereum" in walletProvider &&
+    typeof walletProvider.ethereum === "object" &&
+    walletProvider.ethereum !== null &&
+    "request" in walletProvider.ethereum &&
+    typeof (walletProvider as EthereumContainer).ethereum.request === "function"
+  ) {
+    validProvider = (walletProvider as EthereumContainer)
+      .ethereum as unknown as Eip1193Provider;
+  }
+  // Fallback to window.ethereum
+  else if (
+    window.ethereum &&
+    window.ethereum.request &&
+    typeof window.ethereum.request === "function"
+  ) {
+    validProvider = window.ethereum as unknown as Eip1193Provider;
+  }
+
+  if (!validProvider) {
+    throw new Error("No valid Ethereum provider found");
+  }
+
+  return validProvider;
+}


### PR DESCRIPTION
This PR shifts away from connecting directly through Metamask and instead using the Reown wallet integration.

With this approach I have tested the following:
- connecting wallet
- disconnecting wallet
- fetching balances
- executing swap
- attempting to swap on incorrect source chain and ensuring chain switches as expected
- spend approval

I apologise in advance for the amount of interfaces created. I had no choice as the use of `any` is blocked by our linting.