### PR TITLE
bugfix: fixed infinite loop error with wallet connection

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -42,9 +42,10 @@ const BorrowLendComponent: React.FC = () => {
             </p>
             <div className="flex justify-center">
               <WalletConnectButton
-                className="w-1/4 text-center rounded-lg"
+                className="w-full md:w-1/4 text-center rounded-lg !flex !justify-center !items-center"
                 size="lg"
                 walletType={WalletType.REOWN_EVM}
+                showIcon={true}
               />
             </div>
           </div>


### PR DESCRIPTION
This PR resolves the infinite loop caused by incorrect `useEffect` hooks and wallet state monitoring. We now display the `WalletConnectButton` for Metamask when it is not connected.

Note I have removed many of the `useEffect` hooks from `BorrowComponent`, and they will not be added back in unless sufficient justification is provided. Monitoring of wallet chain state will need to be implemented correctly once this PR is approved.

## Screenshots

**Desktop**
<img width="3156" height="1522" alt="Screenshot 2025-07-27 at 8 21 07 pm" src="https://github.com/user-attachments/assets/a7ea0bb7-9a6d-402e-80f9-fdd6cc9355c9" />

**Mobile**
<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/def6ffba-ec5d-4de6-9f8c-a95aace2b6a5" />
