### PR TITLE
chore: ui enhncements (& temp modal mock test and button redesign)

### DIFF
--- a/src/app/(dapp)/earn/page.tsx
+++ b/src/app/(dapp)/earn/page.tsx
@@ -27,8 +27,8 @@ const ITEMS_PER_PAGE = 10;
 
 const availableProtocols: ProtocolOption[] = [
   {
-    id: "Ether.fi",
-    name: "Ether.fi",
+    id: "ether.fi",
+    name: "ether.fi",
     icon: "/images/etherFi/vaults/ethfi.svg",
     checked: true,
     disabled: false,

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -9,6 +9,7 @@ import {
   CheckCircle,
   AlertCircle,
   Clock,
+  ExternalLink,
 } from "lucide-react";
 import {
   Dialog,
@@ -1406,7 +1407,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
             <Info className="h-4 w-4 text-green-500" />
             <span className="text-sm text-[#FAFAFA]">
               Current APY:{" "}
-              <span className="text-green-500 font-semibold">
+              <span className="text-green-500 font-semibold font-mono">
                 {apy && apy > 0 ? `${apy.toFixed(1)}%` : "TBD"}
               </span>
             </span>
@@ -1475,8 +1476,8 @@ const DepositModal: React.FC<DepositModalProps> = ({
               variant="outline"
               className="w-full border-[#27272A] text-[#FAFAFA] hover:bg-[#27272A]"
             >
-              <ArrowRight className="h-4 w-4 mr-2" />
-              Withdraw on EtherFi
+              <ExternalLink className="h-4 w-4 mr-2" />
+              Withdraw on etherfi
             </Button>
 
             <p className="text-xs text-[#71717A] text-center">

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -10,6 +10,7 @@ import {
   AlertCircle,
   Clock,
   ExternalLink,
+  Wallet,
 } from "lucide-react";
 import {
   Dialog,
@@ -1049,7 +1050,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
               {/* Asset/Chain Selection */}
               <div>
                 <label className="text-sm font-medium text-[#A1A1AA] mb-3 block">
-                  Select Asset
+                  select asset
                 </label>
                 <Select
                   value={
@@ -1189,7 +1190,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
 
                     <SelectGroup>
                       <SelectLabel className="text-[#A1A1AA] px-2 py-1.5 text-xs font-medium">
-                        Cross-chain Swap from
+                        cross-chain swap from
                       </SelectLabel>
                       {chainList
                         .filter((chain) => {
@@ -1258,7 +1259,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
               <div>
                 <div className="flex items-center justify-between mb-3">
                   <label className="text-sm font-medium text-[#A1A1AA]">
-                    Amount
+                    amount
                   </label>
                   <div className="flex items-center gap-2">
                     {/* Balance display - always show when asset is selected */}
@@ -1266,12 +1267,14 @@ const DepositModal: React.FC<DepositModalProps> = ({
                       <div className="text-xs text-amber-500">
                         {selectedSwapToken && (
                           <span>
-                            Balance:{" "}
-                            {selectedSwapToken.userBalance
-                              ? parseFloat(
-                                  selectedSwapToken.userBalance,
-                                ).toFixed(6)
-                              : "0.00"}{" "}
+                            balance:{" "}
+                            <span className="font-mono">
+                              {selectedSwapToken.userBalance
+                                ? parseFloat(
+                                    selectedSwapToken.userBalance,
+                                  ).toFixed(6)
+                                : "0.00"}
+                            </span>{" "}
                             {selectedSwapToken.ticker}
                           </span>
                         )}
@@ -1349,7 +1352,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                     onChange={(e) => {
                       handleSwapAmountChange(e);
                     }}
-                    className="pr-20 bg-[#27272A] border-[#3F3F46] text-[#FAFAFA] placeholder:text-[#71717A]"
+                    className="pr-20 bg-[#27272A] border-[#3F3F46] text-[#FAFAFA] placeholder:text-[#71717A] font-mono"
                   />
                   <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
                     {selectedSwapToken && (
@@ -1381,7 +1384,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                       Will swap {selectedSwapToken.ticker} →{" "}
                       {vault.supportedAssets.deposit[0]}
                       {receiveAmount && (
-                        <span className="text-green-500 ml-2">
+                        <span className="text-green-500 font-mono ml-2">
                           ≈ {receiveAmount} {vault.supportedAssets.deposit[0]}
                         </span>
                       )}
@@ -1446,7 +1449,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                       parseFloat(receiveAmount) <= 0
                     : !isFormValid
                 }
-                className="w-full bg-amber-500 text-black hover:bg-amber-600 disabled:opacity-50"
+                className="w-full bg-amber-500/25 hover:bg-amber-500/50 hover:text-amber-400 text-amber-500 border-[#61410B] border rounded-lg py-3 font-semibold disabled:opacity-50"
               >
                 {isLoadingQuote ? (
                   <div className="flex items-center gap-2">
@@ -1462,8 +1465,8 @@ const DepositModal: React.FC<DepositModalProps> = ({
                       </>
                     ) : (
                       <>
-                        direct deposit {selectedSwapToken?.ticker || ""}
-                        <ArrowRight className="h-4 w-4 ml-2" />
+                        <Wallet className="h-4 w-4 mr-1" />
+                        confirm deposit
                       </>
                     )}
                   </>
@@ -1477,7 +1480,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
               className="w-full border-[#27272A] text-[#FAFAFA] hover:bg-[#27272A]"
             >
               <ExternalLink className="h-4 w-4 mr-2" />
-              Withdraw on etherfi
+              withdraw on ether.fi
             </Button>
 
             <p className="text-xs text-[#71717A] text-center">

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -1020,7 +1020,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                 )}
                 <StepIndicator
                   step={2}
-                  title="Vault Deposit"
+                  title="vault deposit"
                   description={`${activeProcess.targetAsset} → ${vault.name}`}
                 />
               </div>
@@ -1163,7 +1163,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                   <SelectContent className="bg-[#27272A] border-[#3F3F46]">
                     <SelectGroup>
                       <SelectLabel className="text-[#A1A1AA] px-2 py-1.5 text-xs font-medium">
-                        Direct Deposit (Ethereum)
+                        direct deposit (ethereum)
                       </SelectLabel>
                       {vault.supportedAssets.deposit.map((asset) => (
                         <SelectItem
@@ -1406,7 +1406,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
           <div className="flex items-center gap-2 p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
             <Info className="h-4 w-4 text-green-500" />
             <span className="text-sm text-[#FAFAFA]">
-              Current APY:{" "}
+              current apy:{" "}
               <span className="text-green-500 font-semibold font-mono">
                 {apy && apy > 0 ? `${apy.toFixed(1)}%` : "TBD"}
               </span>
@@ -1457,12 +1457,12 @@ const DepositModal: React.FC<DepositModalProps> = ({
                   <>
                     {!isDirectDeposit ? (
                       <>
-                        Start Cross-chain Deposit
+                        start cross-chain deposit
                         <ArrowRight className="h-4 w-4 ml-2" />
                       </>
                     ) : (
                       <>
-                        Direct Deposit {selectedSwapToken?.ticker || ""}
+                        direct deposit {selectedSwapToken?.ticker || ""}
                         <ArrowRight className="h-4 w-4 ml-2" />
                       </>
                     )}

--- a/src/components/ui/earning/EtherFiModal.tsx
+++ b/src/components/ui/earning/EtherFiModal.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { useState } from "react";
 import Image from "next/image";
-import { ExternalLink, Wallet } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -72,67 +72,58 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[600px] bg-[#18181B] border-[#27272A]">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-3 text-[#FAFAFA]">
+      <DialogContent className="sm:max-w-[460px] bg-[#18181B] border-[#27272A]">
+        <DialogHeader className="pb-4">
+          <div className="flex items-center gap-3">
             <Image
               src={data.marketVaultIcon}
               alt={data.marketVault}
-              width={32}
-              height={32}
+              width={40}
+              height={40}
               className="rounded-full"
             />
-            {data.marketVault}
-          </DialogTitle>
-        </DialogHeader>
-
-        <div className="space-y-6">
-          {/* Description */}
-          <div>
-            <h3 className="text-sm font-medium text-[#A1A1AA] mb-2">
-              Description
-            </h3>
-            <p className="text-[#FAFAFA] text-sm leading-relaxed">
-              {vault.description}
-            </p>
-          </div>
-
-          {/* Vault Info */}
-          <div className="grid grid-cols-2 gap-4">
             <div>
-              <h3 className="text-sm font-medium text-[#A1A1AA] mb-2">
-                Protocol
-              </h3>
-              <div className="flex items-center gap-2">
+              <DialogTitle className="text-[#FAFAFA] text-lg font-semibold">
+                {data.marketVault}
+              </DialogTitle>
+              <div className="flex items-center gap-1">
                 <Image
                   src={data.protocolIcon}
                   alt={data.protocol}
-                  width={20}
-                  height={20}
+                  width={12}
+                  height={12}
+                  className="object-contain"
                 />
-                <span className="text-[#FAFAFA]">{data.protocol}</span>
+                <span className="text-sm text-[#A1A1AA]">{data.protocol}</span>
               </div>
             </div>
-            <div>
-              <h3 className="text-sm font-medium text-[#A1A1AA] mb-2">Type</h3>
-              <span className="text-[#FAFAFA]">{vault.type}</span>
-            </div>
           </div>
+        </DialogHeader>
 
-          {/* Performance */}
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <h3 className="text-sm font-medium text-[#A1A1AA] mb-2">APY</h3>
-              <span className="text-green-500 font-semibold text-lg">
-                {data.apy.toFixed(1)}%
-              </span>
-            </div>
-            {!isDashboardRow(data) && (
-              <div>
-                <h3 className="text-sm font-medium text-[#A1A1AA] mb-2">TVL</h3>
-                <span className="text-[#FAFAFA] font-semibold text-lg">
-                  {formatCurrency(data.tvl)}
+        <div className="space-y-4">
+          {/* APY and TVL Cards */}
+          <div className="grid grid-cols-2 gap-2">
+            <div className="bg-[#18181B] border border-[#27272A] rounded-lg p-3">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-semibold text-[#A1A1AA] uppercase tracking-wider">
+                  apy
                 </span>
+                <span className="text-lg font-semibold text-green-400">
+                  {data.apy === 0 ? "TBD" : `${data.apy.toFixed(1)}%`}
+                </span>
+              </div>
+            </div>
+
+            {!isDashboardRow(data) && (
+              <div className="bg-[#18181B] border border-[#27272A] rounded-lg p-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-semibold text-[#A1A1AA] uppercase tracking-wider">
+                    tvl
+                  </span>
+                  <span className="text-lg font-semibold text-[#FAFAFA]">
+                    {formatCurrency(data.tvl)}
+                  </span>
+                </div>
               </div>
             )}
           </div>
@@ -141,17 +132,17 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
           {isDashboardRow(data) && (
             <div className="border border-[#27272A] rounded-lg p-4">
               <h3 className="text-sm font-medium text-[#A1A1AA] mb-3">
-                Your Position
+                your position
               </h3>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <span className="text-sm text-[#A1A1AA]">Balance</span>
+                  <span className="text-sm text-[#A1A1AA]">balance</span>
                   <div className="text-[#FAFAFA] font-medium">
                     {data.balance.toFixed(4)} {data.position}
                   </div>
                 </div>
                 <div>
-                  <span className="text-sm text-[#A1A1AA]">USD Value</span>
+                  <span className="text-sm text-[#A1A1AA]">usd value</span>
                   <div className="text-[#FAFAFA] font-medium">
                     {formatCurrency(data.balanceUsd)}
                   </div>
@@ -162,78 +153,73 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
 
           {/* Supported Assets */}
           <div>
-            <h3 className="text-sm font-medium text-[#A1A1AA] mb-3">
-              Supported Assets
+            <h3 className="text-[#A1A1AA] text-sm font-medium mb-3 uppercase tracking-wider">
+              supported assets
             </h3>
-            <div className="flex flex-wrap gap-2">
-              {data.assets.map((asset, index) => (
+            <div className="flex gap-3">
+              {data.assets.slice(0, 3).map((asset, index) => (
                 <div
                   key={asset}
-                  className="flex items-center gap-2 bg-[#27272A] rounded-full px-3 py-1"
+                  className="flex items-center gap-2 bg-[#27272A] rounded-full px-3 py-2"
                 >
                   <Image
                     src={data.assetIcons[index]}
                     alt={asset}
-                    width={16}
-                    height={16}
+                    width={20}
+                    height={20}
                     className="rounded-full"
                   />
-                  <span className="text-[#FAFAFA] text-sm">{asset}</span>
+                  <span className="text-[#FAFAFA] text-sm font-medium">
+                    {asset}
+                  </span>
                 </div>
               ))}
             </div>
           </div>
 
-          {/* Receive Token */}
+          {/* You Will Receive */}
           <div>
-            <h3 className="text-sm font-medium text-[#A1A1AA] mb-3">
-              You Will Receive
+            <h3 className="text-[#A1A1AA] text-sm font-medium mb-3 uppercase tracking-wider">
+              you will receive
             </h3>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-3 bg-[#27272A] rounded-lg px-4 py-3">
               <Image
                 src={
                   vault.supportedAssets.receive.imagePath ||
                   "/images/etherFi/liquid.svg"
                 }
                 alt={vault.supportedAssets.receive.symbol}
-                width={20}
-                height={20}
+                width={24}
+                height={24}
                 className="rounded-full"
               />
-              <span className="text-[#FAFAFA]">
+              <span className="text-[#FAFAFA] font-semibold text-base">
                 {vault.supportedAssets.receive.symbol}
               </span>
             </div>
           </div>
 
-          {/* Etherscan Link */}
-          <div className="border-t border-[#27272A] pt-4">
-            <Button
-              variant="outline"
-              onClick={() => window.open(vault.links.explorer, "_blank")}
-              className="w-full border-[#27272A] text-[#FAFAFA] hover:bg-[#27272A]"
-            >
-              <ExternalLink className="h-4 w-4 mr-2" />
-              View on Etherscan
-            </Button>
+          {/* Description */}
+          <div className="pt-2">
+            <p className="text-[#A1A1AA] text-sm leading-relaxed">
+              {vault.description}
+            </p>
           </div>
 
-          {/* Main Actions */}
-          <div className="flex gap-3">
+          {/* Action Buttons */}
+          <div className="grid grid-cols-2 gap-3 pt-2">
             {isWalletConnected ? (
               <Button
                 onClick={handleDepositClick}
-                className="flex-1 bg-green-600 text-white hover:bg-green-700"
+                className="bg-green-500/25 hover:bg-green-500/50 hover:text-green-400 text-green-500 border-green-500/30 border rounded-lg py-3 font-semibold"
               >
-                <Wallet className="h-4 w-4 mr-2" />
-                Deposit
+                deposit
               </Button>
             ) : (
               <ConnectWalletModal
                 trigger={
-                  <Button className="flex-1 bg-green-600 text-white hover:bg-green-700">
-                    <Wallet className="h-4 w-4 mr-2" />
-                    Connect
+                  <Button className="bg-green-500/25 hover:bg-green-500/50 hover:text-green-400 text-green-500 border-green-500/30 border rounded-lg py-3 font-semibold">
+                    connect
                   </Button>
                 }
                 onSuccess={handleWalletConnectSuccess}
@@ -241,12 +227,22 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
             )}
             <Button
               onClick={() => window.open(vault.links.analytics, "_blank")}
-              className="flex-1 bg-amber-500 text-black hover:bg-amber-600"
+              className="bg-amber-500/25 hover:bg-amber-500/50 hover:text-amber-400 text-amber-500 border-[#61410B] border rounded-lg py-3 font-semibold"
             >
-              <ExternalLink className="h-4 w-4 mr-2" />
-              Open in Ether.fi
+              <ExternalLink className="h-4 w-4 mr-1" />
+              open vault
             </Button>
           </div>
+
+          {/* Etherscan Link */}
+          <Button
+            variant="outline"
+            onClick={() => window.open(vault.links.explorer, "_blank")}
+            className="w-full border-[#27272A] text-[#A1A1AA] hover:text-[#FAFAFA] hover:bg-[#27272A] py-2 text-sm mt-2"
+          >
+            <ExternalLink className="h-4 w-4 mr-2" />
+            view contract on etherscan
+          </Button>
         </div>
 
         {/* Deposit Modal */}

--- a/src/components/ui/earning/EtherFiModal.tsx
+++ b/src/components/ui/earning/EtherFiModal.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { useState } from "react";
 import Image from "next/image";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, Wallet } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -217,12 +217,14 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
                 onClick={handleDepositClick}
                 className="bg-green-500/25 hover:bg-green-500/50 hover:text-green-400 text-green-500 border-green-500/30 border rounded-lg py-3 font-semibold"
               >
+                <Wallet className="h-4 w-4 mr-1" />
                 deposit
               </Button>
             ) : (
               <ConnectWalletModal
                 trigger={
                   <Button className="bg-green-500/25 hover:bg-green-500/50 hover:text-green-400 text-green-500 border-green-500/30 border rounded-lg py-3 font-semibold">
+                    <Wallet className="h-4 w-4 mr-1" />
                     connect
                   </Button>
                 }

--- a/src/components/ui/earning/EtherFiModal.tsx
+++ b/src/components/ui/earning/EtherFiModal.tsx
@@ -105,10 +105,10 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
           <div className="grid grid-cols-2 gap-2">
             <div className="bg-[#18181B] border border-[#27272A] rounded-lg p-3">
               <div className="flex items-center justify-between">
-                <span className="text-xs font-semibold text-[#A1A1AA] uppercase tracking-wider">
+                <span className="text-sm font-semibold text-zinc-300 lowercase tracking-wider">
                   apy
                 </span>
-                <span className="text-lg font-semibold text-green-400">
+                <span className="text-green-500 font-semibold font-mono">
                   {data.apy === 0 ? "TBD" : `${data.apy.toFixed(1)}%`}
                 </span>
               </div>
@@ -117,10 +117,10 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
             {!isDashboardRow(data) && (
               <div className="bg-[#18181B] border border-[#27272A] rounded-lg p-3">
                 <div className="flex items-center justify-between">
-                  <span className="text-xs font-semibold text-[#A1A1AA] uppercase tracking-wider">
+                  <span className="text-sm font-semibold text-zinc-300 lowercase tracking-wider">
                     tvl
                   </span>
-                  <span className="text-lg font-semibold text-[#FAFAFA]">
+                  <span className="text-[#FAFAFA] font-semibold font-mono">
                     {formatCurrency(data.tvl)}
                   </span>
                 </div>
@@ -131,19 +131,23 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
           {/* User Position (Dashboard only) */}
           {isDashboardRow(data) && (
             <div className="border border-[#27272A] rounded-lg p-4">
-              <h3 className="text-sm font-medium text-[#A1A1AA] mb-3">
+              <h3 className="text-sm font-semibold text-zinc-300 lowercase tracking-wider mb-3">
                 your position
               </h3>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <span className="text-sm text-[#A1A1AA]">balance</span>
-                  <div className="text-[#FAFAFA] font-medium">
+                  <span className="text-sm font-semibold text-zinc-300 lowercase tracking-wider">
+                    balance
+                  </span>
+                  <div className="text-[#FAFAFA] font-semibold font-mono">
                     {data.balance.toFixed(4)} {data.position}
                   </div>
                 </div>
                 <div>
-                  <span className="text-sm text-[#A1A1AA]">usd value</span>
-                  <div className="text-[#FAFAFA] font-medium">
+                  <span className="text-sm font-semibold text-zinc-300 lowercase tracking-wider">
+                    usd value
+                  </span>
+                  <div className="text-[#FAFAFA] font-semibold font-mono">
                     {formatCurrency(data.balanceUsd)}
                   </div>
                 </div>
@@ -153,7 +157,7 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
 
           {/* Supported Assets */}
           <div>
-            <h3 className="text-[#A1A1AA] text-sm font-medium mb-3 uppercase tracking-wider">
+            <h3 className="text-sm font-semibold text-zinc-300 lowercase tracking-wider mb-3">
               supported assets
             </h3>
             <div className="flex gap-3">
@@ -179,7 +183,7 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
 
           {/* You Will Receive */}
           <div>
-            <h3 className="text-[#A1A1AA] text-sm font-medium mb-3 uppercase tracking-wider">
+            <h3 className="text-sm font-semibold text-zinc-300 lowercase tracking-wider mb-3">
               you will receive
             </h3>
             <div className="flex items-center gap-3 bg-[#27272A] rounded-lg px-4 py-3">

--- a/src/config/etherFi.ts
+++ b/src/config/etherFi.ts
@@ -70,7 +70,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "Liquid ETH Yield",
     description:
       "Liquid ETH vault provides staking rewards plus additional yield from ETH delegation strategies.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Featured",
     chain: "ethereum",
     addresses: {
@@ -103,7 +103,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "Liquid BTC Yield",
     description:
       "Liquid BTC vault uses wrapped BTC to generate yield through lending and options strategies.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Featured",
     chain: "ethereum",
     addresses: {
@@ -136,7 +136,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "Market-Neutral USD",
     description:
       "Market-Neutral USD vault focuses on stable returns using conservative stablecoin strategies.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Strategy Vault",
     chain: "ethereum",
     addresses: {
@@ -169,7 +169,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "ETHFI Restaking",
     description:
       "ETHFI Restaking vault allows users to earn rewards by staking ETHFI tokens.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Governance Restaking",
     chain: "ethereum",
     addresses: {
@@ -201,7 +201,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "EIGEN Restaking",
     description:
       "EIGEN Restaking vault allows users to earn rewards by staking EIGEN tokens.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Governance Restaking",
     chain: "ethereum",
     addresses: {
@@ -233,7 +233,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "UltraYield Stablecoin Vault",
     description:
       "Ultra Yield Stablecoin Vault uses aggressive yet secure strategies to maximize stablecoin returns.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Partner Vault",
     chain: "ethereum",
     addresses: {
@@ -266,7 +266,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "Liquid Move ETH",
     description:
       "Liquid Move ETH vault combines ETH staking with automated trading strategies.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Partner Vault",
     chain: "ethereum",
     addresses: {
@@ -298,7 +298,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "The Bera ETH Vault",
     description:
       "The Bera ETH Vault focuses on low-risk strategies with consistent returns for ETH holders.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Partner Vault",
     chain: "ethereum",
     addresses: {
@@ -330,7 +330,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "The Bera BTC Vault",
     description:
       "The Bera BTC Vault focuses on low-risk strategies with consistent returns for BTC holders.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Partner Vault",
     chain: "ethereum",
     addresses: {
@@ -362,7 +362,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     id: 10,
     name: " Symbiotic Restaking",
     description: "TBA",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Featured",
     chain: "ethereum",
     addresses: {
@@ -395,7 +395,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "Bitcoin LRT",
     description:
       "Bitcoin LRT vault providing restaked BTC yield through various Bitcoin strategies.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Featured",
     chain: "ethereum",
     addresses: {
@@ -427,7 +427,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "Ethena USD LRT",
     description:
       "Ethena USD LRT vault combining staking and shorting ETH strategies for stablecoin yield.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Featured",
     chain: "ethereum",
     addresses: {
@@ -460,7 +460,7 @@ export const ETHERFI_VAULTS: Record<number, EtherFiVault> = {
     name: "King Karak LRT",
     description:
       "King Karak LRT vault providing restaked ETH yield through Karak network strategies.",
-    ecosystem: "Ether.fi",
+    ecosystem: "ether.fi",
     type: "Featured",
     chain: "ethereum",
     addresses: {


### PR DESCRIPTION
This PR is straight forward but I would not worry too much about changes to EtherFiModal and DepositModal in terms of spacing, positioning etc, as they will likely be changes soon anyway, this is just to align these modals with the rest of the pages - these were just mock changes.

  - Text casing consistency across both modals and on earn page table for etherfi
  - Consistent font across numbers and text/heading styling
  - added green button styled in the same manner as our standard orange buttons  
  - Proper lucide icon usage with wallet and external link icons
 
 As a note: the only thing im really happy with is this stack of buttons (altho probably need another lucide icon for open vault)
<img width="685" height="211" alt="image" src="https://github.com/user-attachments/assets/eadd742f-2370-4b9f-ae48-2dba5a4382df" />

before: 
<img width="771" height="804" alt="image" src="https://github.com/user-attachments/assets/2106facb-e073-4e96-ab83-09c06f2d4ac1" />

after:
<img width="623" height="728" alt="image" src="https://github.com/user-attachments/assets/e2ef9be5-5823-4788-96e2-0310a2104e94" />

before:
<img width="480" height="609" alt="image" src="https://github.com/user-attachments/assets/0e67eabe-52d6-4888-a33c-1978fb2e8b5a" />

after:
<img width="515" height="651" alt="image" src="https://github.com/user-attachments/assets/cbec9c03-217c-48b4-8161-02c42e1b77f7" />

