### PR TITLE
bugfix: set dark theme as default

### DIFF
--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -34,7 +34,7 @@ const useUIStore = create<UIStoreState>()(
       activeTab: "swap",
       setActiveTab: (tab) => set({ activeTab: tab }),
 
-      theme: "light",
+      theme: "dark", // Default to dark theme
       toggleTheme: () =>
         set((state) => {
           const newTheme = state.theme === "light" ? "dark" : "light";
@@ -71,10 +71,7 @@ if (typeof window !== "undefined") {
 
   if (!storedTheme) {
     // If no stored theme, use system preference
-    const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-      .matches
-      ? "dark"
-      : "light";
+    const systemTheme = "dark"; // Default to dark theme
     store.setTheme(systemTheme);
   } else {
     // If theme was stored, ensure DOM matches stored state

--- a/src/utils/tokenMethods.ts
+++ b/src/utils/tokenMethods.ts
@@ -269,7 +269,7 @@ export const parseDecimalNumber = (
     remainingDigits: formattedNum,
     originalValue,
   };
-}
+};
 
 export const getCompositeKey = (
   chainName: string,


### PR DESCRIPTION
This PR resolves an issue introduced by activating the `uiStore` which set the theme to light mode if enabled on browser default.