### PR TITLE
refactor: decoupled wallet connect button from wallet filter

### DIFF
--- a/src/components/ui/CustomSuiConnectButton.tsx
+++ b/src/components/ui/CustomSuiConnectButton.tsx
@@ -7,12 +7,27 @@ import { cn } from "@/lib/utils";
 export const CustomSuiConnectButton = ({
   onSuccess,
   className,
+  size = "sm",
 }: {
   onSuccess?: () => void;
   className?: string;
+  size?: "sm" | "md" | "lg";
 }) => {
   const buttonRef = useRef<HTMLDivElement>(null);
   const { connected, disconnect } = useWallet();
+
+  // Size classes to match WalletConnectButton exactly
+  const sizeClasses = {
+    sm: "text-xs px-2 py-1",
+    md: "text-sm px-3 py-2",
+    lg: "text-base px-4 py-3",
+  };
+
+  const iconSizes = {
+    sm: { width: 12, height: 12, iconClass: "h-3 w-3" },
+    md: { width: 16, height: 16, iconClass: "h-4 w-4" },
+    lg: { width: 20, height: 20, iconClass: "h-5 w-5" },
+  };
 
   const handleCustomClick = () => {
     if (connected) {
@@ -22,7 +37,6 @@ export const CustomSuiConnectButton = ({
         console.error("Button ref is null or undefined.");
         return;
       }
-
       const suietButton = buttonRef.current.querySelector("button");
       if (!suietButton) {
         console.error(
@@ -30,7 +44,6 @@ export const CustomSuiConnectButton = ({
         );
         return;
       }
-
       suietButton.click();
       // Success will be handled by the wallet sync component
       if (onSuccess) {
@@ -50,25 +63,25 @@ export const CustomSuiConnectButton = ({
       >
         <ConnectButton />
       </div>
-
-      {/* Visible custom button */}
+      {/* Visible custom button - now matches WalletConnectButton styling exactly */}
       <button
         className={cn(
-          "text-xs px-2 py-1 rounded bg-blue-500/20 text-blue-500 hover:text-blue-400 hover:bg-blue-500/30 transition-colors",
-          "flex items-center justify-between w-full",
+          sizeClasses[size],
+          "rounded transition-colors flex items-center justify-between w-full",
+          "bg-blue-500/20 text-blue-500 hover:text-blue-400 hover:bg-blue-500/30",
           className,
         )}
         onClick={handleCustomClick}
       >
         <div className="flex items-center gap-2">
-          <Wallet className="h-3 w-3" />
-          <span className="text-[11px]">connect sui</span>
+          <Wallet className={iconSizes[size].iconClass} />
+          <span className="pr-2">connect sui</span>
         </div>
         <Image
           src="/wallets/sui.svg"
           alt="Suiet"
-          width={12}
-          height={12}
+          width={iconSizes[size].width}
+          height={iconSizes[size].height}
           className="object-contain"
         />
       </button>

--- a/src/components/ui/WalletConnectButton.tsx
+++ b/src/components/ui/WalletConnectButton.tsx
@@ -130,7 +130,7 @@ export const WalletConnectButton: React.FC<WalletConnectButtonProps> = ({
     >
       <div className="flex items-center gap-2">
         <Wallet className={iconSizes[size].iconClass} />
-        <span>
+        <span className="pr-2">
           {children ||
             (connecting
               ? "connecting..."

--- a/src/components/ui/WalletConnectButton.tsx
+++ b/src/components/ui/WalletConnectButton.tsx
@@ -1,0 +1,153 @@
+import React, { useState } from "react";
+import { Wallet } from "lucide-react";
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import { useAppKit } from "@reown/appkit/react";
+import { useWalletConnection } from "@/utils/swap/walletMethods";
+import { WalletType } from "@/types/web3";
+import { toast } from "sonner";
+import { walletOptions } from "@/config/wallets";
+import { CustomSuiConnectButton } from "@/components/ui/CustomSuiConnectButton";
+
+interface WalletConnectButtonProps {
+  walletType: WalletType;
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+  className?: string;
+  size?: "sm" | "md" | "lg";
+  showIcon?: boolean;
+  children?: React.ReactNode;
+}
+
+export const WalletConnectButton: React.FC<WalletConnectButtonProps> = ({
+  walletType,
+  onSuccess,
+  onError,
+  className,
+  size = "sm",
+  showIcon = true,
+  children,
+}) => {
+  const [connecting, setConnecting] = useState(false);
+  const { open: openAppKit } = useAppKit();
+  const { isWalletTypeConnected } = useWalletConnection();
+
+  const walletOption = walletOptions.find(
+    (option) => option.walletType === walletType,
+  );
+
+  if (!walletOption) {
+    console.error(`No wallet option found for wallet type: ${walletType}`);
+    return null;
+  }
+
+  const isConnected = isWalletTypeConnected(walletType);
+
+  if (isConnected) {
+    return null;
+  }
+
+  // handling for Suiet
+  if (walletType === WalletType.SUIET_SUI) {
+    return (
+      <CustomSuiConnectButton onSuccess={onSuccess} className={className} />
+    );
+  }
+
+  const handleConnect = async () => {
+    try {
+      setConnecting(true);
+
+      switch (walletType) {
+        case WalletType.REOWN_EVM:
+          openAppKit({ view: "Connect", namespace: "eip155" });
+          break;
+        case WalletType.REOWN_SOL:
+          openAppKit({ view: "Connect", namespace: "solana" });
+          break;
+        default:
+          throw new Error(`Unsupported wallet type: ${walletType}`);
+      }
+
+      if (onSuccess) {
+        setTimeout(onSuccess, 1000);
+      }
+
+      setTimeout(() => {
+        setConnecting(false);
+      }, 3000);
+    } catch (error) {
+      console.error(`Error connecting to ${walletOption.label}:`, error);
+      const errorMessage =
+        error instanceof Error
+          ? error
+          : new Error(`Failed to connect to ${walletOption.label}`);
+
+      toast.error(errorMessage.message);
+
+      if (onError) {
+        onError(errorMessage);
+      }
+
+      setConnecting(false);
+    }
+  };
+
+  const sizeClasses = {
+    sm: "text-xs px-2 py-1",
+    md: "text-sm px-3 py-2",
+    lg: "text-base px-4 py-3",
+  };
+
+  const iconSizes = {
+    sm: { width: 12, height: 12, iconClass: "h-3 w-3" },
+    md: { width: 16, height: 16, iconClass: "h-4 w-4" },
+    lg: { width: 20, height: 20, iconClass: "h-5 w-5" },
+  };
+
+  const getWalletStyles = () => {
+    switch (walletType) {
+      case WalletType.REOWN_EVM:
+        return "bg-amber-500/20 text-amber-500 hover:text-amber-400 hover:bg-amber-500/30";
+      case WalletType.REOWN_SOL:
+        return "bg-purple-500/20 text-purple-500 hover:text-purple-400 hover:bg-purple-500/30";
+      default:
+        return "bg-blue-500/20 text-blue-500 hover:text-blue-400 hover:bg-blue-500/30";
+    }
+  };
+
+  return (
+    <button
+      onClick={handleConnect}
+      disabled={connecting}
+      className={cn(
+        sizeClasses[size],
+        "rounded transition-colors flex items-center justify-between w-full",
+        getWalletStyles(),
+        connecting && "opacity-50 cursor-not-allowed",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <Wallet className={iconSizes[size].iconClass} />
+        <span>
+          {children ||
+            (connecting
+              ? "connecting..."
+              : `connect ${walletOption.label.toLowerCase()}`)}
+        </span>
+      </div>
+      {showIcon && walletOption.icon && (
+        <Image
+          src={walletOption.icon}
+          alt={walletOption.label}
+          width={iconSizes[size].width}
+          height={iconSizes[size].height}
+          className="object-contain"
+        />
+      )}
+    </button>
+  );
+};
+
+export default WalletConnectButton;

--- a/src/components/ui/WalletFilter.tsx
+++ b/src/components/ui/WalletFilter.tsx
@@ -2,16 +2,16 @@
 
 import * as React from "react";
 import { useState } from "react";
-import { ChevronDownIcon, CheckIcon, Wallet } from "lucide-react";
+import { ChevronDownIcon, CheckIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/Button";
 import Image from "next/image";
-import { useAppKit } from "@reown/appkit/react";
 import { useWalletConnection } from "@/utils/swap/walletMethods";
-import { WalletType, WalletFilterType } from "@/types/web3";
+import { WalletFilterType } from "@/types/web3";
 import { toast } from "sonner";
 import { walletOptions } from "@/config/wallets";
-import { CustomSuiConnectButton } from "@/components/ui/CustomSuiConnectButton";
+import { WalletConnectButton } from "@/components/ui/WalletConnectButton";
+
 interface WalletFilterProps {
   selectedWallet: WalletFilterType;
   onWalletChange: (wallet: WalletFilterType) => void;
@@ -41,7 +41,7 @@ const WalletIcons: React.FC<{
     lg: 24,
   };
 
-  // Handle "all" case with multiple icons
+  // handle all case with multiple icons
   if (selectedOption.icons) {
     return (
       <div className="flex items-center gap-1">
@@ -77,7 +77,7 @@ const WalletIcons: React.FC<{
     );
   }
 
-  // Handle single wallet case
+  // handle single wallet case
   if (selectedOption.icon) {
     return (
       <div className="flex items-center gap-1">
@@ -114,9 +114,6 @@ const WalletFilter: React.FC<WalletFilterProps> = ({
   className,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [connecting, setConnecting] = useState<WalletType | null>(null);
-
-  const { open: openAppKit } = useAppKit();
   const { isWalletTypeConnected } = useWalletConnection();
 
   const selectedOption = walletOptions.find(
@@ -128,37 +125,8 @@ const WalletFilter: React.FC<WalletFilterProps> = ({
     setIsOpen(false);
   };
 
-  const handleWalletConnect = async (
-    walletType: WalletType,
-    walletName: string,
-  ) => {
-    try {
-      setConnecting(walletType);
-
-      switch (walletType) {
-        case WalletType.REOWN_EVM:
-          openAppKit({ view: "Connect", namespace: "eip155" });
-          break;
-        case WalletType.REOWN_SOL:
-          openAppKit({ view: "Connect", namespace: "solana" });
-          break;
-        // Suiet is handled by CustomSuiConnectButton
-      }
-
-      // Reset connecting state after a delay
-      setTimeout(() => {
-        setConnecting(null);
-      }, 3000);
-    } catch (error) {
-      console.error(`Error connecting to ${walletName}:`, error);
-      toast.error(`Failed to connect to ${walletName}`);
-      setConnecting(null);
-    }
-  };
-
-  // Get only connected wallets for dropdown
   const getAvailableOptions = () => {
-    const availableOptions = [walletOptions[0]]; // Always include "all"
+    const availableOptions = [walletOptions[0]];
 
     walletOptions.slice(1).forEach((option) => {
       if (option.walletType && isWalletTypeConnected(option.walletType)) {
@@ -173,7 +141,6 @@ const WalletFilter: React.FC<WalletFilterProps> = ({
 
   return (
     <div className={cn("space-y-2", className)}>
-      {/* Dropdown for connected wallets */}
       <div className="relative">
         <Button
           variant="outline"
@@ -204,7 +171,6 @@ const WalletFilter: React.FC<WalletFilterProps> = ({
 
         {isOpen && (
           <>
-            {/* Backdrop */}
             <div
               className="fixed inset-0 z-10"
               onClick={() => setIsOpen(false)}
@@ -243,62 +209,22 @@ const WalletFilter: React.FC<WalletFilterProps> = ({
         )}
       </div>
 
-      {/* Connect buttons for disconnected wallets */}
       <div className="space-y-2">
         {walletOptions.slice(1).map((option) => {
           if (!option.walletType) return null;
 
           const isConnected = isWalletTypeConnected(option.walletType);
-          const isCurrentlyConnecting = connecting === option.walletType;
 
           if (isConnected) return null; // Don't show connect button if already connected
 
-          // Special handling for Suiet
-          if (option.walletType === WalletType.SUIET_SUI) {
-            return (
-              <CustomSuiConnectButton
-                key={option.value}
-                onSuccess={() => {
-                  toast.success(`Connected to ${option.label}`);
-                }}
-              />
-            );
-          }
-
           return (
-            <button
+            <WalletConnectButton
               key={option.value}
-              onClick={() =>
-                handleWalletConnect(option.walletType!, option.label)
-              }
-              disabled={isCurrentlyConnecting}
-              className={cn(
-                "text-xs px-2 py-1 rounded transition-colors flex items-center justify-between w-full",
-                option.walletType === WalletType.REOWN_EVM &&
-                  "bg-green-500/20 text-green-500 hover:text-green-400 hover:bg-green-500/30",
-                option.walletType === WalletType.REOWN_SOL &&
-                  "bg-purple-500/20 text-purple-500 hover:text-purple-400 hover:bg-purple-500/30",
-                isCurrentlyConnecting && "opacity-50 cursor-not-allowed",
-              )}
-            >
-              <div className="flex items-center gap-2">
-                <Wallet className="h-3 w-3" />
-                <span className="text-[11px]">
-                  {isCurrentlyConnecting
-                    ? "connecting..."
-                    : `connect ${option.label}`}
-                </span>
-              </div>
-              {option.icon && (
-                <Image
-                  src={option.icon}
-                  alt={option.label}
-                  width={12}
-                  height={12}
-                  className="object-contain"
-                />
-              )}
-            </button>
+              walletType={option.walletType}
+              onSuccess={() => {
+                toast.success(`Connected to ${option.label}`);
+              }}
+            />
           );
         })}
       </div>


### PR DESCRIPTION
This PR decouples the wallet connect buttons from the `WalletFilter.tsx` component - not only simplifying the `WalletFilter` component, but also making the wallet connect buttons a simple, reusable component.

The new `WalletConnectButton` can be used like so:
```ts
// 1. basic usage with EVM wallet type
  return (
    <WalletConnectButton 
      walletType={WalletType.REOWN_EVM}
    />

// 2. advanced usage with custom callbacks:

export const ConnectButtonWithCallbacks = () => {
  const handleSuccess = () => {
    console.log("Wallet connected successfully!");
    // do something actually useful here..
  };

  const handleError = (error: Error) => {
    console.error("Connection failed:", error);
    // custom error handling
  };

  return (
    <WalletConnectButton 
      walletType={WalletType.REOWN_SOL}
      onSuccess={handleSuccess}
      onError={handleError}
    />
  );
};
```

I will raise PRs branched off this to refactor the other usages of similar buttons to use this version.