### PR TITLE
refactor: decouple use chain switch

### DIFF
--- a/src/components/ui/SwapInterface.tsx
+++ b/src/components/ui/SwapInterface.tsx
@@ -46,11 +46,13 @@ export function SwapInterface({
   detailsOpen,
   onDetailsToggle,
 }: SwapInterfaceProps) {
+  const sourceChain = useWeb3Store((state) => state.sourceChain);
+
   const {
     isLoading: isSwitchingChain,
     error: chainSwitchError,
     switchToSourceChain,
-  } = useChainSwitch();
+  } = useChainSwitch(sourceChain);
 
   // Get wallet connection information for EVM, Solana, and Sui
   const { evmNetwork, isEvmConnected } = useWalletConnection();
@@ -63,7 +65,6 @@ export function SwapInterface({
   const requiredWallet = useWeb3Store((state) =>
     state.getWalletBySourceChain(),
   );
-  const sourceChain = useWeb3Store((state) => state.sourceChain);
 
   const checkCurrentChain = async (): Promise<boolean> => {
     if (!requiredWallet) {

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -58,6 +58,12 @@ const DepositModal: React.FC<DepositModalProps> = ({
   vault,
   apy,
 }) => {
+  const sourceToken = useWeb3Store((state) => state.sourceToken);
+  const destinationToken = useWeb3Store((state) => state.destinationToken);
+  const sourceChain = useWeb3Store((state) => state.sourceChain);
+  const destinationChain = useWeb3Store((state) => state.destinationChain);
+  const transactionDetails = useWeb3Store((state) => state.transactionDetails);
+
   // Form state
   const [selectedSwapChain, setSelectedSwapChain] = useState<string>("");
   const [selectedSwapToken, setSelectedSwapToken] = useState<Token | null>(
@@ -68,7 +74,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
 
   // Integration hooks
   const { approveToken, depositTokens } = useEtherFiInteract();
-  const { switchToChain } = useChainSwitch();
+  const { switchToChain } = useChainSwitch(sourceChain);
   const { open: openAppKit } = useAppKit();
 
   // Web3Store functions for token management
@@ -89,11 +95,6 @@ const DepositModal: React.FC<DepositModalProps> = ({
   const requiredWallet = useWeb3Store((state) =>
     state.getWalletBySourceChain(),
   );
-  const sourceToken = useWeb3Store((state) => state.sourceToken);
-  const destinationToken = useWeb3Store((state) => state.destinationToken);
-  const sourceChain = useWeb3Store((state) => state.sourceChain);
-  const destinationChain = useWeb3Store((state) => state.destinationChain);
-  const transactionDetails = useWeb3Store((state) => state.transactionDetails);
 
   // Wallet hooks for address retrieval
   const { getEvmSigner } = useWalletProviderAndSigner();

--- a/src/components/ui/earning/EtherFiModal.tsx
+++ b/src/components/ui/earning/EtherFiModal.tsx
@@ -33,12 +33,14 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
 }) => {
   const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
 
+  const sourceChain = getChainById("ethereum");
+
   const isEvmWalletConnected = useIsWalletTypeConnected(WalletType.REOWN_EVM);
   const isSuiWalletConnected = useIsWalletTypeConnected(WalletType.SUIET_SUI);
   const isSolanaWalletConnected = useIsWalletTypeConnected(
     WalletType.REOWN_SOL,
   );
-  const { switchToChain } = useChainSwitch();
+  const { switchToChain } = useChainSwitch(sourceChain);
 
   const isWalletConnected =
     isEvmWalletConnected || isSuiWalletConnected || isSolanaWalletConnected;

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -454,11 +454,11 @@ export function useWalletConnection() {
  * Uses Reown AppKit's network functions
  * Supports both EVM and Solana chains
  */
-export function useChainSwitch() {
+export function useChainSwitch(sourceChain: Chain) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const requiredWallet = useWeb3Store((state) =>
-    state.getWalletBySourceChain(),
+    state.getWalletByChain(sourceChain),
   );
 
   // Get the wallet connection hook for access to both wallet types
@@ -548,8 +548,6 @@ export function useChainSwitch() {
 
     try {
       setIsLoading(true);
-      const sourceChain = useWeb3Store.getState().sourceChain;
-
       return await switchToChain(sourceChain);
     } catch (error) {
       const message =
@@ -572,7 +570,7 @@ export function useChainSwitch() {
  * Ensures the correct wallet type is active for the given chain
  * Automatically switches active wallet if needed and possible
  *
- * @param targetChain The chain we want to use
+ * @param sourceChain The chain we want to use
  * @returns True if the correct wallet type is active or was switched to, false otherwise
  */
 export function ensureCorrectWalletTypeForChain(sourceChain: Chain): boolean {
@@ -699,19 +697,19 @@ export function useTokenTransfer(
 
   // Get relevant state from the web3 store
   const requiredWallet = useWeb3Store((state) =>
-    state.getWalletBySourceChain(),
+    state.getWalletByChain(options.sourceChain),
   );
 
   // Get the transaction details for slippage
-  const receiveAddress = useWeb3Store(
-    (state) => state.transactionDetails.receiveAddress,
-  );
+  const receiveAddress = options.transactionDetails.receiveAddress;
 
   // Get wallet providers and signers
   const { getEvmSigner, getSolanaSigner } = useWalletProviderAndSigner();
 
   // Add the chain switch hook
-  const { switchToSourceChain, isLoading: isChainSwitching } = useChainSwitch();
+  const { switchToSourceChain, isLoading: isChainSwitching } = useChainSwitch(
+    options.sourceChain,
+  );
 
   // Get wallet connection info for chain checking
   const { evmNetwork } = useWalletConnection();


### PR DESCRIPTION
note: branch off #127, will rebase

This PR continues the decoupling process by parameterising the `useChainSwitch` function in `walletMethods.ts`.

Previously, this hook would switch to a chain based on what was set in the `web3Store` as the `sourceChain` value, and it now takes a parameter.

The only commit relevant to this PR is https://github.com/altverseweb3/site/pull/128/commits/c841476e4740494098b3425ddd8b52bd69838267

We are now at the stage where the only direct references to the `web3Store` are regarding connected wallet states and **this is ok** - because connected wallet states, connected wallet chains, etc. is a state that will _always_ be consistent no matter where we are in the dapp.