### PR TITLE
bugfix: missing mayan chain id in BorrowModal definition

### DIFF
--- a/src/components/ui/lending/BorrowModal.tsx
+++ b/src/components/ui/lending/BorrowModal.tsx
@@ -145,6 +145,7 @@ const BorrowModal: FC<BorrowModalProps> = ({
     backgroundColor: "",
     fontColor: "",
     chainId: chainId,
+    mayanChainId: 2,
     decimals: 18,
     l2: false,
     gasDrop: 0,


### PR DESCRIPTION
This PR resolves a bug that was causing a failing build due to an incorrect chain configuration in `BorrowModal.tsx`. I will merge this immediately to resolve the failing build on `master`.