### PR TITLE
feat: integrated swap recorder into useTokenTransfer hook

### DIFF
--- a/src/app/(dapp)/swap/page.tsx
+++ b/src/app/(dapp)/swap/page.tsx
@@ -31,7 +31,7 @@ const SwapComponent: React.FC = () => {
     relayerFeeUsd,
     swapAmounts,
   } = useTokenTransfer({
-    type: "swap",
+    type: "vanilla",
     sourceChain: useSourceChain(),
     destinationChain: useDestinationChain(),
     sourceToken: sourceToken,

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -424,7 +424,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
     receiveAmount,
     isLoadingQuote,
   } = useTokenTransfer({
-    type: "swap",
+    type: "earn/etherFi", // remember to change me when we integrate with other vaults
     sourceChain,
     destinationChain,
     sourceToken,


### PR DESCRIPTION
This PR integrates the swap recorder built by @machineboyy into the `useTokenTransfer` hook. 

In addition, I have replaced the previously redundant `options.type` property from denoting whether the transaction is a `"swap" | "bridge"` to now denoting the source of the swap, in alignment with the swap recorder. Along with that I have removed a whole bunch of conditionals for the whole swap/bridge state (which really should have been removed a long time ago as the bridge page was removed _months_ ago...)