### PR TITLE
feat: added wallet filter dropdown

### DIFF
--- a/src/components/ui/WalletFilter.tsx
+++ b/src/components/ui/WalletFilter.tsx
@@ -22,7 +22,7 @@ interface WalletOption {
   walletType?: WalletType; // Map to actual wallet type
 }
 
-interface WalletSelectorProps {
+interface WalletFilterProps {
   selectedWallet: WalletFilterType;
   onWalletChange: (wallet: WalletFilterType) => void;
   className?: string;
@@ -206,7 +206,7 @@ const CustomSuiConnectButton = ({
       >
         <div className="flex items-center gap-2">
           <Wallet className="h-3 w-3" />
-          <span className="text-[11px]">connect SUI</span>
+          <span className="text-[11px]">connect sui</span>
         </div>
         <Image
           src="/wallets/sui.svg"
@@ -220,7 +220,7 @@ const CustomSuiConnectButton = ({
   );
 };
 
-const WalletSelector: React.FC<WalletSelectorProps> = ({
+const WalletFilter: React.FC<WalletFilterProps> = ({
   selectedWallet,
   onWalletChange,
   className,
@@ -418,5 +418,5 @@ const WalletSelector: React.FC<WalletSelectorProps> = ({
   );
 };
 
-export { WalletSelector, WalletIcons };
-export type { WalletSelectorProps };
+export { WalletFilter, WalletIcons };
+export type { WalletFilterProps };


### PR DESCRIPTION
This PR adds a simple reusable component for filtering between connected user wallets, as well as connecting user wallets when not currently connected. This is useful for components such as the users swap history. This component integrates directly with the `WalletType` type, and includes the `.svg` icons for each wallet.

It also includes the "connect <wallet name>" buttons inspired by those used in the Earn Deposit modal when a user is not connected. The Custom Sui connect button is also handled. 

## Screenshots
<img width="372" height="420" alt="Screenshot 2025-07-17 at 6 47 13 am" src="https://github.com/user-attachments/assets/6433f066-aac6-46a4-ad23-17b08f5576c0" />

<img width="308" height="226" alt="Screenshot 2025-07-17 at 6 54 49 am" src="https://github.com/user-attachments/assets/194e8b27-c0b2-4871-9cb0-2ce87b32a3af" />


TODO: we need to center the sui icon a bit more as you can see it is a bit uncentered.