### PR TITLE
bugfix: enforce evm wallet connection and receive address for earn

### DIFF
--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -43,6 +43,8 @@ import useWeb3Store, {
   useDestinationToken,
   useTransactionDetails,
   useIsWalletTypeConnected,
+  useSetReceiveAddress,
+  useWalletByType,
 } from "@/store/web3Store";
 import useVaultDepositStore, {
   useActiveVaultDepositProcess,
@@ -74,6 +76,8 @@ const DepositModal: React.FC<DepositModalProps> = ({
   const sourceChain = useSourceChain();
   const destinationChain = useDestinationChain();
   const transactionDetails = useTransactionDetails();
+  const setReceiveAddress = useSetReceiveAddress();
+  const evmWallet = useWalletByType(WalletType.REOWN_EVM);
 
   // Form state
   const [selectedSwapChain, setSelectedSwapChain] = useState<string>("");
@@ -814,6 +818,15 @@ const DepositModal: React.FC<DepositModalProps> = ({
   useEffect(() => {
     if (!isMounted) return;
 
+    if (isOpen && evmWallet?.address) {
+      console.log("Setting receiveAddress to EVM wallet:", evmWallet.address);
+      setReceiveAddress(evmWallet.address);
+    } else if (isOpen && !evmWallet?.address) {
+      // Clear receiveAddress if no EVM wallet is connected
+      console.log("Clearing receiveAddress - no EVM wallet connected");
+      setReceiveAddress(null);
+    }
+
     const wasOpen = prevIsOpenRef.current;
     const isOpening = isOpen && !wasOpen; // Modal is transitioning from closed to open
     const isClosing = !isOpen && wasOpen; // Modal is transitioning from open to closed
@@ -846,7 +859,15 @@ const DepositModal: React.FC<DepositModalProps> = ({
         cancelProcess(activeProcess.id);
       }
     }
-  }, [isOpen, vault, isMounted, activeProcess, cancelProcess]);
+  }, [
+    isOpen,
+    vault,
+    isMounted,
+    activeProcess,
+    cancelProcess,
+    evmWallet,
+    setReceiveAddress,
+  ]);
 
   // Vault shares conversion rate effect
   useEffect(() => {

--- a/src/components/ui/earning/EtherFiModal.tsx
+++ b/src/components/ui/earning/EtherFiModal.tsx
@@ -11,7 +11,6 @@ import {
   DialogTitle,
 } from "@/components/ui/StyledDialog";
 import { Button } from "@/components/ui/Button";
-import { ConnectWalletModal } from "@/components/ui/ConnectWalletModal";
 import DepositModal from "@/components/ui/earning/DepositModal";
 import { EarnTableRow, DashboardTableRow } from "@/types/earn";
 import { EtherFiVault } from "@/config/etherFi";
@@ -20,6 +19,7 @@ import { WalletType } from "@/types/web3";
 import { useChainSwitch } from "@/utils/swap/walletMethods";
 import { getChainById } from "@/config/chains";
 import { formatCurrency } from "@/utils/ui/uiHelpers";
+import WalletConnectButton from "@/components/ui/WalletConnectButton";
 
 interface EtherFiModalProps {
   isOpen: boolean;
@@ -37,14 +37,10 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
   const sourceChain = getChainById("ethereum");
 
   const isEvmWalletConnected = useIsWalletTypeConnected(WalletType.REOWN_EVM);
-  const isSuiWalletConnected = useIsWalletTypeConnected(WalletType.SUIET_SUI);
-  const isSolanaWalletConnected = useIsWalletTypeConnected(
-    WalletType.REOWN_SOL,
-  );
+
   const { switchToChain } = useChainSwitch(sourceChain);
 
-  const isWalletConnected =
-    isEvmWalletConnected || isSuiWalletConnected || isSolanaWalletConnected;
+  const isWalletConnected = isEvmWalletConnected;
 
   if (!data) return null;
 
@@ -221,14 +217,12 @@ const EtherFiModal: React.FC<EtherFiModalProps> = ({
                 deposit
               </Button>
             ) : (
-              <ConnectWalletModal
-                trigger={
-                  <Button className="bg-green-500/25 hover:bg-green-500/50 hover:text-green-400 text-green-500 border-green-500/30 border rounded-lg py-3 font-semibold">
-                    <Wallet className="h-4 w-4 mr-1" />
-                    connect
-                  </Button>
-                }
+              <WalletConnectButton
+                walletType={WalletType.REOWN_EVM}
+                size="md"
+                className="border rounded-lg font-semibold bg-amber-500/25 border-[#61410B] D!text-sm !px-4 !h-10 !py-0 !justify-center"
                 onSuccess={handleWalletConnectSuccess}
+                showIcon={false}
               />
             )}
             <Button


### PR DESCRIPTION
This PR resolves a critical bug where the `receiveAddress` for Sui -> EVM earn swaps was using the Sui address as the `receiveAddress`.

I have put in two steps to avoid this bug:

**1. Enforce EVM connection to proceed with vault deposit in `EtherFiModal`**
- Modified an erroneous conditional which checked for any connected wallet type rather than just EVM
- Use the `WalletConnectButton` to make users connect to metamask
<img width="1054" height="1266" alt="Screenshot 2025-07-26 at 12 45 25 pm" src="https://github.com/user-attachments/assets/47f4dbc1-a4ff-4530-879f-1f5edb76c4a9" />



**2. Strictly set the receive address to the connected EVM address in the `DepositModal`**
- In the mounting `useEffect` hook, I call the `useSetReceiveAddress` function from the `web3Store` to ensure that the`receiveAddress` is set to the EVM wallet address.