### PR TITLE
feat: deposit modal token transcation summary

### DIFF
--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -1530,6 +1530,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
               ) : vaultSharesPreview ? (
                 <div className="mt-1">
                   <div className="text-lg font-semibold text-green-500 font-mono">
+                    ~
                     {parseFloat(vaultSharesPreview.vaultTokensReceived).toFixed(
                       6,
                     )}{" "}

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -44,6 +44,10 @@ import useVaultDepositStore, {
 import { GasDrop } from "@/components/ui/GasDrop";
 import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import TokenImage from "@/components/ui/TokenImage";
+import {
+  queryVaultConversionRate,
+  VaultConversionRate,
+} from "@/utils/etherFi/vaultShares";
 
 interface DepositModalProps {
   isOpen: boolean;
@@ -71,6 +75,12 @@ const DepositModal: React.FC<DepositModalProps> = ({
   );
   const [isDirectDeposit, setIsDirectDeposit] = useState<boolean>(true);
   const [isMounted, setIsMounted] = useState(false);
+
+  // Vault shares conversion state
+  const [vaultSharesPreview, setVaultSharesPreview] =
+    useState<VaultConversionRate | null>(null);
+  const [isLoadingConversion, setIsLoadingConversion] = useState(false);
+  const [conversionError, setConversionError] = useState<string | null>(null);
 
   // Integration hooks
   const { approveToken, depositTokens } = useEtherFiInteract();
@@ -848,6 +858,106 @@ const DepositModal: React.FC<DepositModalProps> = ({
     }
   }, [isOpen, vault, isMounted, activeProcess, cancelProcess]);
 
+  // Vault shares conversion rate effect
+  useEffect(() => {
+    console.log("🔄 Vault shares useEffect triggered:", {
+      vault: vault?.name,
+      isMounted,
+      isDirectDeposit,
+      swapAmount,
+      selectedSwapToken: selectedSwapToken?.ticker,
+      receiveAmount,
+    });
+
+    if (!vault || !isMounted) return;
+
+    // Determine the amount and asset to use for conversion
+    let amountToConvert = "";
+    let assetToConvert = "";
+
+    if (!isDirectDeposit) {
+      // For cross-chain swaps, use the receive amount and target asset
+      if (receiveAmount && vault.supportedAssets.deposit[0]) {
+        amountToConvert = receiveAmount;
+        assetToConvert = vault.supportedAssets.deposit[0];
+      }
+    } else {
+      // For direct deposits, use the input amount and selected asset
+      if (swapAmount && selectedSwapToken?.ticker) {
+        amountToConvert = swapAmount;
+        assetToConvert = selectedSwapToken.ticker;
+      }
+    }
+
+    console.log("🎯 Conversion values:", {
+      amountToConvert,
+      assetToConvert,
+      isValidAmount: !!(amountToConvert && parseFloat(amountToConvert) > 0),
+    });
+
+    // Only proceed if we have valid inputs
+    if (
+      !amountToConvert ||
+      !assetToConvert ||
+      parseFloat(amountToConvert) <= 0
+    ) {
+      setVaultSharesPreview(null);
+      setConversionError(null);
+      return;
+    }
+
+    // Check if the asset is supported by the vault (case insensitive)
+    const supportedAssets = vault.supportedAssets.deposit.map((asset) =>
+      asset.toLowerCase(),
+    );
+    if (!supportedAssets.includes(assetToConvert.toLowerCase())) {
+      setVaultSharesPreview(null);
+      setConversionError(`${assetToConvert} not supported by ${vault.name}`);
+      return;
+    }
+
+    const fetchConversionRate = async () => {
+      setIsLoadingConversion(true);
+      setConversionError(null);
+
+      try {
+        const signer = await getEvmSigner();
+        const provider = signer.provider;
+        if (!provider) {
+          throw new Error("Provider not available");
+        }
+
+        const conversionResult = await queryVaultConversionRate(
+          vault.id,
+          assetToConvert,
+          amountToConvert,
+          provider,
+        );
+        setVaultSharesPreview(conversionResult);
+      } catch (error) {
+        console.error("Failed to fetch vault conversion rate:", error);
+        setConversionError(
+          error instanceof Error
+            ? error.message
+            : "Failed to fetch conversion rate",
+        );
+        setVaultSharesPreview(null);
+      } finally {
+        setIsLoadingConversion(false);
+      }
+    };
+
+    fetchConversionRate();
+  }, [
+    vault,
+    swapAmount,
+    selectedSwapToken,
+    receiveAmount,
+    isDirectDeposit,
+    isMounted,
+    getEvmSigner,
+  ]);
+
   // Don't render on server
   if (!isMounted || !vault) return null;
 
@@ -996,7 +1106,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
               height={24}
               className="rounded-full"
             />
-            Deposit to {vault.name}
+            deposit to {vault.name}
           </DialogTitle>
         </DialogHeader>
 
@@ -1032,7 +1142,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                     size="sm"
                     className="w-full text-amber-500 border-amber-500 hover:bg-amber-500/10"
                   >
-                    Cancel & Keep Swapped Tokens
+                    cancel & keep swapped tokens
                   </Button>
                 </div>
               )}
@@ -1283,7 +1393,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                         onClick={connectEvmWallet}
                         className="text-xs px-2 py-1 rounded bg-green-500/20 text-green-500 hover:text-green-400 hover:bg-green-500/30 transition-colors"
                       >
-                        Connect EVM
+                        connect evm
                       </button>
                     )}
                     {selectedSwapToken &&
@@ -1297,7 +1407,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                               onClick={connectSuiWallet}
                               className="text-xs px-2 py-1 rounded bg-blue-500/20 text-blue-500 hover:text-blue-400 hover:bg-blue-500/30 transition-colors"
                             >
-                              Connect SUI
+                              connect sui
                             </button>
                           );
                         } else if (chain?.walletType === WalletType.REOWN_SOL) {
@@ -1306,7 +1416,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                               onClick={connectSolanaWallet}
                               className="text-xs px-2 py-1 rounded bg-purple-500/20 text-purple-500 hover:text-purple-400 hover:bg-purple-500/30 transition-colors"
                             >
-                              Connect Solana
+                              connect solana
                             </button>
                           );
                         } else if (chain?.walletType === WalletType.REOWN_EVM) {
@@ -1315,7 +1425,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                               onClick={connectEvmWallet}
                               className="text-xs px-2 py-1 rounded bg-green-500/20 text-green-500 hover:text-green-400 hover:bg-green-500/30 transition-colors"
                             >
-                              Connect EVM
+                              connect evm
                             </button>
                           );
                         }
