### PR TITLE
feat: added functionality to swap token amounts

### DIFF
--- a/src/app/(dapp)/swap/page.tsx
+++ b/src/app/(dapp)/swap/page.tsx
@@ -19,6 +19,7 @@ const SwapComponent: React.FC = () => {
     totalFeeUsd,
     protocolFeeUsd,
     relayerFeeUsd,
+    swapAmounts,
   } = useTokenTransfer({
     type: "swap",
     enableTracking: true, // Enable automatic tracking
@@ -46,6 +47,7 @@ const SwapComponent: React.FC = () => {
       isButtonDisabled={isButtonDisabled}
       hasActiveWallet={!!requiredWallet}
       onTransfer={handleTransfer}
+      swapAmounts={swapAmounts}
       transferType="swap"
       actionIcon="Coins"
       showDestinationTokenSelector={true}

--- a/src/components/ui/TokenTransfer.tsx
+++ b/src/components/ui/TokenTransfer.tsx
@@ -16,6 +16,7 @@ interface TokenTransferProps {
   onAmountChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   isButtonDisabled?: boolean;
   hasActiveWallet?: boolean;
+  swapAmounts?: () => Promise<void>;
   onTransfer?: () => Promise<string | void>;
   transferType: "swap" | "bridge";
   actionText?: string;
@@ -39,6 +40,7 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
   onAmountChange,
   isButtonDisabled,
   hasActiveWallet = false,
+  swapAmounts,
   onTransfer,
   transferType,
   actionText,
@@ -170,6 +172,9 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
       <TokenSwitch
         onClick={() => {
           swapChains();
+          if (swapAmounts) {
+            swapAmounts();
+          }
         }}
       />
 

--- a/src/utils/walletMethods.ts
+++ b/src/utils/walletMethods.ts
@@ -650,6 +650,7 @@ interface TokenTransferState {
   isTracking: boolean;
   trackingError: Error | null;
 
+  swapAmounts: () => Promise<void>;
   handleTransfer: () => Promise<string | void>;
 }
 
@@ -1170,9 +1171,11 @@ export function useTokenTransfer(
     };
   }, [isValid, isLoadingQuote, isProcessing]);
 
-  const handleTransfer = async (): Promise<string | void> => {
-    // Return swap ID
+  const swapAmounts = async (): Promise<void> => {
+    setAmount(receiveAmount);
+  };
 
+  const handleTransfer = async (): Promise<string | void> => {
     if (!isValid) {
       toast.warning(`Invalid ${options.type} parameters`, {
         description:
@@ -1479,6 +1482,7 @@ export function useTokenTransfer(
       !isValid || isProcessing || !isWalletCompatible || isChainSwitching,
     // Actions
     handleTransfer,
+    swapAmounts,
   };
 }
 /**


### PR DESCRIPTION
This PR adds the functionality to swap the `receiveAmount` into the input amount when the switch button is clicked (along with the chain and token). 

The reason we don't automatically swap the input amount into the `receiveAmount` is that the action of switching all other properties will trigger the quote to run instantly, and the quote will be more accurate. We should _never_ forcibly override the receive amount.

