### PR TITLE
feat: render cards and table conditionally in earn section

### DIFF
--- a/src/app/(dapp)/earn/page.tsx
+++ b/src/app/(dapp)/earn/page.tsx
@@ -5,6 +5,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 import ProtocolFilter from "@/components/ui/earning/ProtocolFilter";
 import { Input } from "@/components/ui/Input";
 import EarnTable from "@/components/ui/earning/EarnTable";
+import EarnCards from "@/components/ui/earning/EarnCards";
 import { ConnectWalletModal } from "@/components/ui/ConnectWalletModal";
 import BrandedButton from "@/components/ui/BrandedButton";
 import { Wallet } from "lucide-react";
@@ -164,12 +165,18 @@ export default function EarnPage() {
     setCurrentPage(1);
   };
 
+  const handleTabChange = (value: string) => {
+    if (value === "earn" || value === "dashboard") {
+      setActiveTab(value);
+    }
+  };
+
   // Show wallet connection requirement only for dashboard tab
   const showWalletConnectionRequired =
     !isEvmWalletConnected && activeTab === "dashboard";
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto px-2 py-8">
       <div className="max-w-6xl mx-auto">
         {/* Main Controls */}
         <div className="mb-6">
@@ -181,11 +188,7 @@ export default function EarnPage() {
               <ToggleGroup
                 type="single"
                 value={activeTab}
-                onValueChange={(value: string) => {
-                  if (value === "earn" || value === "dashboard") {
-                    setActiveTab(value);
-                  }
-                }}
+                onValueChange={handleTabChange}
                 variant="outline"
                 className="justify-start shrink-0"
               >
@@ -291,17 +294,36 @@ export default function EarnPage() {
               </div>
             </div>
           ) : (
-            <EarnTable
-              type={activeTab}
-              data={paginatedData}
-              onSort={handleSort}
-              onDetails={handleDetails}
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={handlePageChange}
-              itemsPerPage={ITEMS_PER_PAGE}
-              totalItems={currentData.length}
-            />
+            <>
+              {/* Mobile Cards View */}
+              <div className="block md:hidden">
+                <EarnCards
+                  type={activeTab}
+                  data={paginatedData}
+                  onDetails={handleDetails}
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  onPageChange={handlePageChange}
+                  itemsPerPage={ITEMS_PER_PAGE}
+                  totalItems={currentData.length}
+                />
+              </div>
+
+              {/* Desktop Table View */}
+              <div className="hidden md:block">
+                <EarnTable
+                  type={activeTab}
+                  data={paginatedData}
+                  onSort={handleSort}
+                  onDetails={handleDetails}
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  onPageChange={handlePageChange}
+                  itemsPerPage={ITEMS_PER_PAGE}
+                  totalItems={currentData.length}
+                />
+              </div>
+            </>
           )}
         </div>
 

