### PR TITLE
chore: change casing of aave unowned vars for consistency

### DIFF
--- a/src/components/ui/lending/BorrowComponent.tsx
+++ b/src/components/ui/lending/BorrowComponent.tsx
@@ -13,7 +13,7 @@ import {
   UserBorrowPosition,
   useAaveFetch,
 } from "@/utils/aave/fetch";
-import BorrowUnOwnedCard from "./BorrowUnownedCard";
+import BorrowUnownedCard from "./BorrowUnownedCard";
 import BorrowOwnedCard from "./BorrowOwnedCard";
 import { WalletType } from "@/types/web3";
 
@@ -285,7 +285,7 @@ const BorrowComponent: React.FC = () => {
                 borrowableReserves.map((reserve) => {
                   const borrowData = calculateAvailableToBorrow(reserve);
                   return (
-                    <BorrowUnOwnedCard
+                    <BorrowUnownedCard
                       key={`${reserve.asset}-${sourceChain.chainId}`}
                       asset={reserve}
                       availableToBorrow={borrowData.amount}

--- a/src/components/ui/lending/BorrowLend.tsx
+++ b/src/components/ui/lending/BorrowLend.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/lending/Accordion";
 import PoweredByAave from "@/components/ui/lending/PoweredByAave";
 import SupplyOwnedCard from "@/components/ui/lending/SupplyOwnedCard";
-import SupplyUnOwnedCard from "@/components/ui/lending/SupplyUnownedCard";
+import SupplyUnownedCard from "@/components/ui/lending/SupplyUnownedCard";
 import SupplyYourPositionsHeader from "@/components/ui/lending/SupplyAvailablePositionsHeader";
 
 const BorrowLend: React.FC = () => {
@@ -22,7 +22,7 @@ const BorrowLend: React.FC = () => {
             </AccordionTrigger>
             <AccordionContent>
               <SupplyOwnedCard asset={undefined} />
-              <SupplyUnOwnedCard />
+              <SupplyUnownedCard />
             </AccordionContent>
           </AccordionItem>
         </Accordion>

--- a/src/components/ui/lending/BorrowUnownedCard.tsx
+++ b/src/components/ui/lending/BorrowUnownedCard.tsx
@@ -14,7 +14,7 @@ import { BorrowModal } from "./BorrowModal";
 import { getChainByChainId } from "@/config/chains";
 import type { Token, Chain } from "@/types/web3";
 
-interface BorrowUnOwnedCardProps {
+interface BorrowUnownedCardProps {
   asset?: AaveReserveData;
   availableToBorrow?: string; // Amount user can borrow based on collateral
   availableToBorrowUSD?: string; // USD value of borrowable amount
@@ -25,7 +25,7 @@ interface BorrowUnOwnedCardProps {
   totalDebtUSD?: number;
 }
 
-const BorrowUnOwnedCard: FC<BorrowUnOwnedCardProps> = ({
+const BorrowUnownedCard: FC<BorrowUnownedCardProps> = ({
   asset,
   availableToBorrow = "0.00",
   availableToBorrowUSD = "0.00",
@@ -188,4 +188,4 @@ const BorrowUnOwnedCard: FC<BorrowUnOwnedCardProps> = ({
   );
 };
 
-export default BorrowUnOwnedCard;
+export default BorrowUnownedCard;

--- a/src/components/ui/lending/SupplyComponent.tsx
+++ b/src/components/ui/lending/SupplyComponent.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/lending/Accordion";
 import SupplyOwnedCard from "./SupplyOwnedCard";
 import SupplyYourPositionsHeader from "@/components/ui/lending/SupplyYourPositionsHeader";
-import SupplyUnOwnedCard from "./SupplyUnownedCard";
+import SupplyUnownedCard from "./SupplyUnownedCard";
 import SupplyAvailablePositionsHeader from "./SupplyAvailablePositionsHeader";
 import { ScrollBoxSupplyBorrowAssets } from "./ScrollBoxSupplyBorrowAssets";
 import { useSourceChain } from "@/store/web3Store";
@@ -280,7 +280,7 @@ const SupplyComponent: React.FC = () => {
 
               {hasData &&
                 aaveReserves.map((reserve) => (
-                  <SupplyUnOwnedCard
+                  <SupplyUnownedCard
                     key={`${reserve.asset}-${sourceChain.chainId}`}
                     asset={reserve}
                     userBalance={reserve.userBalanceFormatted || "0.00"}

--- a/src/components/ui/lending/SupplyUnownedCard.tsx
+++ b/src/components/ui/lending/SupplyUnownedCard.tsx
@@ -15,7 +15,7 @@ import { SupplyModal } from "./SupplyModal";
 import { getChainByChainId } from "@/config/chains";
 import type { Token, Chain } from "@/types/web3";
 
-interface SupplyUnOwnedCardProps {
+interface SupplyUnownedCardProps {
   asset?: AaveReserveData;
   userBalance?: string; // Optional user balance for this asset
   dollarAmount?: string; // Optional USD value of user balance
@@ -23,7 +23,7 @@ interface SupplyUnOwnedCardProps {
   onDetails?: (asset: AaveReserveData) => void;
 }
 
-const SupplyUnOwnedCard: FC<SupplyUnOwnedCardProps> = ({
+const SupplyUnownedCard: FC<SupplyUnownedCardProps> = ({
   asset,
   userBalance = "0",
   dollarAmount = "0.00",
@@ -171,4 +171,4 @@ const SupplyUnOwnedCard: FC<SupplyUnOwnedCardProps> = ({
   );
 };
 
-export default SupplyUnOwnedCard;
+export default SupplyUnownedCard;


### PR DESCRIPTION
This PR changes aave `UnOwned` vars to `Unowned` to match filenames.