### PR TITLE
feat: shorten token name

### DIFF
--- a/src/components/ui/SelectTokenButton.tsx
+++ b/src/components/ui/SelectTokenButton.tsx
@@ -67,7 +67,11 @@ const TokenListItem: React.FC<TokenListItemProps> = React.memo(
             <TokenImage token={token} chain={chain} />
 
             <div className="flex flex-col">
-              <div className="font-medium text-[#FAFAFA]">{token.name}</div>
+              <div className="font-medium text-[#FAFAFA]">
+                {token.name.length > 32
+                  ? token.name.slice(0, 32) + "..."
+                  : token.name}
+              </div>
               <div className="flex items-center text-[0.75rem] text-[#FAFAFA55]">
                 <span className="numeric-input flex items-center w-16">
                   {token.ticker}
@@ -108,7 +112,7 @@ const TokenListItem: React.FC<TokenListItemProps> = React.memo(
             </div>
           </div>
           <div className="text-right">
-            <div className="font-medium text-[#FAFAFA] numeric-input">
+            <div className="font-regular text-[#FAFAFA] numeric-input">
               {token.userBalanceUsd ? `$${token.userBalanceUsd}` : ""}
             </div>
             <div className="text-sm text-[#FAFAFA55] numeric-input">


### PR DESCRIPTION
branched off https://github.com/altverseweb3/site/pull/69/files, will rebase

This PR resolves two UI issues with the Select Token Button modal:
1. The use of Mono Medium instead of Mono Regular on the User Balance in USD
2. Cutting off token names longer than 32 characters to avoid them bleeding into other details.

