### PR TITLE
chore: remove discord link and fix ether.fi vaults ecosystem names

### DIFF
--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -12,14 +12,6 @@ export function SiteFooter() {
 
         <div className="ml-auto flex items-center gap-1">
           <SocialIcon
-            url="https://discord.gg/"
-            bgColor="#0A0A0B"
-            fgColor="#A6A6A9"
-            style={{ height: 24, width: 24 }}
-            className="sm:w-7 sm:h-7"
-          />
-
-          <SocialIcon
             url="https://x.com/altverseweb3"
             bgColor="#0A0A0B"
             fgColor="#A6A6A9"

--- a/src/config/etherFi.ts
+++ b/src/config/etherFi.ts
@@ -395,7 +395,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "Bitcoin LRT",
     description:
       "Bitcoin LRT vault providing restaked BTC yield through various Bitcoin strategies.",
-    ecosystem: "Ethereum",
+    ecosystem: "Ether.fi",
     type: "Featured",
     chain: "ethereum",
     addresses: {
@@ -427,7 +427,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "Ethena USD LRT",
     description:
       "Ethena USD LRT vault combining staking and shorting ETH strategies for stablecoin yield.",
-    ecosystem: "Ethereum",
+    ecosystem: "Ether.fi",
     type: "Featured",
     chain: "ethereum",
     addresses: {
@@ -460,7 +460,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "King Karak LRT",
     description:
       "King Karak LRT vault providing restaked ETH yield through Karak network strategies.",
-    ecosystem: "Ethereum",
+    ecosystem: "Ether.fi",
     type: "Featured",
     chain: "ethereum",
     addresses: {


### PR DESCRIPTION
chore to remove discord link on swap and earn page and fix the ether.fi ecosystem labels 

![image](https://github.com/user-attachments/assets/8208180b-58c1-41ce-9c30-4f1ab40fdc76)
