### PR TITLE
refactor: memoize utils

### DIFF
--- a/src/utils/etherFi/fetch.ts
+++ b/src/utils/etherFi/fetch.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { useCallback } from "react"; // Add this import
 import { useWalletProviderAndSigner } from "@/utils/reownEthersUtils";
 import { ERC20_ABI, TELLER_PAUSED_ABI } from "@/types/etherFiABIs";
 import { ETHERFI_VAULTS, DEPOSIT_ASSETS } from "@/config/etherFi";
@@ -205,8 +206,8 @@ export async function getUserVaultBalance(
 export function useEtherFiFetch() {
   const { getEvmSigner } = useWalletProviderAndSigner();
 
-  return {
-    fetchVaultTVL: async (vaultId: number) => {
+  const fetchVaultTVLMemoized = useCallback(
+    async (vaultId: number) => {
       const signer = await getEvmSigner();
       const provider = signer.provider;
       if (!provider) {
@@ -214,8 +215,11 @@ export function useEtherFiFetch() {
       }
       return fetchVaultTVL(vaultId, provider);
     },
+    [getEvmSigner],
+  );
 
-    checkIfTellerPaused: async (vaultId: number) => {
+  const checkIfTellerPausedMemoized = useCallback(
+    async (vaultId: number) => {
       const signer = await getEvmSigner();
       const provider = signer.provider;
       if (!provider) {
@@ -223,18 +227,27 @@ export function useEtherFiFetch() {
       }
       return checkIfTellerPaused(vaultId, provider);
     },
+    [getEvmSigner],
+  );
 
-    getTokenAllowance: async (tokenSymbol: string, vaultId: number) => {
+  const getTokenAllowanceMemoized = useCallback(
+    async (tokenSymbol: string, vaultId: number) => {
       const signer = await getEvmSigner();
       return getTokenAllowance(tokenSymbol, vaultId, signer);
     },
+    [getEvmSigner],
+  );
 
-    getTokenBalance: async (tokenSymbol: string) => {
+  const getTokenBalanceMemoized = useCallback(
+    async (tokenSymbol: string) => {
       const signer = await getEvmSigner();
       return getTokenBalance(tokenSymbol, signer);
     },
+    [getEvmSigner],
+  );
 
-    getUserVaultBalance: async (vaultId: number) => {
+  const getUserVaultBalanceMemoized = useCallback(
+    async (vaultId: number) => {
       const signer = await getEvmSigner();
       const userAddress = await signer.getAddress();
       const provider = signer.provider;
@@ -243,5 +256,14 @@ export function useEtherFiFetch() {
       }
       return getUserVaultBalance(vaultId, userAddress, provider);
     },
+    [getEvmSigner],
+  );
+
+  return {
+    fetchVaultTVL: fetchVaultTVLMemoized,
+    checkIfTellerPaused: checkIfTellerPausedMemoized,
+    getTokenAllowance: getTokenAllowanceMemoized,
+    getTokenBalance: getTokenBalanceMemoized,
+    getUserVaultBalance: getUserVaultBalanceMemoized,
   };
 }

--- a/src/utils/reownEthersUtils.ts
+++ b/src/utils/reownEthersUtils.ts
@@ -1,5 +1,6 @@
 // utils/reownEthersUtils.ts
 
+import { useCallback } from "react";
 import { ethers } from "ethers";
 import { useAppKitProvider } from "@reown/appkit/react";
 import { getSafeProvider, getSafeSolanaProvider } from "@/utils/providerUtils";
@@ -17,15 +18,13 @@ export function useWalletProviderAndSigner() {
   /**
    * Get EVM signer from wallet provider
    */
-  const getEvmSigner = async () => {
+  const getEvmSigner = useCallback(async () => {
     if (!evmProvider) {
       console.error("No EVM wallet provider available from Reown");
       throw new Error("No EVM wallet provider available");
     }
-
     try {
       const safeProvider = getSafeProvider(evmProvider);
-
       // Create ethers provider and signer
       const ethersProvider = new ethers.BrowserProvider(safeProvider);
       return await ethersProvider.getSigner();
@@ -33,21 +32,19 @@ export function useWalletProviderAndSigner() {
       console.error("Error getting EVM signer from wallet provider:", error);
       throw error;
     }
-  };
+  }, [evmProvider]); // Dependency on evmProvider
 
   /**
    * Get Solana wallet interface for signing
    * Returns an object with methods for signing Solana transactions
    */
-  const getSolanaSigner = async () => {
+  const getSolanaSigner = useCallback(async () => {
     if (!solanaProvider) {
       console.error("No Solana wallet provider available from Reown");
       throw new Error("No Solana wallet provider available");
     }
-
     try {
       const safeProvider = getSafeSolanaProvider(solanaProvider);
-
       if (!safeProvider) {
         throw new Error("Failed to get safe Solana provider");
       }
@@ -76,7 +73,6 @@ export function useWalletProviderAndSigner() {
           if (typeof safeProvider.signTransaction !== "function") {
             throw new Error("Solana provider does not support signTransaction");
           }
-
           return safeProvider.signTransaction(
             transaction,
           ) as Promise<Transaction>;
@@ -88,7 +84,6 @@ export function useWalletProviderAndSigner() {
               "Solana provider does not support signAllTransactions",
             );
           }
-
           return safeProvider.signAllTransactions(transactions) as Promise<
             Transaction[]
           >;
@@ -98,7 +93,6 @@ export function useWalletProviderAndSigner() {
           if (typeof safeProvider.signMessage !== "function") {
             throw new Error("Solana provider does not support signMessage");
           }
-
           return safeProvider.signMessage(message, "utf8");
         },
       };
@@ -106,13 +100,12 @@ export function useWalletProviderAndSigner() {
       console.error("Error getting Solana signer from wallet provider:", error);
       throw error;
     }
-  };
+  }, [solanaProvider]); // Dependency on solanaProvider
 
   /**
    * Get appropriate signer based on active wallet type
    * This is the main function to use for getting a signer for transactions
    */
-
   return {
     evmProvider,
     solanaProvider,


### PR DESCRIPTION
This PR memoizes some of our util functions which were used in `useEffect` hooks. I noticed that with the `getTokenBalance` call failing in `DepositModal`, an infinite loop was being caused inside the `useEffect` hook which calls it.

Further upstream, the `getEvmSigner` and `getSolanaSigner` functions in `useWalletProviderAndSigner` were being recreated on every render, causing new function references each time. When these functions were used as dependencies in useCallback hooks (like in the deposit modal's fetchBalance), it triggered infinite re-render loops.