### PR TITLE
feat: set active swap section

### DIFF
--- a/src/app/(dapp)/earn/page.tsx
+++ b/src/app/(dapp)/earn/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 import ProtocolFilter from "@/components/ui/earning/ProtocolFilter";
 import { Input } from "@/components/ui/Input";
@@ -11,7 +11,10 @@ import BrandedButton from "@/components/ui/BrandedButton";
 import { Wallet } from "lucide-react";
 import { chainList } from "@/config/chains";
 import { WalletType } from "@/types/web3";
-import { useIsWalletTypeConnected } from "@/store/web3Store";
+import {
+  useIsWalletTypeConnected,
+  useSetActiveSwapSection,
+} from "@/store/web3Store";
 import { useEtherFiEarnData, filterEarnData, ProtocolModal } from "./etherFi";
 import {
   EarnTableRow,
@@ -66,7 +69,13 @@ export default function EarnPage() {
   >(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  const setActiveSwapSection = useSetActiveSwapSection();
+
   const isEvmWalletConnected = useIsWalletTypeConnected(WalletType.REOWN_EVM);
+
+  useEffect(() => {
+    setActiveSwapSection("earn");
+  }, [setActiveSwapSection]);
 
   // Use the etherFi hook for data fetching - always fetch earn data, only require wallet for dashboard
   const {

--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -4,10 +4,16 @@ import BorrowComponent from "@/components/ui/lending/BorrowComponent";
 import PoweredByAave from "@/components/ui/lending/PoweredByAave";
 import SupplyBorrowMetricsHeaders from "@/components/ui/lending/SupplyBorrowMetricsHeaders";
 import SupplyComponent from "@/components/ui/lending/SupplyComponent";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { useSetActiveSwapSection } from "@/store/web3Store";
 
 const BorrowLendComponent: React.FC = () => {
   const [activeTab, setActiveTab] = useState("borrow");
+  const setActiveSwapSection = useSetActiveSwapSection();
+
+  useEffect(() => {
+    setActiveSwapSection("lend");
+  }, [setActiveSwapSection]);
 
   return (
     <div className="flex h-full w-full items-start justify-center sm:pt-[6vh] pt-[2vh] min-h-[500px]">

--- a/src/app/(dapp)/swap/page.tsx
+++ b/src/app/(dapp)/swap/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useEffect } from "react";
 import { useTokenTransfer } from "@/utils/swap/walletMethods";
 import { TokenTransfer } from "@/components/ui/TokenTransfer";
 import {
@@ -9,11 +9,13 @@ import {
   useDestinationChain,
   useTransactionDetails,
   useGetWalletBySourceChain,
+  useSetActiveSwapSection,
 } from "@/store/web3Store";
 
 const SwapComponent: React.FC = () => {
   const sourceToken = useSourceToken();
   const destinationToken = useDestinationToken();
+  const setActiveSwapSection = useSetActiveSwapSection();
 
   // Use the shared hook with tracking enabled
   const {
@@ -48,6 +50,10 @@ const SwapComponent: React.FC = () => {
       console.log("Swap initiated with ID:", swapId);
     },
   });
+
+  useEffect(() => {
+    setActiveSwapSection("swap");
+  }, [setActiveSwapSection]);
 
   return (
     <TokenTransfer

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -86,6 +86,11 @@ const useWeb3Store = create<Web3StoreState>()(
         }));
       },
 
+      setActiveSwapSection: (sectionKey: SectionKey) => {
+        console.log(`Setting active swap section to: ${sectionKey}`);
+        set({ activeSwapSection: sectionKey });
+      },
+
       setSourceChain: (chain: Chain) => {
         const key = get().activeSwapSection;
         set((state) => {
@@ -966,6 +971,10 @@ export const useSetReceiveAddress = () => {
 
 export const useSetGasDrop = () => {
   return useWeb3Store((state) => state.setGasDrop);
+};
+
+export const useSetActiveSwapSection = () => {
+  return useWeb3Store((state) => state.setActiveSwapSection);
 };
 
 export default useWeb3Store;

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -121,6 +121,7 @@ export interface Web3StoreState {
   // New integration-specific actions
   getSwapStateForSection: () => SwapStateForSection;
   initializeSwapStateForSection: () => void;
+  setActiveSwapSection: (sectionKey: SectionKey) => void;
   setSourceChain: (chain: Chain) => void;
   setDestinationChain: (chain: Chain) => void;
   swapChains: () => void;


### PR DESCRIPTION
note: branch off #140, will rebase

This PR adds functionality to actually set the `activeSwapSection`. This is done through a `useEffect` hook at the root `page.tsx` for each section. This is safe and does not cause an infinite loop as the `web3Store` hook calls are stable and not recreated on each render.

The only commit relevant to this PR is f24c5d78bb1c5191f7bc6acf51e7701cc2644428

