### PR TITLE
feat: render earn cards when full table width cannot fit

### DIFF
--- a/src/app/(dapp)/earn/page.tsx
+++ b/src/app/(dapp)/earn/page.tsx
@@ -373,7 +373,7 @@ export default function EarnPage() {
           ) : (
             <>
               {/* Mobile Cards View */}
-              <div className="block md:hidden">
+              <div className="block 2xl:hidden">
                 <EarnCards
                   type={activeTab}
                   data={paginatedData}
@@ -386,8 +386,8 @@ export default function EarnPage() {
                 />
               </div>
 
-              {/* Desktop Table View */}
-              <div className="hidden md:block">
+              {/* Desktop Table View - Only show when header and all columns fit properly */}
+              <div className="hidden 2xl:block">
                 <EarnTable
                   type={activeTab}
                   data={paginatedData}

--- a/src/app/(dapp)/earn/page.tsx
+++ b/src/app/(dapp)/earn/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 import ProtocolFilter from "@/components/ui/earning/ProtocolFilter";
+import SortDropdown from "@/components/ui/earning/SortDropdown";
 import { Input } from "@/components/ui/Input";
 import EarnTable from "@/components/ui/earning/EarnTable";
 import EarnCards from "@/components/ui/earning/EarnCards";
@@ -63,6 +64,7 @@ export default function EarnPage() {
     column: string;
     direction: "asc" | "desc";
   } | null>(null);
+  const [sortDropdownValue, setSortDropdownValue] = useState<string>("");
   const [selectedRowForModal, setSelectedRowForModal] = useState<
     EarnTableRow | DashboardTableRow | null
   >(null);
@@ -88,48 +90,76 @@ export default function EarnPage() {
     const filtered = filterEarnData(earnData, filters);
 
     if (sortConfig) {
-      const sortedEarnRows = [...filtered.earnRows].sort((a, b) => {
-        const aValue = a[sortConfig.column as keyof EarnTableRow];
-        const bValue = b[sortConfig.column as keyof EarnTableRow];
+      const sortEarnData = (data: EarnTableRow[]) => {
+        return [...data].sort((a, b) => {
+          // Handle multi-column sorting for dropdown options
+          if (sortDropdownValue === "apy-desc-tvl-desc") {
+            // Sort by APY first (desc), then by TVL (desc)
+            const apyDiff = b.apy - a.apy;
+            if (apyDiff !== 0) return apyDiff;
+            return b.tvl - a.tvl;
+          } else if (sortDropdownValue === "tvl-desc-apy-desc") {
+            // Sort by TVL first (desc), then by APY (desc)
+            const tvlDiff = b.tvl - a.tvl;
+            if (tvlDiff !== 0) return tvlDiff;
+            return b.apy - a.apy;
+          } else {
+            // Single column sorting
+            const aValue = a[sortConfig.column as keyof EarnTableRow];
+            const bValue = b[sortConfig.column as keyof EarnTableRow];
 
-        if (typeof aValue === "number" && typeof bValue === "number") {
-          return sortConfig.direction === "asc"
-            ? aValue - bValue
-            : bValue - aValue;
-        }
+            if (typeof aValue === "number" && typeof bValue === "number") {
+              return sortConfig.direction === "asc"
+                ? aValue - bValue
+                : bValue - aValue;
+            }
 
-        const aStr = String(aValue).toLowerCase();
-        const bStr = String(bValue).toLowerCase();
-        return sortConfig.direction === "asc"
-          ? aStr.localeCompare(bStr)
-          : bStr.localeCompare(aStr);
-      });
+            const aStr = String(aValue).toLowerCase();
+            const bStr = String(bValue).toLowerCase();
+            return sortConfig.direction === "asc"
+              ? aStr.localeCompare(bStr)
+              : bStr.localeCompare(aStr);
+          }
+        });
+      };
 
-      const sortedDashboardRows = [...filtered.dashboardRows].sort((a, b) => {
-        const aValue = a[sortConfig.column as keyof DashboardTableRow];
-        const bValue = b[sortConfig.column as keyof DashboardTableRow];
+      const sortDashboardData = (data: DashboardTableRow[]) => {
+        return [...data].sort((a, b) => {
+          // Dashboard rows don't have TVL, so multi-column sorting only applies to APY
+          if (
+            sortDropdownValue === "apy-desc-tvl-desc" ||
+            sortDropdownValue === "tvl-desc-apy-desc"
+          ) {
+            // For dashboard, just sort by APY since TVL doesn't exist
+            return b.apy - a.apy;
+          } else {
+            // Single column sorting
+            const aValue = a[sortConfig.column as keyof DashboardTableRow];
+            const bValue = b[sortConfig.column as keyof DashboardTableRow];
 
-        if (typeof aValue === "number" && typeof bValue === "number") {
-          return sortConfig.direction === "asc"
-            ? aValue - bValue
-            : bValue - aValue;
-        }
+            if (typeof aValue === "number" && typeof bValue === "number") {
+              return sortConfig.direction === "asc"
+                ? aValue - bValue
+                : bValue - aValue;
+            }
 
-        const aStr = String(aValue).toLowerCase();
-        const bStr = String(bValue).toLowerCase();
-        return sortConfig.direction === "asc"
-          ? aStr.localeCompare(bStr)
-          : bStr.localeCompare(aStr);
-      });
+            const aStr = String(aValue).toLowerCase();
+            const bStr = String(bValue).toLowerCase();
+            return sortConfig.direction === "asc"
+              ? aStr.localeCompare(bStr)
+              : bStr.localeCompare(aStr);
+          }
+        });
+      };
 
       return {
-        earnRows: sortedEarnRows,
-        dashboardRows: sortedDashboardRows,
+        earnRows: sortEarnData(filtered.earnRows),
+        dashboardRows: sortDashboardData(filtered.dashboardRows),
       };
     }
 
     return filtered;
-  }, [earnData, filters, sortConfig]);
+  }, [earnData, filters, sortConfig, sortDropdownValue]);
 
   const currentData =
     activeTab === "earn" ? filteredData.earnRows : filteredData.dashboardRows;
