### PR TITLE
refactor: decoupled source/destination token/chain in walletMethods

### DIFF
--- a/src/app/(dapp)/swap/page.tsx
+++ b/src/app/(dapp)/swap/page.tsx
@@ -5,6 +5,9 @@ import { TokenTransfer } from "@/components/ui/TokenTransfer";
 import useWeb3Store from "@/store/web3Store";
 
 const SwapComponent: React.FC = () => {
+  const sourceToken = useWeb3Store((state) => state.sourceToken);
+  const destinationToken = useWeb3Store((state) => state.destinationToken);
+
   // Use the shared hook with tracking enabled
   const {
     amount,
@@ -13,8 +16,6 @@ const SwapComponent: React.FC = () => {
     handleTransfer,
     receiveAmount,
     isLoadingQuote,
-    sourceToken,
-    destinationToken,
     estimatedTimeSeconds,
     totalFeeUsd,
     protocolFeeUsd,
@@ -22,6 +23,10 @@ const SwapComponent: React.FC = () => {
     swapAmounts,
   } = useTokenTransfer({
     type: "swap",
+    sourceChain: useWeb3Store((state) => state.sourceChain),
+    destinationChain: useWeb3Store((state) => state.destinationChain),
+    sourceToken: useWeb3Store((state) => state.sourceToken),
+    destinationToken: useWeb3Store((state) => state.destinationToken),
     enableTracking: true, // Enable automatic tracking
     onSuccess: (amount, sourceToken, destinationToken) => {
       // This now fires when the swap actually completes (after tracking)

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -89,6 +89,9 @@ const DepositModal: React.FC<DepositModalProps> = ({
   const requiredWallet = useWeb3Store((state) =>
     state.getWalletBySourceChain(),
   );
+  const sourceToken = useWeb3Store((state) => state.sourceToken);
+  const destinationToken = useWeb3Store((state) => state.destinationToken);
+  const sourceChain = useWeb3Store((state) => state.sourceChain);
   const destinationChain = useWeb3Store((state) => state.destinationChain);
 
   // Wallet hooks for address retrieval
@@ -412,6 +415,11 @@ const DepositModal: React.FC<DepositModalProps> = ({
     isLoadingQuote,
   } = useTokenTransfer({
     type: "swap",
+    sourceChain,
+    destinationChain,
+    sourceToken,
+    destinationToken,
+
     enableTracking: true,
     pauseQuoting: !!isDirectDeposit,
     onSuccess: (amount, sourceToken, destinationToken) => {


### PR DESCRIPTION
This PR begins the process of decoupling and parameterising the `useTokenTransfer` hook in `walletMethods.ts`. In the interest of keeping PRs small, I will do this change in chunks of components that are currently tied to the `web3Store`.

To get us started I have parameterised:
- `sourceChain`
- `destinationChain`
- `sourceToken`
- `destinationToken`

These now get passed into the `useTokenTransfer` hook, rather than being explicitly tied to the `web3Store` values inside the hook itself.

>[!NOTE]
> I am still currently using the exact same values - a reference to the `web3Store` values for the above 4 paramterised values, in both the swap and earn deposit modal pages. However, once this decoupling process has been completed, we will be able to keep distinct values for both.