### PR TITLE
feat: require EVM wallet connection for cross-env etherfi swaps

### DIFF
--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -681,11 +681,17 @@ const DepositModal: React.FC<DepositModalProps> = ({
             )}
 
             <Button
-              onClick={selectedSwapChain ? handleSwapTransfer : handleDeposit}
+              onClick={
+                selectedSwapChain
+                  ? isWalletConnected
+                    ? handleSwapTransfer
+                    : connectEvmWallet // Require EVM connection for cross-chain swaps
+                  : handleDeposit
+              }
               disabled={
                 selectedSwapChain
                   ? isSwapButtonDisabled ||
-                    !isChainWalletConnected(selectedSwapChain) // Cross-chain swap
+                    !isChainWalletConnected(selectedSwapChain) // Source chain wallet must be connected
                   : !isFormValid || isLoading || (needsApproval && isFormValid) // Direct deposit
               }
               className="w-full bg-amber-500 text-black hover:bg-amber-600 disabled:opacity-50"
@@ -698,17 +704,24 @@ const DepositModal: React.FC<DepositModalProps> = ({
               ) : (
                 <>
                   {selectedSwapChain ? (
-                    <>
-                      Cross-chain Swap{" "}
-                      {
-                        chainList.find(
-                          (chain) => chain.id === selectedSwapChain,
-                        )?.chainToken
-                      }
-                      {receiveAmount &&
-                        ` → ${receiveAmount} ${vault.supportedAssets.deposit[0]}`}
-                      <ArrowRight className="h-4 w-4 ml-2" />
-                    </>
+                    isWalletConnected ? (
+                      <>
+                        Cross-chain Swap{" "}
+                        {
+                          chainList.find(
+                            (chain) => chain.id === selectedSwapChain,
+                          )?.chainToken
+                        }
+                        {receiveAmount &&
+                          ` → ${receiveAmount} ${vault.supportedAssets.deposit[0]}`}
+                        <ArrowRight className="h-4 w-4 ml-2" />
+                      </>
+                    ) : (
+                      <>
+                        Connect EVM Wallet for Swap (Required)
+                        <ArrowRight className="h-4 w-4 ml-2" />
+                      </>
+                    )
                   ) : (
                     <>
                       Direct Deposit {selectedAsset}


### PR DESCRIPTION
This PR is concerned with requiring that an EVM wallet is connected to conduct a cross-environment swap in the earn section modals.

See https://github.com/altverseweb3/site/commit/7bf078acdc9230aed69b4cca3708a60f1062bfd0 for relevant changes.

---

![image](https://github.com/user-attachments/assets/833672a4-54df-4df9-b342-1df35bf88402)

