### PR TITLE
feat: added chain picker for aave frontend

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import BorrowComponent from "@/components/ui/lending/BorrowComponent";
 import PoweredByAave from "@/components/ui/lending/PoweredByAave";
 import SupplyBorrowMetricsHeaders from "@/components/ui/lending/SupplyBorrowMetricsHeaders";
@@ -11,26 +10,89 @@ import {
   useIsWalletTypeConnected,
 } from "@/store/web3Store";
 import { WalletType } from "@/types/web3";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
+import Image from "next/image";
+import { getTokenGradient } from "@/utils/ui/uiHelpers";
+import { chainList } from "@/config/chains";
 
 const BorrowLendComponent: React.FC = () => {
   const [activeTab, setActiveTab] = useState("borrow");
+  const [selectedChain, setSelectedChain] = useState<string>(""); // Single chain selection
+  const [isMounted, setIsMounted] = useState(false);
   const setActiveSwapSection = useSetActiveSwapSection();
   const isWalletConnected = useIsWalletTypeConnected(WalletType.REOWN_EVM);
+  const aaveSupportedChains = chainList.filter((chain) => chain.aaveSupported);
 
   useEffect(() => {
     setActiveSwapSection("lend");
+    setIsMounted(true);
   }, [setActiveSwapSection]);
+
+  const handleChainChange = (chainId: string) => {
+    setSelectedChain(chainId);
+  };
+
+  // Don't render anything until component is mounted
+  if (!isMounted) {
+    return (
+      <div className="w-full">
+        <div className="text-center py-16 md:py-24 px-4 md:px-8">
+          <div className="animate-pulse">
+            <div className="h-4 bg-zinc-700 rounded w-1/2 mx-auto mb-6"></div>
+            <div className="h-12 bg-zinc-700 rounded w-1/4 mx-auto"></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full">
       {isWalletConnected ? (
         <>
+          {/* Chain Selection - Single Selection */}
+          <div className="mb-6">
+            <ToggleGroup
+              type="single"
+              value={selectedChain}
+              onValueChange={handleChainChange}
+              variant="outline"
+              className="justify-start flex-wrap"
+            >
+              {aaveSupportedChains.map((chain) => {
+                const isSelected = selectedChain === chain.id;
+                return (
+                  <ToggleGroupItem
+                    key={chain.id}
+                    value={chain.id}
+                    aria-label={`Toggle ${chain.name}`}
+                    className="relative h-8 w-8 p-1 overflow-hidden"
+                  >
+                    <Image
+                      src={isSelected ? chain.brandedIcon : chain.icon}
+                      alt={chain.name}
+                      width={16}
+                      height={16}
+                      className="object-contain relative z-10"
+                    />
+                    {isSelected && (
+                      <div
+                        className={`pointer-events-none absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-1/2 -translate-y-1/2 overflow-visible rounded-full bg-gradient-to-r ${getTokenGradient(
+                          chain.chainTokenSymbol,
+                        )} opacity-70 blur-[20px] filter`}
+                      />
+                    )}
+                  </ToggleGroupItem>
+                );
+              })}
+            </ToggleGroup>
+          </div>
+
           <SupplyBorrowMetricsHeaders
             activeTab={activeTab}
             onTabChange={setActiveTab}
           />
           {activeTab === "supply" ? <SupplyComponent /> : <BorrowComponent />}
-
           <PoweredByAave />
         </>
       ) : (
@@ -53,4 +115,5 @@ const BorrowLendComponent: React.FC = () => {
     </div>
   );
 };
+
 export default BorrowLendComponent;

--- a/src/components/ui/lending/BorrowModal.tsx
+++ b/src/components/ui/lending/BorrowModal.tsx
@@ -150,6 +150,7 @@ const BorrowModal: FC<BorrowModalProps> = ({
     l2: false,
     gasDrop: 0,
     walletType: WalletType.REOWN_EVM,
+    aaveSupported: true,
   };
 
   // Handle client-side mounting

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -34,6 +34,7 @@ export const chains: Record<string, Chain> = {
     l2: false,
     gasDrop: 0.05,
     walletType: WalletType.REOWN_EVM,
+    aaveSupported: true,
   },
   arbitrum: {
     id: "arbitrum",
@@ -70,6 +71,7 @@ export const chains: Record<string, Chain> = {
     l2: true,
     gasDrop: 0.01,
     walletType: WalletType.REOWN_EVM,
+    aaveSupported: true,
   },
   optimism: {
     id: "optimism",
@@ -109,6 +111,7 @@ export const chains: Record<string, Chain> = {
     l2: true,
     gasDrop: 0.01,
     walletType: WalletType.REOWN_EVM,
+    aaveSupported: true,
   },
   base: {
     id: "base",
@@ -140,6 +143,7 @@ export const chains: Record<string, Chain> = {
     l2: true,
     gasDrop: 0.01,
     walletType: WalletType.REOWN_EVM,
+    aaveSupported: true,
   },
   unichain: {
     id: "unichain",
@@ -180,6 +184,7 @@ export const chains: Record<string, Chain> = {
     l2: true,
     gasDrop: 0.01,
     walletType: WalletType.REOWN_EVM,
+    aaveSupported: false,
   },
   polygon: {
     id: "polygon",
@@ -206,6 +211,7 @@ export const chains: Record<string, Chain> = {
     l2: false,
     gasDrop: 0.2,
     walletType: WalletType.REOWN_EVM,
+    aaveSupported: true,
   },
   "binance-smart-chain": {
     id: "binance-smart-chain",
@@ -237,6 +243,7 @@ export const chains: Record<string, Chain> = {
     l2: false,
     gasDrop: 0.02,
     walletType: WalletType.REOWN_EVM,
+    aaveSupported: true,
   },
   avalanche: {
     id: "avalanche",
@@ -271,6 +278,7 @@ export const chains: Record<string, Chain> = {
     l2: false,
     gasDrop: 0.1,
     walletType: WalletType.REOWN_EVM,
+    aaveSupported: true,
   },
   sui: {
     id: "sui",
@@ -300,6 +308,7 @@ export const chains: Record<string, Chain> = {
     l2: false,
     gasDrop: 0.01,
     walletType: WalletType.SUIET_SUI,
+    aaveSupported: false,
   },
   solana: {
     id: "solana",
@@ -331,6 +340,7 @@ export const chains: Record<string, Chain> = {
     gasDrop: 0.01,
     l2: false,
     walletType: WalletType.REOWN_SOL,
+    aaveSupported: false,
   },
 };
 

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -86,6 +86,7 @@ export type Chain = {
   l2: boolean;
   gasDrop: number;
   walletType: WalletType;
+  aaveSupported: boolean;
 };
 
 export type SectionKey = "swap" | "earn" | "lend";


### PR DESCRIPTION
This PR adds the chain picker from Earn to show which chain the user wants to load their current/available positions on Aave.

Note this PR is simply for the UI component - it is not yet functional.

This selected chain state with be tied to the web3Store and directly influence the users metamask wallet state when a chain is switched, and reload the aave assets.