### PR TITLE
bugfix: add failsafe for token icon race condition

### DIFF
--- a/src/components/ui/TokenImage.tsx
+++ b/src/components/ui/TokenImage.tsx
@@ -49,6 +49,11 @@ export const TokenImage: React.FC<TokenImageProps> = ({
     if (token.isL2Token) {
       return `/tokens/native/l2/${chain.id}.png`;
     }
+
+    if (token.icon.startsWith("/images")) {
+      // If the icon path is already relative to /tokens, return it directly
+      return token.icon;
+    }
     return `/tokens/${chain.id}/pngs/${token.icon}`;
   };
 


### PR DESCRIPTION
This PR adds a failsafe for vault deposit assets as there is occasionally a condition where the `.icon` property for Vault Asset returns the full image path. This is a good generic failsafe as from now on any time a token icon is set to the full path, that will just get returned.