--- a/src/components/ui/earning/EarnCard.tsx
+++ b/src/components/ui/earning/EarnCard.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import React from "react";
+import { EarnTableRow, DashboardTableRow, EarnTableType } from "@/types/earn";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/Card";
+import BrandedButton from "@/components/ui/BrandedButton";
+import Image from "next/image";
+import { chains } from "@/config/chains";
+import { formatCurrency } from "@/utils/ui/uiHelpers";
+
+interface EarnCardProps {
+  type: EarnTableType;
+  data: EarnTableRow | DashboardTableRow;
+  onDetails?: (row: EarnTableRow | DashboardTableRow) => void;
+}
+
+const EarnCard: React.FC<EarnCardProps> = ({ type, data, onDetails }) => {
+  const formatAPY = (apy: number) => {
+    if (apy === 0 || apy === null || apy === undefined) {
+      return "TBD";
+    }
+    return `${apy.toFixed(1)}%`;
+  };
+
+  const AssetIcons = ({
+    assets,
+    assetIcons,
+  }: {
+    assets: string[];
+    assetIcons: string[];
+  }) => (
+    <div className="flex -space-x-1">
+      {assets.map((asset, index) => (
+        <div
+          key={asset}
+          className="relative w-5 h-5 rounded-full border border-[#27272A] overflow-hidden"
+          title={asset}
+        >
+          <Image
+            src={assetIcons[index]}
+            alt={asset}
+            width={20}
+            height={20}
+            className="object-cover"
+          />
+        </div>
+      ))}
+    </div>
+  );
+
+  const ChainIcons = ({
+    chains: chainNames,
+    chainIcons,
+  }: {
+    chains: string[];
+    chainIcons: string[];
+  }) => (
+    <div className="flex -space-x-1">
+      {chainNames.map((chainName, index) => {
+        const chain = chains[chainName];
+        return (
+          <div
+            key={chainName}
+            className="relative w-4 h-4 rounded-full border border-[#27272A] overflow-hidden"
+            title={chainName}
+            style={{ backgroundColor: chain?.backgroundColor || "#18181B" }}
+          >
+            <Image
+              src={chainIcons[index]}
+              alt={chainName}
+              width={16}
+              height={16}
+              className="object-contain p-0.5"
+              style={{ filter: "brightness(0) saturate(100%) invert(1)" }}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <Card className="text-white border border-[#27272A] bg-[#18181B] rounded-lg shadow-none hover:bg-[#1C1C1F] transition-colors">
+      <CardHeader className="flex flex-row items-start p-4 pb-2 space-y-0">
+        <div className="w-8 h-8 rounded-full overflow-hidden flex items-center justify-center mr-3 flex-shrink-0">
+          <Image
+            src={data.protocolIcon}
+            alt={data.protocol}
+            width={32}
+            height={32}
+            className="object-contain"
+          />
+        </div>
+        <div className="flex-1 min-w-0">
+          <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
+            {data.protocol}
+          </CardTitle>
+          <CardDescription className="text-[#A1A1AA] text-xs mt-1 flex items-center gap-2">
+            <Image
+              src={data.marketVaultIcon}
+              alt={data.marketVault}
+              width={16}
+              height={16}
+              className="object-contain"
+            />
+            {data.marketVault}
+          </CardDescription>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-4 pt-2 space-y-3">
+        {/* Assets row */}
+        <div className="flex justify-between items-center">
+          <div className="text-[#A1A1AA] text-sm">assets</div>
+          <div className="flex items-center gap-2">
+            <AssetIcons assets={data.assets} assetIcons={data.assetIcons} />
+            <span className="text-[#FAFAFA] text-xs">
+              {data.assets.join(", ")}
+            </span>
+          </div>
+        </div>
+
+        {/* Chains row */}
+        <div className="flex justify-between items-center">
+          <div className="text-[#A1A1AA] text-sm">chains</div>
+          <div className="flex items-center gap-2">
+            <ChainIcons
+              chains={data.supportedChains}
+              chainIcons={data.supportedChainIcons}
+            />
+            <span className="text-[#FAFAFA] text-xs">
+              {data.supportedChains.join(", ")}
+            </span>
+          </div>
+        </div>
+
+        {/* Dashboard specific fields */}
+        {type === "dashboard" && "position" in data && (
+          <>
+            <div className="flex justify-between items-center">
+              <div className="text-[#A1A1AA] text-sm">position</div>
+              <div className="text-[#FAFAFA] text-sm font-semibold">
+                {data.position}
+              </div>
+            </div>
+            <div className="flex justify-between items-center">
+              <div className="text-[#A1A1AA] text-sm">balance</div>
+              <div className="text-right">
+                <div className="text-[#FAFAFA] text-sm font-semibold font-mono">
+                  {data.balance.toFixed(4)}
+                </div>
+                <div className="text-[#A1A1AA] text-xs font-mono">
+                  {formatCurrency(data.balanceUsd)}
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Earn specific fields */}
+        {type === "earn" && (
+          <div className="flex justify-between items-center">
+            <div className="text-[#A1A1AA] text-sm">tvl</div>
+            <div className="text-[#FAFAFA] text-sm font-semibold font-mono">
+              {formatCurrency((data as EarnTableRow).tvl)}
+            </div>
+          </div>
+        )}
+
+        {/* APY row */}
+        <div className="flex justify-between items-center">
+          <div className="text-[#A1A1AA] text-sm">apy</div>
+          <div className="text-green-500 text-sm font-semibold font-mono">
+            {formatAPY(data.apy)}
+          </div>
+        </div>
+      </CardContent>
+
+      <CardFooter className="flex justify-center p-4 pt-0">
+        <BrandedButton
+          buttonText={type === "dashboard" ? "view" : "details"}
+          onClick={() => onDetails?.(data)}
+          className="w-full text-xs py-2 h-8"
+        />
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default EarnCard;

--- a/src/components/ui/earning/EarnCards.tsx
+++ b/src/components/ui/earning/EarnCards.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React from "react";
+import { EarnTableRow, DashboardTableRow, EarnTableType } from "@/types/earn";
+import EarnCard from "./EarnCard";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+interface EarnCardsProps {
+  type: EarnTableType;
+  data: EarnTableRow[] | DashboardTableRow[];
+  onDetails?: (row: EarnTableRow | DashboardTableRow) => void;
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  itemsPerPage: number;
+  totalItems: number;
+}
+
+const EarnCards: React.FC<EarnCardsProps> = ({
+  type,
+  data,
+  onDetails,
+  currentPage,
+  totalPages,
+  onPageChange,
+  itemsPerPage,
+  totalItems,
+}) => {
+  const startItem = (currentPage - 1) * itemsPerPage + 1;
+  const endItem = Math.min(currentPage * itemsPerPage, data.length);
+
+  return (
+    <div className="w-full">
+      {/* Cards Grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 p-4">
+        {data.map((row) => (
+          <EarnCard key={row.id} type={type} data={row} onDetails={onDetails} />
+        ))}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex flex-col sm:flex-row items-center justify-between px-4 py-4 border-t border-[#27272A] gap-4">
+          <div className="text-sm text-[#A1A1AA] order-2 sm:order-1">
+            Showing {startItem}-{endItem} of {totalItems} results
+          </div>
+          <div className="flex items-center gap-2 order-1 sm:order-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+              className="border-[#27272A] text-[#FAFAFA] hover:bg-[#27272A]"
+            >
+              Previous
+            </Button>
+            <div className="flex items-center gap-1">
+              {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+                // Show current page and 2 pages on each side, or first/last 5
+                let page;
+                if (totalPages <= 5) {
+                  page = i + 1;
+                } else if (currentPage <= 3) {
+                  page = i + 1;
+                } else if (currentPage >= totalPages - 2) {
+                  page = totalPages - 4 + i;
+                } else {
+                  page = currentPage - 2 + i;
+                }
+
+                return (
+                  <Button
+                    key={page}
+                    variant={page === currentPage ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => onPageChange(page)}
+                    className={cn(
+                      "w-8 h-8 p-0",
+                      page === currentPage
+                        ? "bg-amber-500/25 text-amber-500 border-[#61410B] hover:bg-amber-500/50 hover:text-amber-400"
+                        : "border-[#27272A] text-[#FAFAFA] hover:bg-[#27272A]",
+                    )}
+                  >
+                    {page}
+                  </Button>
+                );
+              })}
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              className="border-[#27272A] text-[#FAFAFA] hover:bg-[#27272A]"
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EarnCards;

--- a/src/components/ui/earning/EtherFiModal.tsx
+++ b/src/components/ui/earning/EtherFiModal.tsx
@@ -19,6 +19,7 @@ import { useIsWalletTypeConnected } from "@/store/web3Store";
 import { WalletType } from "@/types/web3";
 import { useChainSwitch } from "@/utils/swap/walletMethods";
 import { getChainById } from "@/config/chains";
+import { formatCurrency } from "@/utils/ui/uiHelpers";
 
 interface EtherFiModalProps {
   isOpen: boolean;
@@ -59,14 +60,6 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
 
   const handleWalletConnectSuccess = () => {
     setIsDepositModalOpen(true);
-  };
-
-  const formatCurrency = (value: number) => {
-    if (value === 0) return "$0";
-    if (value >= 1e9) return `$${(value / 1e9).toFixed(2)}B`;
-    if (value >= 1e6) return `$${(value / 1e6).toFixed(2)}M`;
-    if (value >= 1e3) return `$${(value / 1e3).toFixed(2)}K`;
-    return `$${value.toFixed(2)}`;
   };
 
   const isDashboardRow = (

--- a/src/utils/ui/uiHelpers.ts
+++ b/src/utils/ui/uiHelpers.ts
@@ -33,3 +33,13 @@ export function getColorFilter(hexColor: string): string {
 
   return `brightness(0) saturate(100%) invert(1) hue-rotate(${hue}deg) saturate(${saturation}%) brightness(${brightness}%)`;
 }
+
+export function formatCurrency(value: number): string {
+  if (value === 0) return "$0";
+  if (value >= 1e15) return `$${(value / 1e15).toFixed(2)}Q`;
+  if (value >= 1e12) return `$${(value / 1e12).toFixed(2)}T`;
+  if (value >= 1e9) return `$${(value / 1e9).toFixed(2)}B`;
+  if (value >= 1e6) return `$${(value / 1e6).toFixed(2)}M`;
+  if (value >= 1e3) return `$${(value / 1e3).toFixed(2)}K`;
+  return `$${value.toFixed(2)}`;
+}


### PR DESCRIPTION
The purpose of this PR is to decouple the logic passed into UI with `page.tsx` to conditionally render either a set of scrollable cards OR a table based on viewport of device.

> [!NOTE]
> cards UI & table/scroll area responsiveness is in progress.

---

mobile viewport:

![image](https://github.com/user-attachments/assets/88a8e7fd-1fc4-4308-8bc6-8548d8058ea8)

tablet viewport:

![image](https://github.com/user-attachments/assets/1b6adc3e-da94-44e7-a58d-c9351cdb4066)
