### PR TITLE
feat: swap tracking integration

### DIFF
--- a/src/app/(dapp)/swap/page.tsx
+++ b/src/app/(dapp)/swap/page.tsx
@@ -1,12 +1,11 @@
 "use client";
-
 import React from "react";
 import { useTokenTransfer } from "@/utils/walletMethods";
 import { TokenTransfer } from "@/components/ui/TokenTransfer";
 import useWeb3Store from "@/store/web3Store";
 
 const SwapComponent: React.FC = () => {
-  // Use the shared hook for all swap functionality
+  // Use the shared hook with tracking enabled
   const {
     amount,
     handleAmountChange,
@@ -22,10 +21,17 @@ const SwapComponent: React.FC = () => {
     relayerFeeUsd,
   } = useTokenTransfer({
     type: "swap",
+    enableTracking: true, // Enable automatic tracking
     onSuccess: (amount, sourceToken, destinationToken) => {
+      // This now fires when the swap actually completes (after tracking)
       console.log(
-        `Swap succeeded: ${amount} ${sourceToken.ticker} → ${destinationToken?.ticker}`,
+        `Swap completed: ${amount} ${sourceToken.ticker} → ${destinationToken?.ticker}`,
       );
+      // Any additional success logic can go here
+    },
+    onSwapInitiated: (swapId: string) => {
+      // Optional: Log when swap transaction is submitted
+      console.log("Swap initiated with ID:", swapId);
     },
   });
 

--- a/src/components/ui/TokenTransfer.tsx
+++ b/src/components/ui/TokenTransfer.tsx
@@ -16,7 +16,7 @@ interface TokenTransferProps {
   onAmountChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   isButtonDisabled?: boolean;
   hasActiveWallet?: boolean;
-  onTransfer?: () => Promise<void>;
+  onTransfer?: () => Promise<string | void>;
   transferType: "swap" | "bridge";
   actionText?: string;
   actionIcon?: AvailableIconName;

--- a/src/hooks/useSwapTracking.ts
+++ b/src/hooks/useSwapTracking.ts
@@ -57,7 +57,7 @@ export function useSwapTracking(
         console.log("Tracking error:", err.message);
 
         if (hasCompletedRef.current) {
-         console.log("Already completed, ignoring error");
+          console.log("Already completed, ignoring error");
           return;
         }
 


### PR DESCRIPTION
branch off #85, #86, will need to rebase

note: the only files concerning this PR are `walletMethods`, `swap/page.tsx`, and `TokenTransfer.tsx`.

This PR adds integration of the `useSwapTracking` hook into the `handleTransfer` function on `walletMethods`. The handleTransfer function now no longer returns a `void`, but rather a `string | void`, hence why `page.tsx` and `TokenTransfer.tsx` needed to be updated.

The new approach in `walletMethods` will now poll the swap status API provided by Mayan every 2 seconds for a maximum of 25 minutes. Since each step required for the swap is given to us in the swap status response, we are able to show progression on the swap as it completes each step.

![image](https://github.com/user-attachments/assets/fed026b7-6bb2-4d63-9273-d8de4ad6813b)

For this implementation, we simply show that the swap is progressing and show which step we are currently at. A further implementation could take this much further and add some kind of animation outside of the toast notifications.