### PR TITLE
feat: added versioned storage context

### DIFF
--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -86,6 +86,9 @@ export type Chain = {
 };
 
 export interface Web3StoreState {
+  // Store version
+  version: number;
+
   // Wallet-related state
   connectedWallets: Array<Omit<WalletInfo, "provider">>;
 


### PR DESCRIPTION
This PR adds an absolutely critical storage context versioning capability to the `web3Store`.

The versioning works like so:
1. Any time a major/breaking change is made to the `web3Store` or it's persisted types, we can update the `STORE_VERSION` value
2. When the storage context loads, it checks to see whether the version stored currently matches the current `STORE_VERSION`
3. If:
  a. No version exists (which will be the case for our current users)
  b. The version does not match
  Then the storage context is wiped and reinstated using the current version.

>[!IMPORTANT]
> It is the responsibility of all developers going forward to ensure that the storage context is updated when breaking changes are made. This includes breaking changes to, in particular:
> `Token` types and config
> `Token` and `Chain` image paths