### PR TITLE
feature: regex to parse error messages to deposit modal and fixes to error/number input handling

### DIFF
--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -304,18 +304,16 @@ const DepositModal: React.FC<DepositModalProps> = ({
               "❌ Deposit failed after approval:",
               depositResult.message,
             );
-            failDepositStep(
-              processId,
+            const friendlyError = parseDepositError(
               depositResult.message || "Deposit failed after approval",
             );
+            failDepositStep(processId, friendlyError);
             return false;
           }
         } else {
           console.error("❌ Approval failed:", approvalResult.message);
-          failDepositStep(
-            processId,
-            `Approval failed: ${approvalResult.message}`,
-          );
+          const friendlyError = parseDepositError(approvalResult.message);
+          failDepositStep(processId, friendlyError);
           return false;
         }
       } catch (error) {
@@ -408,7 +406,10 @@ const DepositModal: React.FC<DepositModalProps> = ({
           return true;
         } else {
           console.error("❌ Deposit failed:", result.message);
-          failDepositStep(processId, result.message || "Deposit failed");
+          const friendlyError = parseDepositError(
+            result.message || "Deposit failed",
+          );
+          failDepositStep(processId, friendlyError);
           return false;
         }
       } catch (error) {
@@ -1117,7 +1118,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
           {/* Process Progress */}
           {activeProcess && activeProcess.state !== "CANCELLED" && (
             <div className="p-4 bg-[#27272A] rounded-lg border border-[#3F3F46]">
-              <div className="text-sm text-wrap font-medium text-[#FAFAFA] mb-3 break-all">
+              <div className="text-sm font-medium text-[#FAFAFA] mb-3 break-words">
                 {formatErrorMessage(processProgress?.description) ||
                   "Processing..."}
               </div>

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -33,7 +33,11 @@ import {
 import { EtherFiVault, DEPOSIT_ASSETS } from "@/config/etherFi";
 import { getTokenAllowance } from "@/utils/etherFi/fetch";
 import { useEtherFiInteract } from "@/utils/etherFi/interact";
-import { useChainSwitch, useTokenTransfer } from "@/utils/swap/walletMethods";
+import {
+  useChainSwitch,
+  useTokenTransfer,
+  parseDepositError,
+} from "@/utils/swap/walletMethods";
 import { WalletType, Token, SwapStatus } from "@/types/web3";
 import { chainList, getChainById, chains } from "@/config/chains";
 import { useAppKit } from "@reown/appkit/react";
@@ -316,9 +320,8 @@ const DepositModal: React.FC<DepositModalProps> = ({
         }
       } catch (error) {
         console.error("❌ Approval error:", error);
-        const errorMessage =
-          error instanceof Error ? error.message : "Unknown error";
-        failDepositStep(processId, `Approval error: ${errorMessage}`);
+        const friendlyError = parseDepositError(error);
+        failDepositStep(processId, friendlyError);
         return false;
       }
     },
@@ -409,10 +412,9 @@ const DepositModal: React.FC<DepositModalProps> = ({
           return false;
         }
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : "Unknown error";
-        console.error("❌ Vault deposit error:", errorMessage);
-        failDepositStep(processId, errorMessage);
+        console.error("❌ Vault deposit error:", error);
+        const friendlyError = parseDepositError(error);
+        failDepositStep(processId, friendlyError);
         return false;
       }
     },
@@ -705,10 +707,9 @@ const DepositModal: React.FC<DepositModalProps> = ({
         }
       } catch (error) {
         if (isCancelled) return;
-        const errorMessage =
-          error instanceof Error ? error.message : "Unknown error";
-        console.error("❌ Cross-chain vault deposit error:", errorMessage);
-        failDepositStep(process.id, errorMessage);
+        console.error("❌ Cross-chain vault deposit error:", error);
+        const friendlyError = parseDepositError(error);
+        failDepositStep(process.id, friendlyError);
       } finally {
         operationInProgress.current = false;
       }

--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -1458,10 +1458,25 @@ const DepositModal: React.FC<DepositModalProps> = ({
                 <div className="relative">
                   <Input
                     type="number"
+                    step="any"
+                    min="0"
                     placeholder="0.00"
                     value={swapAmount}
                     onChange={(e) => {
-                      handleSwapAmountChange(e);
+                      // Only allow positive numbers
+                      const value = parseFloat(e.target.value);
+                      if (
+                        e.target.value === "" ||
+                        (!isNaN(value) && value >= 0)
+                      ) {
+                        handleSwapAmountChange(e);
+                      }
+                    }}
+                    onKeyDown={(e) => {
+                      // Prevent negative sign and scientific notation
+                      if (e.key === "-" || e.key === "e" || e.key === "E") {
+                        e.preventDefault();
+                      }
                     }}
                     className="pr-20 bg-[#27272A] border-[#3F3F46] text-[#FAFAFA] placeholder:text-[#71717A] font-mono"
                   />

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -1567,6 +1567,12 @@ export function parseDepositError(error: unknown): string {
 
     // Try to extract common error patterns
     const patterns = [
+      // User rejection errors - CHECK FIRST to avoid false matches with gas/fee keywords
+      {
+        regex:
+          /user rejected action|ethers-user-denied|User rejected the request|user denied/i,
+        message: "Transaction was cancelled by user",
+      },
       // Balance errors
       {
         regex: /transfer amount exceeds balance/i,
@@ -1586,12 +1592,6 @@ export function parseDepositError(error: unknown): string {
       {
         regex: /timeout|timed? out|expired/i,
         message: "Request timed out. Please try again.",
-      },
-      // User rejection errors
-      {
-        regex:
-          /user rejected action|ethers-user-denied|User rejected the request|user denied/i,
-        message: "Transaction was cancelled by user",
       },
     ];
 

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -1520,30 +1520,30 @@ export function parseSwapError(error: unknown): string {
     // Check for specific error patterns
     for (const pattern of patterns) {
       if (pattern.regex.test(errorString)) {
-        return pattern.message;
+        return truncateMessage(pattern.message);
       }
     }
 
     // Extract reason if present (common in revert errors)
     const reasonMatch = /reason="([^"]+)"/.exec(errorString);
     if (reasonMatch && reasonMatch[1]) {
-      return reasonMatch[1];
+      return truncateMessage(reasonMatch[1]);
     }
 
     // Extract message if present
     const messageMatch = /"message":"([^"]+)"/.exec(errorString);
     if (messageMatch && messageMatch[1]) {
-      return messageMatch[1];
+      return truncateMessage(messageMatch[1]);
     }
 
     // If error is actually an Error object
     if (error instanceof Error) {
-      return error.message;
+      return truncateMessage(error.message);
     }
 
     // If error is a string
     if (typeof error === "string") {
-      return error;
+      return truncateMessage(error);
     }
 
     return friendlyMessage;
@@ -1554,6 +1554,39 @@ export function parseSwapError(error: unknown): string {
 }
 
 //Extract a user-friendly error message from deposit-related blockchain errors
+
+//Truncates error messages to 200-300 character limit for better UX
+
+function truncateMessage(message: string): string {
+  const MAX_LENGTH = 300;
+  const MIN_LENGTH = 200;
+
+  if (message.length <= MAX_LENGTH) {
+    return message;
+  }
+
+  // Try to find a good break point (sentence, word boundary) within the limit
+  const truncated = message.substring(0, MAX_LENGTH);
+  const lastSentenceEnd = Math.max(
+    truncated.lastIndexOf("."),
+    truncated.lastIndexOf("!"),
+    truncated.lastIndexOf("?"),
+  );
+
+  // If we found a sentence boundary after MIN_LENGTH, use it
+  if (lastSentenceEnd > MIN_LENGTH) {
+    return message.substring(0, lastSentenceEnd + 1);
+  }
+
+  // Otherwise, find the last word boundary
+  const lastSpace = truncated.lastIndexOf(" ");
+  if (lastSpace > MIN_LENGTH) {
+    return message.substring(0, lastSpace) + "...";
+  }
+
+  // Fallback to hard truncation
+  return message.substring(0, MAX_LENGTH) + "...";
+}
 
 export function parseDepositError(error: unknown): string {
   // Default fallback message
@@ -1598,30 +1631,30 @@ export function parseDepositError(error: unknown): string {
     // Check for specific error patterns
     for (const pattern of patterns) {
       if (pattern.regex.test(errorString)) {
-        return pattern.message;
+        return truncateMessage(pattern.message);
       }
     }
 
     // Extract reason if present (common in revert errors)
     const reasonMatch = /reason="([^"]+)"/.exec(errorString);
     if (reasonMatch && reasonMatch[1]) {
-      return reasonMatch[1];
+      return truncateMessage(reasonMatch[1]);
     }
 
     // Extract message if present
     const messageMatch = /"message":"([^"]+)"/.exec(errorString);
     if (messageMatch && messageMatch[1]) {
-      return messageMatch[1];
+      return truncateMessage(messageMatch[1]);
     }
 
     // If error is actually an Error object
     if (error instanceof Error) {
-      return error.message;
+      return truncateMessage(error.message);
     }
 
     // If error is a string
     if (typeof error === "string") {
-      return error;
+      return truncateMessage(error);
     }
 
     return friendlyMessage;


### PR DESCRIPTION
Added parseDepositError, similar to existing parseSwapError in walletMethods.tsx to handle error messages in deposit modal.

Added input restrictions to numbers only for deposit modal, not allowing scientific notation which caused some parsing issues.

Also fixed the wrapping behaviour of the error messages in the deposit modal. 