@@ -139,8 +169,31 @@ export default function EarnPage() {
     currentPage * ITEMS_PER_PAGE,
   );
 
-  const handleSort = (column: string, direction: "asc" | "desc") => {
+  const handleSortDropdownChange = (
+    column: string,
+    direction: "asc" | "desc",
+  ) => {
     setSortConfig({ column, direction });
+
+    if (column === "apy") {
+      setSortDropdownValue("apy-desc");
+    } else if (column === "tvl") {
+      setSortDropdownValue("tvl-desc");
+    }
+
+    setCurrentPage(1);
+  };
+
+  const handleMultiSort = (sortValue: string) => {
+    setSortDropdownValue(sortValue);
+
+    // Set sortConfig for the primary column
+    if (sortValue === "apy-desc-tvl-desc") {
+      setSortConfig({ column: "apy", direction: "desc" });
+    } else if (sortValue === "tvl-desc-apy-desc") {
+      setSortConfig({ column: "tvl", direction: "desc" });
+    }
+
     setCurrentPage(1);
   };
 
@@ -251,13 +304,26 @@ export default function EarnPage() {
               </ToggleGroup>
             </div>
 
-            {/* Right Side: Protocol Filter and Asset Input */}
+            {/* Right Side: Protocol Filter, Sort Dropdown, and Asset Input */}
             <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center xl:shrink-0">
-              <ProtocolFilter
-                protocols={availableProtocols}
-                selectedProtocols={filters.protocols}
-                onSelectionChange={handleProtocolChange}
-              />
+              {/* Protocol Filter and Sort Dropdown - side by side on mobile */}
+              <div className="flex gap-4 w-full sm:w-auto">
+                <div className="flex-1 sm:flex-none">
+                  <ProtocolFilter
+                    protocols={availableProtocols}
+                    selectedProtocols={filters.protocols}
+                    onSelectionChange={handleProtocolChange}
+                  />
+                </div>
+                <div className="flex-1 sm:flex-none">
+                  <SortDropdown
+                    value={sortDropdownValue}
+                    onSortChange={handleSortDropdownChange}
+                    onMultiSort={handleMultiSort}
+                    className="w-full sm:w-32"
+                  />
+                </div>
+              </div>
 
               <Input
                 placeholder="filter by asset (e.g., ETH, BTC)"
@@ -325,7 +391,6 @@ export default function EarnPage() {
                 <EarnTable
                   type={activeTab}
                   data={paginatedData}
-                  onSort={handleSort}
                   onDetails={handleDetails}
                   currentPage={currentPage}
                   totalPages={totalPages}

--- a/src/components/ui/earning/EarnTable.tsx
+++ b/src/components/ui/earning/EarnTable.tsx
@@ -6,7 +6,6 @@ import { EarnTableRow, DashboardTableRow, EarnTableType } from "@/types/earn";
 import { Button } from "@/components/ui/Button";
 import BrandedButton from "@/components/ui/BrandedButton";
 import Image from "next/image";
-import { ScrollArea, ScrollBar } from "@/components/ui/ScrollArea";
 import { chains } from "@/config/chains";
 
 interface EarnTableProps {
@@ -117,121 +116,112 @@ const EarnTable: React.FC<EarnTableProps> = ({
 
   return (
     <div className="w-full">
-      <ScrollArea className="w-full h-auto">
-        <div className="min-w-[900px] w-full">
-          <table className="w-full min-w-[900px]">
-            <thead className="bg-zinc-800/90 border-b border-[#27272A]">
-              <tr>
-                <th className={cn(tableHeaderClass, "pl-6")}>protocol</th>
-                <th className={tableHeaderClass}>market/vault</th>
-                <th className={tableHeaderClass}>assets</th>
-                <th className={tableHeaderClass}>chains</th>
-                {type === "dashboard" && (
+      <div className="w-full overflow-hidden">
+        <table className="w-full">
+          <thead className="bg-zinc-800/90 border-b border-[#27272A]">
+            <tr>
+              <th className={cn(tableHeaderClass, "pl-6")}>protocol</th>
+              <th className={tableHeaderClass}>market/vault</th>
+              <th className={tableHeaderClass}>assets</th>
+              <th className={tableHeaderClass}>chains</th>
+              {type === "dashboard" && (
+                <>
+                  <th className={tableHeaderClass}>position</th>
+                  <th className={tableHeaderClass}>balance</th>
+                </>
+              )}
+              {type === "earn" && <th className={tableHeaderClass}>tvl</th>}
+              <th className={tableHeaderClass}>apy</th>
+              <th className={tableHeaderClass}>details</th>
+            </tr>
+          </thead>
+          <tbody className="bg-[#18181B] divide-y divide-[#27272A]">
+            {data.map((row) => (
+              <tr key={row.id} className="hover:bg-[#1C1C1F] transition-colors">
+                <td className="px-4 py-3 pl-6">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full overflow-hidden flex items-center justify-center">
+                      <Image
+                        src={row.protocolIcon}
+                        alt={row.protocol}
+                        width={32}
+                        height={32}
+                        className="object-contain"
+                      />
+                    </div>
+                    <span className="text-[#FAFAFA] font-semibold">
+                      {row.protocol}
+                    </span>
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 flex items-center justify-center">
+                      <Image
+                        src={row.marketVaultIcon}
+                        alt={row.marketVault}
+                        width={28}
+                        height={28}
+                        className="object-contain"
+                      />
+                    </div>
+                    <span className="text-[#FAFAFA] text-sm font-semibold">
+                      {row.marketVault}
+                    </span>
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <AssetIcons assets={row.assets} assetIcons={row.assetIcons} />
+                </td>
+                <td className="px-4 py-3">
+                  <ChainIcons
+                    chains={row.supportedChains}
+                    chainIcons={row.supportedChainIcons}
+                  />
+                </td>
+                {type === "dashboard" && "position" in row && (
                   <>
-                    <th className={tableHeaderClass}>position</th>
-                    <th className={tableHeaderClass}>balance</th>
-                  </>
-                )}
-                {type === "earn" && <th className={tableHeaderClass}>tvl</th>}
-                <th className={tableHeaderClass}>apy</th>
-                <th className={tableHeaderClass}>details</th>
-              </tr>
-            </thead>
-            <tbody className="bg-[#18181B] divide-y divide-[#27272A]">
-              {data.map((row) => (
-                <tr
-                  key={row.id}
-                  className="hover:bg-[#1C1C1F] transition-colors"
-                >
-                  <td className="px-4 py-3 pl-6">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full overflow-hidden flex items-center justify-center">
-                        <Image
-                          src={row.protocolIcon}
-                          alt={row.protocol}
-                          width={32}
-                          height={32}
-                          className="object-contain"
-                        />
-                      </div>
-                      <span className="text-[#FAFAFA] font-semibold">
-                        {row.protocol}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 flex items-center justify-center">
-                        <Image
-                          src={row.marketVaultIcon}
-                          alt={row.marketVault}
-                          width={28}
-                          height={28}
-                          className="object-contain"
-                        />
-                      </div>
-                      <span className="text-[#FAFAFA] text-sm font-semibold">
-                        {row.marketVault}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">
-                    <AssetIcons
-                      assets={row.assets}
-                      assetIcons={row.assetIcons}
-                    />
-                  </td>
-                  <td className="px-4 py-3">
-                    <ChainIcons
-                      chains={row.supportedChains}
-                      chainIcons={row.supportedChainIcons}
-                    />
-                  </td>
-                  {type === "dashboard" && "position" in row && (
-                    <>
-                      <td className="px-4 py-3">
-                        <span className="text-[#FAFAFA] text-sm font-semibold">
-                          {row.position}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3">
-                        <div className="flex flex-col">
-                          <span className="text-[#FAFAFA] font-semibold font-mono">
-                            {row.balance.toFixed(4)}
-                          </span>
-                          <span className="text-[#A1A1AA] text-xs font-mono">
-                            {formatCurrency(row.balanceUsd)}
-                          </span>
-                        </div>
-                      </td>
-                    </>
-                  )}
-                  {type === "earn" && (
                     <td className="px-4 py-3">
-                      <span className="text-[#FAFAFA] font-semibold font-mono">
-                        {formatCurrency((row as EarnTableRow).tvl)}
+                      <span className="text-[#FAFAFA] text-sm font-semibold">
+                        {row.position}
                       </span>
                     </td>
-                  )}
+                    <td className="px-4 py-3">
+                      <div className="flex flex-col">
+                        <span className="text-[#FAFAFA] font-semibold font-mono">
+                          {row.balance.toFixed(4)}
+                        </span>
+                        <span className="text-[#A1A1AA] text-xs font-mono">
+                          {formatCurrency(row.balanceUsd)}
+                        </span>
+                      </div>
+                    </td>
+                  </>
+                )}
+                {type === "earn" && (
                   <td className="px-4 py-3">
-                    <span className="text-green-500 font-semibold font-mono">
-                      {formatAPY(row.apy)}
+                    <span className="text-[#FAFAFA] font-semibold font-mono">
+                      {formatCurrency((row as EarnTableRow).tvl)}
                     </span>
                   </td>
-                  <td className="px-4 py-3 pr-6">
-                    <BrandedButton
-                      buttonText={type === "dashboard" ? " view " : "details"}
-                      onClick={() => onDetails?.(row)}
-                      className="text-sm h-8 px-2"
-                    />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-        <ScrollBar orientation="horizontal" />
-      </ScrollArea>
+                )}
+                <td className="px-4 py-3">
+                  <span className="text-green-500 font-semibold font-mono">
+                    {formatAPY(row.apy)}
+                  </span>
+                </td>
+                <td className="px-4 py-3 pr-6">
+                  <BrandedButton
+                    buttonText={type === "dashboard" ? " view " : "details"}
+                    onClick={() => onDetails?.(row)}
+                    className="text-sm h-8 px-2"
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
 
       {/* Pagination */}
       {totalPages > 1 && (

--- a/src/components/ui/earning/EarnTable.tsx
+++ b/src/components/ui/earning/EarnTable.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import * as React from "react";
-import { useState } from "react";
-import { ChevronUpIcon, ChevronDownIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EarnTableRow, DashboardTableRow, EarnTableType } from "@/types/earn";
 import { Button } from "@/components/ui/Button";
@@ -14,7 +12,6 @@ import { chains } from "@/config/chains";
 interface EarnTableProps {
   type: EarnTableType;
   data: EarnTableRow[] | DashboardTableRow[];
-  onSort?: (column: string, direction: "asc" | "desc") => void;
   onDetails?: (row: EarnTableRow | DashboardTableRow) => void;
   currentPage: number;
   totalPages: number;
@@ -22,58 +19,6 @@ interface EarnTableProps {
   itemsPerPage: number;
   totalItems: number;
 }
-
-interface SortableHeaderProps {
-  children: React.ReactNode;
-  column: string;
-  onSort?: (column: string, direction: "asc" | "desc") => void;
-  sortDirection?: "asc" | "desc" | null;
-  className?: string;
-}
-
-const SortableHeader: React.FC<SortableHeaderProps> = ({
-  children,
-  column,
-  onSort,
-  sortDirection,
-  className,
-}) => {
-  const handleSort = () => {
-    if (!onSort) return;
-    const newDirection = sortDirection === "asc" ? "desc" : "asc";
-    onSort(column, newDirection);
-  };
-
-  return (
-    <th
-      className={cn(
-        "px-4 py-2 text-left text-sm font-semibold text-zinc-300 lowercase tracking-wider cursor-pointer hover:text-zinc-50 transition-colors",
-        className,
-      )}
-      onClick={handleSort}
-    >
-      <div className="flex items-center gap-1">
-        {children}
-        {onSort && (
-          <div className="flex flex-col">
-            <ChevronUpIcon
-              className={cn(
-                "h-3 w-3",
-                sortDirection === "asc" ? "text-amber-500" : "text-zinc-400",
-              )}
-            />
-            <ChevronDownIcon
-              className={cn(
-                "h-3 w-3 -mt-1",
-                sortDirection === "desc" ? "text-amber-500" : "text-zinc-400",
-              )}
-            />
-          </div>
-        )}
-      </div>
-    </th>
-  );
-};
 
 const AssetIcons: React.FC<{ assets: string[]; assetIcons: string[] }> = ({
   assets,
@@ -143,7 +88,6 @@ const ChainIcons: React.FC<{ chains: string[]; chainIcons: string[] }> = ({
 const EarnTable: React.FC<EarnTableProps> = ({
   type,
   data,
-  onSort,
   onDetails,
   currentPage,
   totalPages,
@@ -151,15 +95,6 @@ const EarnTable: React.FC<EarnTableProps> = ({
   itemsPerPage,
   totalItems,
 }) => {
-  const [sortColumn, setSortColumn] = useState<string | null>(null);
-  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
-
-  const handleSort = (column: string, direction: "asc" | "desc") => {
-    setSortColumn(column);
-    setSortDirection(direction);
-    onSort?.(column, direction);
-  };
-
   const formatCurrency = (value: number) => {
     if (value === 0) return "$0";
     if (value >= 1e9) return `$${(value / 1e9).toFixed(1)}B`;
@@ -194,33 +129,11 @@ const EarnTable: React.FC<EarnTableProps> = ({
                 {type === "dashboard" && (
                   <>
                     <th className={tableHeaderClass}>position</th>
-                    <SortableHeader
-                      column="balance"
-                      onSort={handleSort}
-                      sortDirection={
-                        sortColumn === "balance" ? sortDirection : null
-                      }
-                    >
-                      balance
-                    </SortableHeader>
+                    <th className={tableHeaderClass}>balance</th>
                   </>
                 )}
-                {type === "earn" && (
-                  <SortableHeader
-                    column="tvl"
-                    onSort={handleSort}
-                    sortDirection={sortColumn === "tvl" ? sortDirection : null}
-                  >
-                    tvl
-                  </SortableHeader>
-                )}
-                <SortableHeader
-                  column="apy"
-                  onSort={handleSort}
-                  sortDirection={sortColumn === "apy" ? sortDirection : null}
-                >
-                  apy
-                </SortableHeader>
+                {type === "earn" && <th className={tableHeaderClass}>tvl</th>}
+                <th className={tableHeaderClass}>apy</th>
                 <th className={tableHeaderClass}>details</th>
               </tr>
             </thead>

--- a/src/components/ui/earning/ProtocolFilter.tsx
+++ b/src/components/ui/earning/ProtocolFilter.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { ChevronDownIcon } from "lucide-react";
 import { Button } from "../Button";
+import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -23,6 +24,7 @@ const ProtocolFilter: React.FC<ProtocolFilterProps> = ({
   protocols,
   selectedProtocols,
   onSelectionChange,
+  className,
 }) => {
   const handleCheckedChange = (protocolId: string, checked: boolean) => {
     if (checked) {
@@ -47,7 +49,10 @@ const ProtocolFilter: React.FC<ProtocolFilterProps> = ({
       <DropdownMenuTrigger asChild className="h-8">
         <Button
           variant="outline"
-          className="justify-between min-w-[140px] border-[#27272A] text-[#FAFAFA] hover:bg-[#27272A] bg-[#18181B]"
+          className={cn(
+            "justify-between w-full sm:min-w-[140px] border-[#27272A] text-[#FAFAFA] hover:bg-[#27272A] bg-[#18181B]",
+            className,
+          )}
         >
           <span className="truncate">{displayText}</span>
           <ChevronDownIcon className="h-4 w-4 opacity-50" />

--- a/src/components/ui/earning/SortDropdown.tsx
+++ b/src/components/ui/earning/SortDropdown.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
+import { Button } from "@/components/ui/Button";
+import { ChevronDownIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface SortOption {
+  label: string;
+  value: string;
+  column: string;
+  direction: "asc" | "desc";
+}
+
+interface SortDropdownProps {
+  value?: string;
+  onSortChange: (column: string, direction: "asc" | "desc") => void;
+  onMultiSort?: (sortValue: string) => void;
+  className?: string;
+}
+
+const sortOptions: SortOption[] = [
+  { label: "apy", value: "apy-desc", column: "apy", direction: "desc" },
+  { label: "tvl", value: "tvl-desc", column: "tvl", direction: "desc" },
+  {
+    label: "apy, tvl",
+    value: "apy-desc-tvl-desc",
+    column: "apy",
+    direction: "desc",
+  },
+  {
+    label: "tvl, apy",
+    value: "tvl-desc-apy-desc",
+    column: "tvl",
+    direction: "desc",
+  },
+];
+
+const SortDropdown: React.FC<SortDropdownProps> = ({
+  value,
+  onSortChange,
+  onMultiSort,
+  className,
+}) => {
+  const currentSort = value
+    ? sortOptions.find((option) => option.value === value)
+    : null;
+
+  const handleSortSelect = (option: SortOption) => {
+    if (option.value.includes("-") && option.value.split("-").length > 2) {
+      // Multi-column sort
+      onMultiSort?.(option.value);
+    } else {
+      // Single column sort
+      onSortChange(option.column, option.direction);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            "h-8 border-[#27272A] bg-[#18181B] text-[#FAFAFA] hover:bg-[#27272A] focus:border-amber-500/80 focus:ring-amber-500/80 justify-between",
+            className,
+          )}
+        >
+          <span className="text-sm text-left">
+            {currentSort ? currentSort.label : "sort by"}
+          </span>
+          <ChevronDownIcon className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="w-32 bg-[#18181B] border-[#27272A]"
+      >
+        {sortOptions.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            onClick={() => handleSortSelect(option)}
+            className="text-[#FAFAFA] hover:bg-[#27272A] cursor-pointer"
+          >
+            <span className="text-sm">{option.label}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default SortDropdown;


### PR DESCRIPTION
This PR builds on top of https://github.com/altverseweb3/site/pull/172, please see https://github.com/altverseweb3/site/commit/3caff3241f60855d2436b7cb19d4eca764b2bee3 for changes on top.

The table will no longer be displayed unless every single column can be comfortably displayed AND the full earn header can be displayed in a single row. 

There is nothing new in practice to display from a UI perspective.

Additionally, the volume of changes in the referenced commit is far smaller than it seems, they are mostly there because of linting, the most significant ones are here:

<img width="1291" height="565" alt="image" src="https://github.com/user-attachments/assets/630bad51-6477-4bee-b54e-3ddc0eaa0e65" />
<img width="1381" height="173" alt="image" src="https://github.com/user-attachments/assets/eb09db3c-ee4a-4deb-9847-ceaf7cef67c7" />


