### PR TITLE
fix: SerializedToken should reflect native/l2/wrapped flags

### DIFF
--- a/src/store/storeVersion.ts
+++ b/src/store/storeVersion.ts
@@ -1,1 +1,1 @@
-export const STORE_VERSION = 3;
+export const STORE_VERSION = 4;

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -792,6 +792,9 @@ const useWeb3Store = create<Web3StoreState>()(
             userBalanceUsd: token.userBalanceUsd,
             isWalletToken: token.isWalletToken,
             alwaysLoadPrice: token.alwaysLoadPrice,
+            isNativeGas: token.isNativeGas,
+            isNativeWrapped: token.isNativeWrapped,
+            isL2Token: token.isL2Token,
           };
         };
         // Serialize each swap integration

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -400,6 +400,9 @@ export type SerializedToken = {
   userBalanceUsd?: string;
   isWalletToken?: boolean;
   alwaysLoadPrice?: boolean;
+  isNativeGas?: boolean;
+  isNativeWrapped?: boolean;
+  isL2Token?: boolean;
 } | null;
 
 export type SerializedSwapStateForSection = {


### PR DESCRIPTION
A patch for native/l2/wrapped tokens not loading:

<img width="465" height="366" alt="image" src="https://github.com/user-attachments/assets/d13c69c3-eae6-47aa-b0d6-8a76bf2a2f0b" />

This was occuring as a consequence of the `SerializedToken` type omitting the `isNativeGas || isNativeWrapped || isL2Token` types.