### PR TITLE
feat: added getWalletByChain agnostic function to web3Store

### DIFF
--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -171,6 +171,13 @@ const useWeb3Store = create<Web3StoreState>()(
         return wallets.filter((w) => w.type === walletType);
       },
 
+      getWalletByChain: (chain: Chain): WalletInfo | null => {
+        return (
+          get().connectedWallets.find((w) => w.type === chain.walletType) ||
+          null
+        );
+      },
+
       getWalletBySourceChain: () => {
         const sourceChainWalletType = get().sourceChain.walletType;
         return (

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -156,6 +156,7 @@ export interface Web3StoreState {
   isWalletTypeConnected: (walletType: WalletType) => boolean;
   getWalletByType: (walletType: WalletType) => WalletInfo | null;
   getWalletBySourceChain: () => WalletInfo | null;
+  getWalletByChain: (chain: Chain) => WalletInfo | null;
   getWalletByDestinationChain: () => WalletInfo | null;
 }
 


### PR DESCRIPTION
This PR adds a "selected chain agnostic" function `getWalletByChain` to the `web3Store`, which takes any `Chain` object as a parameter and compares the `walletType` to the currently connected wallets, and if a match is found, returns the wallet.

This will be critical to our initiative to decouple the `useTokenTransfer` hook, as we can no longer rely on the `getWalletBySourceChain` which leverages the currently set `sourceChain` value in the `web3Store`.