### PR TITLE
chore: drop barrel exports

### DIFF
--- a/src/utils/aave/index.ts
+++ b/src/utils/aave/index.ts
@@ -1,5 +1,0 @@
-// Barrel exports for Aave utilities
-export * from "./aaveSDK";
-export * from "./interact";
-export * from "./fetch";
-export * from "./format";


### PR DESCRIPTION
This PR removes the barrel export file, which is not necessary since all relevant functions in the files would be re-exported.