### PR TITLE
bugfix: receive address enforcement

### DIFF
--- a/src/utils/swap/mayanSwapMethods.ts
+++ b/src/utils/swap/mayanSwapMethods.ts
@@ -313,7 +313,6 @@ export async function executeSuiSwap({
 }): Promise<string> {
   try {
     if (!quote) throw new Error("Invalid quote");
-
     const suiClient = new SuiClient({ url: getFullnodeUrl("mainnet") });
 
     // Get the transaction block from Mayan SDK

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -1175,6 +1175,25 @@ export function useTokenTransfer(
       return;
     }
 
+    if (!receiveAddress) {
+      switch (options.destinationChain.walletType) {
+        case WalletType.REOWN_SOL:
+          throw new Error(
+            "Please connect a Solana wallet or provide a receive address",
+          );
+        case WalletType.SUIET_SUI:
+          throw new Error(
+            "Please connect a Sui wallet or provide a receive address",
+          );
+        case WalletType.REOWN_EVM:
+          throw new Error(
+            "Please connect an EVM wallet or provide a receive address",
+          );
+        default:
+          throw new Error("Please provide a receive address for the transfer");
+      }
+    }
+
     // Check if wallet is compatible with source chain
     if (!isWalletCompatible) {
       const requiredWalletType = options.sourceChain.walletType;
@@ -1316,7 +1335,7 @@ export function useTokenTransfer(
         result = await executeSolanaSwap({
           quote: quotes[0],
           swapperAddress: requiredWallet!.address,
-          destinationAddress: receiveAddress || requiredWallet!.address,
+          destinationAddress: receiveAddress,
           sourceToken: sourceToken!.address,
           amount,
           referrerAddresses: {
@@ -1337,7 +1356,7 @@ export function useTokenTransfer(
         result = await executeSuiSwap({
           quote: quotes[0],
           swapperAddress: requiredWallet!.address,
-          destinationAddress: receiveAddress || requiredWallet!.address,
+          destinationAddress: receiveAddress,
           referrerAddresses: {
             solana: REFERRER_SOL,
             evm: REFERRER_EVM,
@@ -1353,7 +1372,7 @@ export function useTokenTransfer(
         result = await executeEvmSwap({
           quote: quotes[0],
           swapperAddress: requiredWallet!.address,
-          destinationAddress: receiveAddress || requiredWallet!.address,
+          destinationAddress: receiveAddress,
           sourceToken: sourceToken!.address,
           amount,
           referrerAddresses: {


### PR DESCRIPTION
branch off #179, will rebase

The only file relevant for this PR is `walletMethods.ts` where the root cause is addressed.

This PR resolves the root cause associated with the `sourceChain` required wallet address being used as the `receiveAddress` in swaps. This was first discovered in Earn, but was later found to be prevalent in all swaps.

The core issue was an erroneous OR conditional which would use set the swap transaction `receiveAddress` like so:

```ts
destinationAddress: receiveAddress || requiredWallet!.address,
```

This is likely due to confusion about what `requiredWallet` represents - it is the required SOURCE wallet not the destination wallet. We don't enforce destination wallet connections (except for EVM in Earn) as we provide functionality for users to enter a manual destination address in the transaction details.

Now, when a `receiveAddress` is not set users will simply get an error toast notifying them to connect the required destination wallet or manually set the address in the transaction details.