### PR TITLE
fix: use ethereum provider for vault summaries in cross chain EVM instances

### DIFF
--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -929,17 +929,11 @@ const DepositModal: React.FC<DepositModalProps> = ({
       setConversionError(null);
 
       try {
-        const signer = await getEvmSigner();
-        const provider = signer.provider;
-        if (!provider) {
-          throw new Error("Provider not available");
-        }
-
+        // Use automatic Ethereum provider for vault queries (vaults only exist on Ethereum)
         const conversionResult = await queryVaultConversionRate(
           vault.id,
           assetToConvert,
           amountToConvert,
-          provider,
         );
         setVaultSharesPreview(conversionResult);
       } catch (error) {


### PR DESCRIPTION
ADded getEthereumProvider() which  always returns a provider connected to eth mainnet using the configured rpc endpoints
   - It will first try to use the wallets provider if connected to eth mainnet
   - If not, it will fall back to a eth provider for cross chain scenarios, this is done through vaultProvider.
  
This was causing missing revert data error on cross chain evm based chains, as etherfi vault contracts only exist on eth mainnet and would fail and cause a revert when the wallet was connected to Arbitrum/other chains, now it uses ethRPC for all vault conversion queries