@@ -1401,6 +1511,44 @@ const DepositModal: React.FC<DepositModalProps> = ({
             </>
           )}
 
+          {/* Vault shares preview */}
+          {((!isDirectDeposit && receiveAmount) ||
+            (isDirectDeposit && swapAmount)) && (
+            <div className="p-3 bg-zinc-800/50 rounded-lg border border-zinc-700">
+              <div className="flex items-center justify-between">
+                <div className="text-sm text-zinc-400">you will receive</div>
+                {isLoadingConversion && (
+                  <div className="text-xs text-zinc-500">loading...</div>
+                )}
+              </div>
+
+              {conversionError ? (
+                <div className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <AlertCircle className="w-4 h-4" />
+                  {conversionError}
+                </div>
+              ) : vaultSharesPreview ? (
+                <div className="mt-1">
+                  <div className="text-lg font-semibold text-green-500 font-mono">
+                    {parseFloat(vaultSharesPreview.vaultTokensReceived).toFixed(
+                      6,
+                    )}{" "}
+                    {vaultSharesPreview.vaultTokenSymbol}
+                  </div>
+                  <div className="text-xs text-zinc-500 mt-1">
+                    exchange rate: 1 {vaultSharesPreview.depositAsset} ={" "}
+                    {vaultSharesPreview.exchangeRate.toFixed(6)}{" "}
+                    {vaultSharesPreview.vaultTokenSymbol}
+                  </div>
+                </div>
+              ) : (
+                <div className="mt-1 text-sm text-zinc-500">
+                  enter amount to see vault shares preview
+                </div>
+              )}
+            </div>
+          )}
+
           {/* APY Information */}
           <div className="flex items-center gap-2 p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
             <Info className="h-4 w-4 text-green-500" />
