### PR TITLE
feat: store version automation

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,12 @@
+#!/bin/bash
+set -eou pipefail
+
 npx prettier --write "**/*.{ts,tsx,js,jsx,json}" && git add -A
 npm run lint
+
+if git diff --staged --name-only | grep -q "src/store/web3Store.ts"; then
+  current_version=$(grep -o 'STORE_VERSION = [0-9]\+' src/store/storeVersion.ts | grep -o '[0-9]\+')
+  new_version=$((current_version + 1))
+  sed -i "s/STORE_VERSION = [0-9]\+/STORE_VERSION = $new_version/" src/store/storeVersion.ts
+  git add src/store/storeVersion.ts
+fi

--- a/src/store/storeVersion.ts
+++ b/src/store/storeVersion.ts
@@ -1,0 +1,1 @@
+export const STORE_VERSION = 3;

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -20,8 +20,7 @@ import {
 } from "@/utils/tokens/tokenMethods";
 import { chains } from "@/config/chains";
 import { TokenPrice } from "@/types/web3";
-
-const STORE_VERSION = 2;
+import { STORE_VERSION } from "@/store/storeVersion";
 
 const useWeb3Store = create<Web3StoreState>()(
   persist(


### PR DESCRIPTION
This functionality checks if the web store file has been updated (and as a consequence so has the zustand schema) through a `git diff` as part of the `pre-commit` hook, and if it has, the `STORE_VERSION`, which now lives in a separate file, is incremented and added to the commit as well.

`STORE_VERSION` updates are now automated. This has been tested as `STORE_VERSION` has been updated to `3` automatically on this PR's commit.