### PR TITLE
feat: added swap integration type

### DIFF
--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -387,3 +387,15 @@ export interface SwapTrackingOptions {
   onComplete?: (status: SwapStatus) => void;
   onError?: (error: Error) => void;
 }
+
+export interface SwapIntegration {
+  sourceChain: Chain;
+  destinationChain: Chain;
+  sourceToken: Token | null;
+  destinationToken: Token | null;
+  transactionDetails: {
+    slippage: "auto" | string;
+    receiveAddress: string | null;
+    gasDrop: number;
+  };
+}


### PR DESCRIPTION
This PR adds a new interface type which will be used to differentiate between the persisted values for various swap integrations.

This will be included as a Record set in the `web3Store` in future PRs, so each swap integration is able to maintain and persist its own set of values for the swap integration.