@@ -1450,7 +1598,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
                 {isLoadingQuote ? (
                   <div className="flex items-center gap-2">
                     <div className="w-4 h-4 border-2 border-black/20 border-t-black rounded-full animate-spin" />
-                    Getting Quote...
+                    getting quote...
                   </div>
                 ) : (
                   <>

--- a/src/config/etherFi.ts
+++ b/src/config/etherFi.ts
@@ -42,7 +42,7 @@ export interface EtherFiVault {
 }
 
 // Shared lens address for all vaults
-const SHARED_LENS_ADDRESS = "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B";
+export const SHARED_LENS_ADDRESS = "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B";
 
 // Fallback APY values based on EtherFi website observations (as of current date)
 // These should be updated periodically by checking the actual website

--- a/src/config/etherFi.ts
+++ b/src/config/etherFi.ts
@@ -47,9 +47,9 @@ const SHARED_LENS_ADDRESS = "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B";
 // Fallback APY values based on EtherFi website observations (as of current date)
 // These should be updated periodically by checking the actual website
 export const FALLBACK_APY_VALUES: Record<string, number> = {
-  "0x83599937c2c9bea0e0e8ac096c6f32e86486b410": 3.2, // Bera ETH Vault (lowercase)
-  "0xe77076518a813616315eaaba6ca8e595e845eee9": 3.0, // EIGEN Restaking (lowercase)
-  "0x86b5780b606940eb59a062aa85a07959518c0161": 25.0, // ETHFI Restaking (lowercase)
+  "0x83599937c2c9bea0e0e8ac096c6f32e86486b410": 1.2, // Bera ETH Vault (lowercase)
+  "0xe77076518a813616315eaaba6ca8e595e845eee9": 2.7, // EIGEN Restaking (lowercase)
+  "0x86b5780b606940eb59a062aa85a07959518c0161": 20.0, // ETHFI Restaking (lowercase)
   "0xca8711daf13d852ed2121e4be3894dae366039e4": 11.0, // Liquid Move ETH (lowercase)
 };
 

--- a/src/store/vaultDepositStore.ts
+++ b/src/store/vaultDepositStore.ts
@@ -91,7 +91,7 @@ const useVaultDepositStore = create<VaultDepositStoreState>()(
       // Cancel process (transitions to CANCELLED state)
       cancelProcess: (processId) => {
         get().updateProcessState(processId, "CANCELLED", {
-          errorMessage: "Process cancelled by user",
+          errorMessage: "process cancelled by user",
         });
       },
 
@@ -263,7 +263,7 @@ const useVaultDepositStore = create<VaultDepositStoreState>()(
       getProcessProgress: (processId) => {
         const process = get().processes[processId];
         if (!process)
-          return { current: 0, total: 2, description: "Process not found" };
+          return { current: 0, total: 2, description: "process not found" };
 
         const totalSteps = process.type === "DIRECT" ? 1 : 2;
 
@@ -272,55 +272,55 @@ const useVaultDepositStore = create<VaultDepositStoreState>()(
             return {
               current: 0,
               total: totalSteps,
-              description: "Ready to start",
+              description: "ready to start",
             };
           case "SWAP_PENDING":
             return {
               current: 0,
               total: totalSteps,
-              description: "Swapping tokens...",
+              description: "swapping tokens...",
             };
           case "SWAP_COMPLETE":
             return {
               current: 1,
               total: totalSteps,
-              description: "Swap complete, checking allowance...",
+              description: "swap complete, checking allowance...",
             };
           case "APPROVAL_PENDING": // Add this case
             return {
               current: 1,
               total: totalSteps,
-              description: "Waiting for token approval...",
+              description: "waiting for token approval...",
             };
           case "DEPOSIT_PENDING":
             return {
               current: 1,
               total: totalSteps,
-              description: "Depositing to vault...",
+              description: "depositing to vault...",
             };
           case "COMPLETED":
             return {
               current: totalSteps,
               total: totalSteps,
-              description: "Deposit completed successfully",
+              description: "deposit completed successfully",
             };
           case "CANCELLED":
             return {
               current: 1,
               total: totalSteps,
-              description: "Process cancelled",
+              description: "process cancelled",
             };
           case "FAILED":
             return {
               current: 0,
               total: totalSteps,
-              description: process.errorMessage || "Process failed",
+              description: process.errorMessage || "process failed",
             };
           default:
             return {
               current: 0,
               total: totalSteps,
-              description: "Unknown state",
+              description: "unknown state",
             };
         }
       },

--- a/src/types/etherFiABIs.ts
+++ b/src/types/etherFiABIs.ts
@@ -74,3 +74,18 @@ export const TELLER_PAUSED_ABI = [
   "function isPaused() view returns (bool)",
   "function paused() view returns (bool)",
 ] as const;
+
+export const VAULT_SHARES_PREVIEW_ABI = [
+  {
+    inputs: [
+      { name: "depositAsset", type: "address" },
+      { name: "depositAmount", type: "uint256" },
+      { name: "boringVault", type: "address" },
+      { name: "accountant", type: "address" },
+    ],
+    name: "previewDeposit",
+    outputs: [{ name: "shares", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;

--- a/src/utils/etherFi/vaultShares.ts
+++ b/src/utils/etherFi/vaultShares.ts
@@ -1,27 +1,12 @@
 import { ethers } from "ethers";
 import { useCallback } from "react";
 import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
-import { ETHERFI_VAULTS } from "@/config/etherFi";
-import { DEPOSIT_ASSETS } from "@/config/etherFi";
-
-// Shared lens contract address for all vaults
-const SHARED_LENS_ADDRESS = "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B";
-
-// Lens contract ABI - minimal interface for conversion rate queries
-const LENS_ABI = [
-  {
-    inputs: [
-      { name: "depositAsset", type: "address" },
-      { name: "depositAmount", type: "uint256" },
-      { name: "boringVault", type: "address" },
-      { name: "accountant", type: "address" },
-    ],
-    name: "previewDeposit",
-    outputs: [{ name: "shares", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-];
+import {
+  ETHERFI_VAULTS,
+  DEPOSIT_ASSETS,
+  SHARED_LENS_ADDRESS,
+} from "@/config/etherFi";
+import { VAULT_SHARES_PREVIEW_ABI } from "@/types/etherFiABIs";
 
 export interface VaultConversionRate {
   vaultId: number;
@@ -41,9 +26,8 @@ export interface ConversionRateError {
   error: string;
 }
 
-/**
- * Query conversion rate for a specific vault and deposit asset pair
- */
+// Query conversion rate for a specific vault and deposit asset pair
+
 export async function queryVaultConversionRate(
   vaultId: number,
   depositAsset: string,
@@ -61,20 +45,20 @@ export async function queryVaultConversionRate(
   );
   if (!supportedAssets.includes(depositAsset.toLowerCase())) {
     throw new Error(
-      `Asset ${depositAsset} not supported by vault ${vault.name}`,
+      `asset ${depositAsset} not supported by vault ${vault.name}`,
     );
   }
 
   const asset = DEPOSIT_ASSETS[depositAsset.toLowerCase()];
   if (!asset) {
-    throw new Error(`Deposit asset ${depositAsset} not configured`);
+    throw new Error(`deposit asset ${depositAsset} not configured`);
   }
 
   try {
     // Create lens contract instance
     const lensContract = new ethers.Contract(
       SHARED_LENS_ADDRESS,
-      LENS_ABI,
+      VAULT_SHARES_PREVIEW_ABI,
       provider,
     );
 
@@ -146,9 +130,8 @@ export async function queryVaultConversionRate(
   }
 }
 
-/**
- * Query conversion rates for multiple vault-asset pairs
- */
+//Query conversion rates for multiple vault-asset pairs
+
 export async function queryMultipleConversionRates(
   queries: Array<{
     vaultId: number;
@@ -189,9 +172,7 @@ export async function queryMultipleConversionRates(
   return { successful, failed };
 }
 
-/**
- * Get all possible conversion rates for a specific deposit asset across all vaults
- */
+// Get all possible conversion rates for a specific deposit asset across all vaults
 export async function queryAllVaultsForAsset(
   depositAsset: string,
   depositAmount: string,
@@ -211,9 +192,9 @@ export async function queryAllVaultsForAsset(
       failed: [
         {
           vaultId: 0,
-          vaultName: "No vaults found",
+          vaultName: "no vaults found",
           depositAsset,
-          error: `No vaults support deposit asset ${depositAsset}`,
+          error: `no vaults support deposit asset ${depositAsset}`,
         },
       ],
     };
@@ -229,9 +210,8 @@ export async function queryAllVaultsForAsset(
   return queryMultipleConversionRates(queries, provider);
 }
 
-/**
- * React hook for vault share conversion queries with wallet integration
- */
+// React hook for vault share conversion queries with wallet integration
+
 export function useVaultShares() {
   const { getEvmSigner } = useWalletProviderAndSigner();
 
@@ -240,7 +220,7 @@ export function useVaultShares() {
       const signer = await getEvmSigner();
       const provider = signer.provider;
       if (!provider) {
-        throw new Error("Signer must have a provider");
+        throw new Error("signer must have a provider");
       }
       return queryVaultConversionRate(
         vaultId,
@@ -263,7 +243,7 @@ export function useVaultShares() {
       const signer = await getEvmSigner();
       const provider = signer.provider;
       if (!provider) {
-        throw new Error("Signer must have a provider");
+        throw new Error("signer must have a provider");
       }
       return queryMultipleConversionRates(queries, provider);
     },
@@ -275,7 +255,7 @@ export function useVaultShares() {
       const signer = await getEvmSigner();
       const provider = signer.provider;
       if (!provider) {
-        throw new Error("Signer must have a provider");
+        throw new Error("signer must have a provider");
       }
       return queryAllVaultsForAsset(depositAsset, depositAmount, provider);
     },

--- a/src/utils/etherFi/vaultShares.ts
+++ b/src/utils/etherFi/vaultShares.ts
@@ -1,0 +1,290 @@
+import { ethers } from "ethers";
+import { useCallback } from "react";
+import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
+import { ETHERFI_VAULTS } from "@/config/etherFi";
+import { DEPOSIT_ASSETS } from "@/config/etherFi";
+
+// Shared lens contract address for all vaults
+const SHARED_LENS_ADDRESS = "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B";
+
+// Lens contract ABI - minimal interface for conversion rate queries
+const LENS_ABI = [
+  {
+    inputs: [
+      { name: "depositAsset", type: "address" },
+      { name: "depositAmount", type: "uint256" },
+      { name: "boringVault", type: "address" },
+      { name: "accountant", type: "address" },
+    ],
+    name: "previewDeposit",
+    outputs: [{ name: "shares", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+export interface VaultConversionRate {
+  vaultId: number;
+  vaultName: string;
+  depositAsset: string;
+  depositAmount: string;
+  vaultTokensReceived: string;
+  vaultTokenSymbol: string;
+  exchangeRate: number;
+  timestamp: Date;
+}
+
+export interface ConversionRateError {
+  vaultId: number;
+  vaultName: string;
+  depositAsset: string;
+  error: string;
+}
+
+/**
+ * Query conversion rate for a specific vault and deposit asset pair
+ */
+export async function queryVaultConversionRate(
+  vaultId: number,
+  depositAsset: string,
+  depositAmount: string,
+  provider: ethers.Provider,
+): Promise<VaultConversionRate> {
+  const vault = ETHERFI_VAULTS[vaultId];
+  if (!vault) {
+    throw new Error(`Vault ${vaultId} not found`);
+  }
+
+  // Check if the asset is supported by the vault (case insensitive)
+  const supportedAssets = vault.supportedAssets.deposit.map((asset) =>
+    asset.toLowerCase(),
+  );
+  if (!supportedAssets.includes(depositAsset.toLowerCase())) {
+    throw new Error(
+      `Asset ${depositAsset} not supported by vault ${vault.name}`,
+    );
+  }
+
+  const asset = DEPOSIT_ASSETS[depositAsset.toLowerCase()];
+  if (!asset) {
+    throw new Error(`Deposit asset ${depositAsset} not configured`);
+  }
+
+  try {
+    // Create lens contract instance
+    const lensContract = new ethers.Contract(
+      SHARED_LENS_ADDRESS,
+      LENS_ABI,
+      provider,
+    );
+
+    // Parse deposit amount with correct decimals
+    const parsedAmount = ethers.parseUnits(depositAmount, asset.decimals);
+
+    // Query conversion rate using previewDeposit
+    const vaultTokensReceived = await lensContract.previewDeposit(
+      asset.contractAddress,
+      parsedAmount,
+      vault.addresses.vault,
+      vault.addresses.accountant,
+    );
+
+    console.log("🔍 Debug vault conversion:", {
+      vaultName: vault.name,
+      asset: depositAsset,
+      parsedAmount: parsedAmount.toString(),
+      vaultTokensReceived: vaultTokensReceived.toString(),
+      assetDecimals: asset.decimals,
+      assetContractAddress: asset.contractAddress,
+      vaultAddress: vault.addresses.vault,
+      accountantAddress: vault.addresses.accountant,
+    });
+
+    // Query the vault token decimals to format correctly
+    const vaultContract = new ethers.Contract(
+      vault.addresses.vault,
+      [
+        {
+          name: "decimals",
+          outputs: [{ name: "", type: "uint8" }],
+          stateMutability: "view",
+          type: "function",
+        },
+      ],
+      provider,
+    );
+
+    const vaultTokenDecimals = await vaultContract.decimals();
+    console.log("🔍 Vault token decimals:", vaultTokenDecimals.toString());
+
+    // Format the received vault tokens with correct decimals
+    const formattedVaultTokens = ethers.formatUnits(
+      vaultTokensReceived,
+      vaultTokenDecimals,
+    );
+
+    // Calculate exchange rate
+    const exchangeRate =
+      parseFloat(formattedVaultTokens) / parseFloat(depositAmount);
+
+    return {
+      vaultId,
+      vaultName: vault.name,
+      depositAsset,
+      depositAmount,
+      vaultTokensReceived: formattedVaultTokens,
+      vaultTokenSymbol: vault.supportedAssets.receive.symbol,
+      exchangeRate,
+      timestamp: new Date(),
+    };
+  } catch (error) {
+    throw new Error(
+      `Failed to query conversion rate for vault ${vault.name} with ${depositAsset}: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }`,
+    );
+  }
+}
+
+/**
+ * Query conversion rates for multiple vault-asset pairs
+ */
+export async function queryMultipleConversionRates(
+  queries: Array<{
+    vaultId: number;
+    depositAsset: string;
+    depositAmount: string;
+  }>,
+  provider: ethers.Provider,
+): Promise<{
+  successful: VaultConversionRate[];
+  failed: ConversionRateError[];
+}> {
+  const successful: VaultConversionRate[] = [];
+  const failed: ConversionRateError[] = [];
+
+  // Process queries concurrently
+  const promises = queries.map(async (query) => {
+    try {
+      const result = await queryVaultConversionRate(
+        query.vaultId,
+        query.depositAsset,
+        query.depositAmount,
+        provider,
+      );
+      successful.push(result);
+    } catch (error) {
+      const vault = ETHERFI_VAULTS[query.vaultId];
+      failed.push({
+        vaultId: query.vaultId,
+        vaultName: vault?.name || `Unknown Vault ${query.vaultId}`,
+        depositAsset: query.depositAsset,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  });
+
+  await Promise.allSettled(promises);
+
+  return { successful, failed };
+}
+
+/**
+ * Get all possible conversion rates for a specific deposit asset across all vaults
+ */
+export async function queryAllVaultsForAsset(
+  depositAsset: string,
+  depositAmount: string,
+  provider: ethers.Provider,
+): Promise<{
+  successful: VaultConversionRate[];
+  failed: ConversionRateError[];
+}> {
+  // Find all vaults that support the given deposit asset
+  const supportedVaults = Object.entries(ETHERFI_VAULTS)
+    .filter(([, vault]) => vault.supportedAssets.deposit.includes(depositAsset))
+    .map(([vaultId]) => parseInt(vaultId));
+
+  if (supportedVaults.length === 0) {
+    return {
+      successful: [],
+      failed: [
+        {
+          vaultId: 0,
+          vaultName: "No vaults found",
+          depositAsset,
+          error: `No vaults support deposit asset ${depositAsset}`,
+        },
+      ],
+    };
+  }
+
+  // Create queries for all supported vaults
+  const queries = supportedVaults.map((vaultId) => ({
+    vaultId,
+    depositAsset,
+    depositAmount,
+  }));
+
+  return queryMultipleConversionRates(queries, provider);
+}
+
+/**
+ * React hook for vault share conversion queries with wallet integration
+ */
+export function useVaultShares() {
+  const { getEvmSigner } = useWalletProviderAndSigner();
+
+  const queryVaultConversionRateMemoized = useCallback(
+    async (vaultId: number, depositAsset: string, depositAmount: string) => {
+      const signer = await getEvmSigner();
+      const provider = signer.provider;
+      if (!provider) {
+        throw new Error("Signer must have a provider");
+      }
+      return queryVaultConversionRate(
+        vaultId,
+        depositAsset,
+        depositAmount,
+        provider,
+      );
+    },
+    [getEvmSigner],
+  );
+
+  const queryMultipleConversionRatesMemoized = useCallback(
+    async (
+      queries: Array<{
+        vaultId: number;
+        depositAsset: string;
+        depositAmount: string;
+      }>,
+    ) => {
+      const signer = await getEvmSigner();
+      const provider = signer.provider;
+      if (!provider) {
+        throw new Error("Signer must have a provider");
+      }
+      return queryMultipleConversionRates(queries, provider);
+    },
+    [getEvmSigner],
+  );
+
+  const queryAllVaultsForAssetMemoized = useCallback(
+    async (depositAsset: string, depositAmount: string) => {
+      const signer = await getEvmSigner();
+      const provider = signer.provider;
+      if (!provider) {
+        throw new Error("Signer must have a provider");
+      }
+      return queryAllVaultsForAsset(depositAsset, depositAmount, provider);
+    },
+    [getEvmSigner],
+  );
+
+  return {
+    queryVaultConversionRate: queryVaultConversionRateMemoized,
+    queryMultipleConversionRates: queryMultipleConversionRatesMemoized,
+    queryAllVaultsForAsset: queryAllVaultsForAssetMemoized,
+  };
+}


### PR DESCRIPTION
Adds a new util "vaultShares.ts" this uses the lens contract to query the amount of shares/tokens the user will receive in their chosen vault once they enter in an amount. 

It will also work with cross chain swaps - gets quote from mayan (BNB to USDC  for example), this is used as input for vaultTokensReceieved, which uses previewDeposit from Lens Contract to fetch the conversion from USDC (or any vault accepted token) to liquidUSD.

Direct deposits just use the amounts and token pairs, to fetch using the previewDeposit function. 

<img width="581" height="868" alt="image" src="https://github.com/user-attachments/assets/6364c572-8b31-4c07-b12e-fdd6cb029a74" />

Please disregard the old styling, used old branch to branch from.

Changes are also made to casing for deposit modal in vaultDepositStore.ts.

This is still buggy, it will not mess anything up with actually depositing however there are some pairs that still need debugging as they are not properly working such as arbitrum, thank god for claude though. 