### PR TITLE
fix:separate load states for dashboard and earn table

### DIFF
--- a/src/app/(dapp)/earn/etherFi.ts
+++ b/src/app/(dapp)/earn/etherFi.ts
@@ -25,18 +25,19 @@ export function useEtherFiEarnData(isWalletConnected: boolean) {
     dashboardRows: [],
   });
   const [loading, setLoading] = useState(false);
+  const [userPositionsLoading, setUserPositionsLoading] = useState(false);
   const evmWallet = useWalletByType(WalletType.REOWN_EVM);
 
+  // Effect 1: Fetch vault data (independent of wallet connection)
   useEffect(() => {
     let isMounted = true;
 
-    const fetchData = async (): Promise<void> => {
+    const fetchVaultData = async (): Promise<void> => {
       if (!isMounted) return;
       setLoading(true);
 
       try {
         const earnRows: EarnTableRow[] = [];
-        const dashboardRows: DashboardTableRow[] = [];
 
         // Fetch APY data for all vaults first
         const apyData = await queryAllVaultsAPY().catch(
@@ -112,7 +113,48 @@ export function useEtherFiEarnData(isWalletConnected: boolean) {
           ...(vaultResults.filter((row) => row !== null) as EarnTableRow[]),
         );
 
-        // Fetch user positions if wallet is connected
+        if (isMounted) {
+          setData((prevData) => ({
+            ...prevData,
+            earnRows,
+          }));
+        }
+      } catch (error) {
+        console.error("Error fetching etherFi vault data:", error);
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchVaultData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []); // Only run once on mount
+
+  // Effect 2: Fetch user positions (only when wallet connects/changes)
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchUserPositions = async (): Promise<void> => {
+      if (!isMounted || !isWalletConnected || !evmWallet?.address) {
+        // Clear dashboard rows if wallet disconnected
+        if (isMounted) {
+          setData((prevData) => ({
+            ...prevData,
+            dashboardRows: [],
+          }));
+        }
+        return;
+      }
+
+      setUserPositionsLoading(true);
+
+      try {
+        const dashboardRows: DashboardTableRow[] = [];
         if (isWalletConnected && evmWallet?.address) {
           const provider = new ethers.JsonRpcProvider("https://1rpc.io/eth");
 
@@ -192,28 +234,35 @@ export function useEtherFiEarnData(isWalletConnected: boolean) {
         }
 
         if (isMounted) {
-          setData({
-            earnRows,
+          setData((prevData) => ({
+            ...prevData,
             dashboardRows,
-          });
+          }));
         }
       } catch (error) {
-        console.error("Error fetching etherFi earn data:", error);
+        console.error("Error fetching user positions:", error);
       } finally {
         if (isMounted) {
-          setLoading(false);
+          setUserPositionsLoading(false);
         }
       }
     };
 
-    fetchData();
+    // Only fetch user positions if we have earn rows already loaded
+    if (data.earnRows.length > 0) {
+      fetchUserPositions();
+    }
 
     return () => {
       isMounted = false;
     };
-  }, [isWalletConnected, evmWallet?.address]);
+  }, [isWalletConnected, evmWallet?.address, data.earnRows.length]);
 
-  return { data, loading };
+  return {
+    data,
+    loading: loading, // Only vault data loading
+    userPositionsLoading, // Separate loading state for user positions
+  };
 }
 
 function getAssetIcon(assetSymbol: string): string {

--- a/src/app/(dapp)/earn/etherFi.ts
+++ b/src/app/(dapp)/earn/etherFi.ts
@@ -157,6 +157,7 @@ export function useEtherFiEarnData(isWalletConnected: boolean) {
         const dashboardRows: DashboardTableRow[] = [];
         if (isWalletConnected && evmWallet?.address) {
           const provider = new ethers.JsonRpcProvider("https://1rpc.io/eth");
+          const vaultEntries = Object.entries(ETHERFI_VAULTS);
 
           // Create parallel promises for all user vault positions
           const userPositionPromises = vaultEntries.map(
@@ -173,7 +174,9 @@ export function useEtherFiEarnData(isWalletConnected: boolean) {
                 // Only include positions with non-zero balance
                 if (parseFloat(userBalance.formatted) > 0) {
                   // Find the corresponding earn row for vault details
-                  const earnRow = earnRows.find((row) => row.id === vaultId);
+                  const earnRow = data.earnRows.find(
+                    (row) => row.id === vaultId,
+                  );
                   if (earnRow) {
                     // Calculate USD value of the position
                     const vault = ETHERFI_VAULTS[vaultId];
@@ -256,7 +259,7 @@ export function useEtherFiEarnData(isWalletConnected: boolean) {
     return () => {
       isMounted = false;
     };
-  }, [isWalletConnected, evmWallet?.address, data.earnRows.length]);
+  }, [isWalletConnected, evmWallet?.address, data.earnRows]);
 
   return {
     data,

--- a/src/app/(dapp)/earn/page.tsx
+++ b/src/app/(dapp)/earn/page.tsx
@@ -68,7 +68,11 @@ export default function EarnPage() {
   const isEvmWalletConnected = useIsWalletTypeConnected(WalletType.REOWN_EVM);
 
   // Use the etherFi hook for data fetching - always fetch earn data, only require wallet for dashboard
-  const { data: earnData, loading } = useEtherFiEarnData(isEvmWalletConnected);
+  const {
+    data: earnData,
+    loading,
+    userPositionsLoading,
+  } = useEtherFiEarnData(isEvmWalletConnected);
 
   // Filter and sort data
   const filteredData = useMemo(() => {
@@ -272,7 +276,8 @@ export default function EarnPage() {
                 }
               />
             </div>
-          ) : loading ? (
+          ) : (activeTab === "earn" && loading) ||
+            (activeTab === "dashboard" && userPositionsLoading) ? (
             <div className="text-center py-16">
               <div className="text-[#A1A1AA]">
                 Loading {activeTab === "earn" ? "opportunities" : "positions"}

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -53,12 +53,14 @@ interface DepositModalProps {
   isOpen: boolean;
   onClose: () => void;
   vault: EtherFiVault | null;
+  apy?: number;
 }
 
 const DepositModal: React.FC<DepositModalProps> = ({
   isOpen,
   onClose,
   vault,
+  apy,
 }) => {
   // Form state
   const [selectedAsset, setSelectedAsset] = useState<string>("");
@@ -1389,7 +1391,9 @@ const DepositModal: React.FC<DepositModalProps> = ({
             <Info className="h-4 w-4 text-green-500" />
             <span className="text-sm text-[#FAFAFA]">
               Current APY:{" "}
-              <span className="text-green-500 font-semibold">5.2%</span>
+              <span className="text-green-500 font-semibold">
+                {apy && apy > 0 ? `${apy.toFixed(1)}%` : "TBD"}
+              </span>
             </span>
           </div>
 

--- a/src/components/ui/earning/EtherFiModal.tsx
+++ b/src/components/ui/earning/EtherFiModal.tsx
@@ -259,6 +259,7 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
           isOpen={isDepositModalOpen}
           onClose={() => setIsDepositModalOpen(false)}
           vault={vault}
+          apy={data.apy}
         />
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
Fix for deposit modal exiting and reloading earn table and fetching all data again upon connecting/reconnecting wallet. 

Now dashboard and earn table have independent loading states, vault data runs once on mount, and user positions runs when wallet connects/changes. 

So we preserve earnRows when connecting wallet and only update dashboardRows - effects only update their own data while retaining previous data.

APY fixes also for deposit modal, utilising existing prop instead of hardcoded values. 