### PR TITLE
refactor: decoupled transaction details

### DIFF
--- a/src/app/(dapp)/swap/page.tsx
+++ b/src/app/(dapp)/swap/page.tsx
@@ -27,6 +27,7 @@ const SwapComponent: React.FC = () => {
     destinationChain: useWeb3Store((state) => state.destinationChain),
     sourceToken: useWeb3Store((state) => state.sourceToken),
     destinationToken: useWeb3Store((state) => state.destinationToken),
+    transactionDetails: useWeb3Store((state) => state.transactionDetails),
     enableTracking: true, // Enable automatic tracking
     onSuccess: (amount, sourceToken, destinationToken) => {
       // This now fires when the swap actually completes (after tracking)

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -93,6 +93,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
   const destinationToken = useWeb3Store((state) => state.destinationToken);
   const sourceChain = useWeb3Store((state) => state.sourceChain);
   const destinationChain = useWeb3Store((state) => state.destinationChain);
+  const transactionDetails = useWeb3Store((state) => state.transactionDetails);
 
   // Wallet hooks for address retrieval
   const { getEvmSigner } = useWalletProviderAndSigner();
@@ -419,7 +420,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
     destinationChain,
     sourceToken,
     destinationToken,
-
+    transactionDetails,
     enableTracking: true,
     pauseQuoting: !!isDirectDeposit,
     onSuccess: (amount, sourceToken, destinationToken) => {

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -622,6 +622,11 @@ interface TokenTransferOptions {
   destinationChain: Chain;
   sourceToken?: Token | null;
   destinationToken?: Token | null;
+  transactionDetails: {
+    slippage: "auto" | string;
+    receiveAddress: string | null;
+    gasDrop: number;
+  };
 }
 
 interface TokenTransferState {
@@ -698,7 +703,6 @@ export function useTokenTransfer(
   );
 
   // Get the transaction details for slippage
-  const transactionDetails = useWeb3Store((state) => state.transactionDetails);
   const receiveAddress = useWeb3Store(
     (state) => state.transactionDetails.receiveAddress,
   );
@@ -883,32 +887,32 @@ export function useTokenTransfer(
 
   // Convert slippage from string (e.g., "3.00%") to basis points (e.g., 300) or "auto"
   const getSlippageBps = useCallback((): "auto" | number => {
-    if (!transactionDetails.slippage) return "auto"; // Default to 'auto'
+    if (options.transactionDetails.slippage) return "auto"; // Default to 'auto'
 
-    if (transactionDetails.slippage === "auto") {
+    if (options.transactionDetails.slippage === "auto") {
       return "auto";
     }
 
     // Remove "%" and convert to number
     const slippagePercent = parseFloat(
-      transactionDetails.slippage.replace("%", ""),
+      options.transactionDetails.slippage.replace("%", ""),
     );
 
     // Convert percentage to basis points (1% = 100 bps)
     return Math.round(slippagePercent * 100);
-  }, [transactionDetails.slippage]);
+  }, [options.transactionDetails.slippage]);
 
   // Convert gasDrop from store (number) or default to 0
   const getGasDrop = useCallback((): number => {
     // if it isn't set or isn't a number, fall back to 0
     if (
-      transactionDetails.gasDrop === undefined ||
-      typeof transactionDetails.gasDrop !== "number"
+      options.transactionDetails.gasDrop === undefined ||
+      typeof options.transactionDetails.gasDrop !== "number"
     ) {
       return 0;
     }
-    return transactionDetails.gasDrop;
-  }, [transactionDetails.gasDrop]);
+    return options.transactionDetails.gasDrop;
+  }, [options.transactionDetails.gasDrop]);
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setAmount(e.target.value);
@@ -1166,7 +1170,7 @@ export function useTokenTransfer(
     options.sourceChain,
     options.destinationChain,
     options.type,
-    transactionDetails.slippage,
+    options.transactionDetails.slippage,
     getSlippageBps,
     getGasDrop,
     refreshTrigger,


### PR DESCRIPTION
This PR continues the process of decoupling `useTokenTransfer` by parameterising the `transactionDetails`. 

>[!NOTE]
> You will notice that there is going to be a growing list of individual parameters being passed in - my plan is to eventually group these into a single `interface` type, but in the interest of keeping PRs small I will decouple them all in sections, and then convert them into a single interface once `useTokenTransfer` is completely parameterised and decoupled from `web3Store`.