### PR TITLE
chore: added pauseQuoting option to useTokenTransfer

### DIFF
--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -218,6 +218,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
   } = useTokenTransfer({
     type: "swap",
     enableTracking: true,
+    pauseQuoting: !!selectedSwapChain,
     onSuccess: (amount, sourceToken, destinationToken) => {
       console.log("TOKEN TRANSFER onSuccess called:", {
         amount,

--- a/src/utils/walletMethods.ts
+++ b/src/utils/walletMethods.ts
@@ -604,6 +604,7 @@ export function ensureCorrectWalletTypeForChain(sourceChain: Chain): boolean {
 
 interface TokenTransferOptions {
   type: "swap" | "bridge" | "V";
+  pauseQuoting?: boolean;
   enableTracking?: boolean; // New option to enable automatic tracking
   trackingOptions?: SwapTrackingOptions; // Pass through tracking configuration
   onSuccess?: (
@@ -920,6 +921,11 @@ export function useTokenTransfer(
 
   // Update this useEffect to include fee calculation
   useEffect(() => {
+    if (options.pauseQuoting === false) {
+      failQuote();
+      return;
+    }
+
     let timeoutId: NodeJS.Timeout;
 
     const fetchQuote = async () => {
@@ -1149,6 +1155,7 @@ export function useTokenTransfer(
     getGasDrop,
     refreshTrigger,
     isValid,
+    options.pauseQuoting,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
This PR adds a new optional parameter `pauseQuoting` to `useTokenTransfer`, enabling components such as the `DepositModal` to conditionally pause quotes when appropriate, such as when a vault supported asset for direct deposit is selected. 

This allows the input amount on the `DepositModal` to remain as a single consolidated value referencing the `swapAmount`, without actually fetching quotes for swaps that are not required for a direct deposit.

