### PR TITLE
feat: integrated new active swap state into swap page

### DIFF
--- a/src/app/(dapp)/swap/page.tsx
+++ b/src/app/(dapp)/swap/page.tsx
@@ -2,11 +2,18 @@
 import React from "react";
 import { useTokenTransfer } from "@/utils/swap/walletMethods";
 import { TokenTransfer } from "@/components/ui/TokenTransfer";
-import useWeb3Store from "@/store/web3Store";
+import {
+  useSourceToken,
+  useDestinationToken,
+  useSourceChain,
+  useDestinationChain,
+  useTransactionDetails,
+  useGetWalletBySourceChain,
+} from "@/store/web3Store";
 
 const SwapComponent: React.FC = () => {
-  const sourceToken = useWeb3Store((state) => state.sourceToken);
-  const destinationToken = useWeb3Store((state) => state.destinationToken);
+  const sourceToken = useSourceToken();
+  const destinationToken = useDestinationToken();
 
   // Use the shared hook with tracking enabled
   const {
@@ -23,11 +30,11 @@ const SwapComponent: React.FC = () => {
     swapAmounts,
   } = useTokenTransfer({
     type: "swap",
-    sourceChain: useWeb3Store((state) => state.sourceChain),
-    destinationChain: useWeb3Store((state) => state.destinationChain),
-    sourceToken: useWeb3Store((state) => state.sourceToken),
-    destinationToken: useWeb3Store((state) => state.destinationToken),
-    transactionDetails: useWeb3Store((state) => state.transactionDetails),
+    sourceChain: useSourceChain(),
+    destinationChain: useDestinationChain(),
+    sourceToken: sourceToken,
+    destinationToken: destinationToken,
+    transactionDetails: useTransactionDetails(), // Use the shared transaction details
     enableTracking: true, // Enable automatic tracking
     onSuccess: (amount, sourceToken, destinationToken) => {
       // This now fires when the swap actually completes (after tracking)
@@ -42,16 +49,12 @@ const SwapComponent: React.FC = () => {
     },
   });
 
-  const requiredWallet = useWeb3Store((state) =>
-    state.getWalletBySourceChain(),
-  );
-
   return (
     <TokenTransfer
       amount={amount}
       onAmountChange={handleAmountChange}
       isButtonDisabled={isButtonDisabled}
-      hasActiveWallet={!!requiredWallet}
+      hasActiveWallet={!!useGetWalletBySourceChain()}
       onTransfer={handleTransfer}
       swapAmounts={swapAmounts}
       transferType="swap"

--- a/src/components/meta/TokensInitializer.tsx
+++ b/src/components/meta/TokensInitializer.tsx
@@ -3,7 +3,12 @@
 
 import { useEffect, useState } from "react";
 import { useIdleTimer } from "react-idle-timer";
-import useWeb3Store from "@/store/web3Store";
+import useWeb3Store, {
+  useSourceChain,
+  useDestinationChain,
+  useSourceToken,
+  useDestinationToken,
+} from "@/store/web3Store";
 import { getPricesAndBalances } from "@/utils/tokens/tokenApiMethods";
 
 /**
@@ -14,13 +19,13 @@ const TokenInitializer: React.FC = () => {
   // Use separate selectors to avoid object reference changes
   const tokenCount = useWeb3Store((state) => state.allTokensList.length);
   const connectedWallets = useWeb3Store((state) => state.connectedWallets);
-  const sourceChain = useWeb3Store((state) => state.sourceChain);
-  const destinationChain = useWeb3Store((state) => state.destinationChain);
+  const sourceChain = useSourceChain();
+  const destinationChain = useDestinationChain();
   const requiredWallet = useWeb3Store((state) =>
     state.getWalletBySourceChain(),
   );
-  const destinationToken = useWeb3Store((state) => state.destinationToken);
-  const sourceToken = useWeb3Store((state) => state.sourceToken);
+  const destinationToken = useDestinationToken();
+  const sourceToken = useSourceToken();
 
   // Track whether the user is active or idle
   const [isIdle, setIsIdle] = useState(false);
@@ -40,14 +45,14 @@ const TokenInitializer: React.FC = () => {
       const fetchData = () => {
         if (!isIdle) {
           console.log("Fetching token data - user is active");
-          getPricesAndBalances();
+          getPricesAndBalances(sourceChain, destinationChain);
         } else {
           console.log("Skipping token data fetch - user is idle");
         }
       };
 
       // Initial fetch when dependencies change (regardless of idle state)
-      getPricesAndBalances();
+      getPricesAndBalances(sourceChain, destinationChain);
 
       // Set up interval to run every 10 seconds
       const intervalId = setInterval(fetchData, 10000); // 10 seconds

--- a/src/components/ui/AssetBox.tsx
+++ b/src/components/ui/AssetBox.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from "react";
 import { SelectChainButton } from "@/components/ui/SelectChainButton";
 import { Chain } from "@/types/web3";
 import useUIStore from "@/store/uiStore";
-import useWeb3Store from "@/store/web3Store";
+import { useSourceToken, useDestinationToken } from "@/store/web3Store";
 
 interface AssetBoxProps {
   title: string;
@@ -33,8 +33,8 @@ export function AssetBox({
   const setDestinationTokenSelectOpen = useUIStore(
     (state) => state.setDestinationTokenSelectOpen,
   );
-  const sourceToken = useWeb3Store((state) => state.sourceToken);
-  const destinationToken = useWeb3Store((state) => state.destinationToken);
+  const sourceToken = useSourceToken();
+  const destinationToken = useDestinationToken();
 
   const setIsOpen =
     boxType === "source"

--- a/src/components/ui/SelectChainButton.tsx
+++ b/src/components/ui/SelectChainButton.tsx
@@ -9,7 +9,10 @@ import {
 } from "@/components/ui/DropdownMenu";
 import { chainList, defaultSourceChain } from "@/config/chains";
 import { Chain } from "@/types/web3";
-import useWeb3Store from "@/store/web3Store";
+import useWeb3Store, {
+  useSourceChain,
+  useDestinationChain,
+} from "@/store/web3Store";
 
 interface SelectChainButtonProps {
   selectedChain?: Chain;
@@ -27,8 +30,8 @@ export const SelectChainButton: React.FC<SelectChainButtonProps> = ({
   storeType,
 }) => {
   // Get store values and setters if storeType is provided
-  const sourceChain = useWeb3Store((state) => state.sourceChain);
-  const destinationChain = useWeb3Store((state) => state.destinationChain);
+  const sourceChain = useSourceChain();
+  const destinationChain = useDestinationChain();
   const setSourceChain = useWeb3Store((state) => state.setSourceChain);
   const setDestinationChain = useWeb3Store(
     (state) => state.setDestinationChain,

--- a/src/components/ui/SwapInterface.tsx
+++ b/src/components/ui/SwapInterface.tsx
@@ -7,7 +7,7 @@ import {
   useWalletConnection,
   ensureCorrectWalletTypeForChain,
 } from "@/utils/swap/walletMethods";
-import useWeb3Store from "@/store/web3Store";
+import useWeb3Store, { useSourceChain } from "@/store/web3Store";
 import { toast } from "sonner";
 import { AvailableIconName } from "@/types/ui";
 import { WalletType } from "@/types/web3";
@@ -46,7 +46,7 @@ export function SwapInterface({
   detailsOpen,
   onDetailsToggle,
 }: SwapInterfaceProps) {
-  const sourceChain = useWeb3Store((state) => state.sourceChain);
+  const sourceChain = useSourceChain();
 
   const {
     isLoading: isSwitchingChain,

--- a/src/components/ui/TokenInputGroup.tsx
+++ b/src/components/ui/TokenInputGroup.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { SelectTokenButton } from "@/components/ui/SelectTokenButton";
 import { TokenAmountInput } from "@/components/ui/TokenAmountInput";
 import useUIStore from "@/store/uiStore";
-import useWeb3Store from "@/store/web3Store";
+import { useSourceToken, useDestinationToken } from "@/store/web3Store";
 
 interface TokenInputGroupProps {
   variant: "source" | "destination";
@@ -31,8 +31,8 @@ export function TokenInputGroup({
   const setDestinationTokenSelectOpen = useUIStore(
     (state) => state.setDestinationTokenSelectOpen,
   );
-  const sourceToken = useWeb3Store((state) => state.sourceToken);
-  const destinationToken = useWeb3Store((state) => state.destinationToken);
+  const sourceToken = useSourceToken();
+  const destinationToken = useDestinationToken();
 
   const setIsOpen =
     variant === "source"

--- a/src/components/ui/TokenTransfer.tsx
+++ b/src/components/ui/TokenTransfer.tsx
@@ -8,7 +8,10 @@ import { ConnectWalletModal } from "@/components/ui/ConnectWalletModal";
 import { BrandedButton } from "@/components/ui/BrandedButton";
 import { AvailableIconName } from "@/types/ui";
 import { swapChains } from "@/utils/chains/chainMethods";
-import useWeb3Store from "@/store/web3Store";
+import useWeb3Store, {
+  useSourceToken,
+  useDestinationToken,
+} from "@/store/web3Store";
 import { Token } from "@/types/web3";
 
 interface TokenTransferProps {
@@ -66,8 +69,8 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
   const tokensByCompositeKey = useWeb3Store(
     (state) => state.tokensByCompositeKey,
   );
-  const destinationToken = useWeb3Store((state) => state.destinationToken);
-  const sourceToken = useWeb3Store((state) => state.sourceToken);
+  const destinationToken = useDestinationToken();
+  const sourceToken = useSourceToken();
 
   useEffect(() => {
     const shouldBeEnabled =

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -31,12 +31,18 @@ import {
 import { EtherFiVault, DEPOSIT_ASSETS } from "@/config/etherFi";
 import { getTokenAllowance } from "@/utils/etherFi/fetch";
 import { useEtherFiInteract } from "@/utils/etherFi/interact";
-import { useIsWalletTypeConnected } from "@/store/web3Store";
 import { useChainSwitch, useTokenTransfer } from "@/utils/swap/walletMethods";
 import { WalletType, Token, SwapStatus } from "@/types/web3";
 import { chainList, getChainById, chains } from "@/config/chains";
 import { useAppKit } from "@reown/appkit/react";
-import useWeb3Store from "@/store/web3Store";
+import useWeb3Store, {
+  useSourceChain,
+  useDestinationChain,
+  useSourceToken,
+  useDestinationToken,
+  useTransactionDetails,
+  useIsWalletTypeConnected,
+} from "@/store/web3Store";
 import { ConnectButton } from "@suiet/wallet-kit";
 import useVaultDepositStore, {
   useActiveVaultDepositProcess,
@@ -58,11 +64,11 @@ const DepositModal: React.FC<DepositModalProps> = ({
   vault,
   apy,
 }) => {
-  const sourceToken = useWeb3Store((state) => state.sourceToken);
-  const destinationToken = useWeb3Store((state) => state.destinationToken);
-  const sourceChain = useWeb3Store((state) => state.sourceChain);
-  const destinationChain = useWeb3Store((state) => state.destinationChain);
-  const transactionDetails = useWeb3Store((state) => state.transactionDetails);
+  const sourceToken = useSourceToken();
+  const destinationToken = useDestinationToken();
+  const sourceChain = useSourceChain();
+  const destinationChain = useDestinationChain();
+  const transactionDetails = useTransactionDetails();
 
   // Form state
   const [selectedSwapChain, setSelectedSwapChain] = useState<string>("");

--- a/src/utils/tokens/tokenApiMethods.ts
+++ b/src/utils/tokens/tokenApiMethods.ts
@@ -12,6 +12,7 @@ import {
   TokenBalance,
 } from "@/types/web3";
 import { SuiBalanceResult } from "@/api/altverse";
+import { Chain } from "@/types/web3";
 
 /**
  * Formats a balance from hex or large number string to a human-readable token amount
@@ -55,7 +56,10 @@ function formatTokenBalance(balanceStr: string, decimals: number): string {
   }
 }
 
-export async function getPricesAndBalances(): Promise<boolean> {
+export async function getPricesAndBalances(
+  sourceChain: Chain,
+  destinationChain: Chain,
+): Promise<boolean> {
   const store = useWeb3Store.getState();
   const sourceWallet = store.getWalletBySourceChain();
   const destinationWallet = store.getWalletByDestinationChain();
@@ -65,12 +69,12 @@ export async function getPricesAndBalances(): Promise<boolean> {
   try {
     const [sourceResult, destinationResult] = await Promise.allSettled([
       getPricesAndBalancesForChain(
-        store.sourceChain.chainId,
+        sourceChain.chainId,
         sourceWallet?.address,
         "source",
       ),
       getPricesAndBalancesForChain(
-        store.destinationChain.chainId,
+        destinationChain.chainId,
         destinationWallet?.address,
         "destination",
       ),


### PR DESCRIPTION
This PR integrates the new handling of active swap state into all of our core components, including the swap page.

Most of the changes involve correctly fetching the active swap state properties such as the `sourceChain`, `destinationChain`, `sourceToken`, `destinationToken` and `transactionDetails` from the `web3Store` helper functions (which really we always should have done as opposed to calling the state directly...), and these functions now return only the value of the active swap state as opposed to one singular value for the entire dApp.

