### PR TITLE
feature: swap response types

### DIFF
--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -423,3 +423,57 @@ export interface UserWallets {
   solana?: string;
   sui?: string;
 }
+
+export interface SwapData {
+  trader: string;
+  sourceTxHash: string;
+  sourceChain: string;
+  swapChain: string;
+  destChain: string;
+  fromAmount: string;
+  fromTokenAddress: string;
+  fromTokenChain: string;
+  fromTokenSymbol: string;
+  fromTokenLogoUri: string;
+  fromTokenPrice: number;
+  toTokenPrice: number;
+  toTokenAddress: string;
+  toTokenChain: string;
+  toTokenSymbol: string;
+  toTokenLogoUri: string;
+  destAddress: string;
+  status: string;
+  clientStatus: string;
+  initiatedAt: string;
+  toAmount: string;
+  stateAddr: string;
+  service: string;
+  statusUpdatedAt: string;
+  auctionMode: number;
+  referrerBps: number;
+  mayanBps: number;
+  orderHash: string;
+  cctpNonce: string | null;
+  fulfillTxHash: string;
+  refundTxHash: string | null;
+  clientRelayerFeeRefund: number;
+  orderId: string;
+}
+
+export interface SwapResponse {
+  data: SwapData[];
+  metadata: {
+    count: number;
+    volume: number;
+  };
+}
+
+export interface SwapQueryResult {
+  referrerAddress: string;
+  traderAddress: string;
+  response: SwapResponse;
+  rawResponse?: Response;
+  error?: string;
+}
+
+export type ChainType = "EVM" | "SOL" | "SUI";


### PR DESCRIPTION
branch off #154, #155, #156, will rebase

This PR adds 3 new types for handling swap history responses from the Mayan API. It includes:
- `SwapData`: the full transaction details object that will be parsed from the list in the response
- `SwapResponse`: the mid level response object which contains the list of `SwapData`
- `SwapQueryResponse`: the top layer response object which contains the `SwapResponse` (you can thank linting for making me break this into 3 layers)

There is also the `ChainType` which has been added in - this is so we can group swap transactions based on their required wallet type. The functionality for this will be revealed in subsequent PRs.