### PR TITLE
feat: added aave chain to web3Store

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -4,30 +4,53 @@ import BorrowComponent from "@/components/ui/lending/BorrowComponent";
 import PoweredByAave from "@/components/ui/lending/PoweredByAave";
 import SupplyBorrowMetricsHeaders from "@/components/ui/lending/SupplyBorrowMetricsHeaders";
 import SupplyComponent from "@/components/ui/lending/SupplyComponent";
+import WalletConnectButton from "@/components/ui/WalletConnectButton";
 import React, { useState, useEffect } from "react";
-import { useSetActiveSwapSection } from "@/store/web3Store";
+import {
+  useSetActiveSwapSection,
+  useIsWalletTypeConnected,
+} from "@/store/web3Store";
+import { WalletType } from "@/types/web3";
 
 const BorrowLendComponent: React.FC = () => {
   const [activeTab, setActiveTab] = useState("borrow");
   const setActiveSwapSection = useSetActiveSwapSection();
+  const isWalletConnected = useIsWalletTypeConnected(WalletType.REOWN_EVM);
 
   useEffect(() => {
     setActiveSwapSection("lend");
   }, [setActiveSwapSection]);
 
   return (
-    <div className="flex h-full w-full items-start justify-center sm:pt-[6vh] pt-[2vh] min-h-[500px]">
-      <div className="w-full">
-        <SupplyBorrowMetricsHeaders
-          activeTab={activeTab}
-          onTabChange={setActiveTab}
-        />
-        {activeTab === "supply" ? <SupplyComponent /> : <BorrowComponent />}
+    <div className="w-full">
+      {isWalletConnected ? (
+        <>
+          <SupplyBorrowMetricsHeaders
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+          />
+          {activeTab === "supply" ? <SupplyComponent /> : <BorrowComponent />}
 
-        <PoweredByAave />
-      </div>
+          <PoweredByAave />
+        </>
+      ) : (
+        <>
+          <div className="text-center py-16 md:py-24 px-4 md:px-8">
+            <p className="text-zinc-400 mb-6 px-2 sm:px-8 md:px-16 lg:px-20 text-sm md:text-lg max-w-3xl mx-auto leading-relaxed">
+              please connect an EVM wallet (metamask, etc.) to view and manage
+              your positions.
+            </p>
+            <div className="flex justify-center">
+              <WalletConnectButton
+                className="w-1/4 text-center rounded-lg"
+                size="lg"
+                walletType={WalletType.REOWN_EVM}
+              />
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };
-
 export default BorrowLendComponent;

--- a/src/components/ui/lending/BorrowModal.tsx
+++ b/src/components/ui/lending/BorrowModal.tsx
@@ -145,11 +145,11 @@ const BorrowModal: FC<BorrowModalProps> = ({
     backgroundColor: "",
     fontColor: "",
     chainId: chainId,
+    mayanChainId: 2,
     decimals: 18,
     l2: false,
     gasDrop: 0,
     walletType: WalletType.REOWN_EVM,
-    mayanChainId: 0,
   };
 
   // Handle client-side mounting

--- a/src/store/storeVersion.ts
+++ b/src/store/storeVersion.ts
@@ -1,1 +1,1 @@
-export const STORE_VERSION = 5;
+export const STORE_VERSION = 6;

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -64,6 +64,8 @@ const useWeb3Store = create<Web3StoreState>()(
       tokenBalancesByWallet: {},
       tokenPricesUsd: {},
 
+      aaveChain: getChainByChainId(1),
+
       // New integration management methods
       getSwapStateForSection: () => {
         const key = get().activeSwapSection;
@@ -747,6 +749,10 @@ const useWeb3Store = create<Web3StoreState>()(
       setTokensLoading: (loading) => {
         set({ tokensLoading: loading });
       },
+
+      setAaveChain(chain: Chain) {
+        set({ aaveChain: chain });
+      },
     }),
     {
       name: "altverse-storage-web3",
@@ -821,6 +827,7 @@ const useWeb3Store = create<Web3StoreState>()(
             chainId: wallet.chainId,
           })),
           swapIntegrations: serializedIntegrations,
+          aaveChain: state.aaveChain,
         };
       },
     },

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -108,6 +108,8 @@ export interface Web3StoreState {
   tokenBalancesByWallet: Record<string, Record<string, string>>;
   tokenPricesUsd: Record<string, string>;
 
+  aaveChain: Chain;
+
   // Wallet actions (remain the same)
   addWallet: (wallet: WalletInfo) => void;
   removeWallet: (walletType: WalletType) => void;
@@ -147,6 +149,7 @@ export interface Web3StoreState {
   updateTokenPrices: (priceResults: TokenPriceResult[]) => void;
   addCustomToken: (token: Token) => void;
   setTokensLoading: (loading: boolean) => void;
+  setAaveChain: (chain: Chain) => void;
 }
 
 export enum Network {


### PR DESCRIPTION
This PR adds `aaveChain` as a new property to our web3Store. The point of this property is to track which chain a user wants to supply their supply/borrow positions in (currently just EVM networks). This will work similar to our persisted `sourceChain` and `destinationChain` for the persisted swap states.

This will be a persisted property.