### PR TITLE
feature: chain picker wallet sync

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -13,25 +13,33 @@ import {
 import { WalletType } from "@/types/web3";
 import { chainList } from "@/config/chains";
 import { AaveSDK } from "@/utils/aave/aaveSDK";
+import { useChainSwitch } from "@/utils/swap/walletMethods";
+import { getChainById } from "@/config/chains";
 
 const BorrowLendComponent: React.FC = () => {
   const [activeTab, setActiveTab] = useState("borrow");
-  const [selectedChain, setSelectedChain] = useState<string>(""); // Single chain selection
+  const [selectedChain, setSelectedChain] = useState<string>("");
   const setActiveSwapSection = useSetActiveSwapSection();
   const isWalletConnected = useIsWalletTypeConnected(WalletType.REOWN_EVM);
-
   const aaveLendingSupportedChains = chainList.filter((chain) =>
     AaveSDK.isChainSupported(chain.chainId),
   );
+
+  const { switchToChain } = useChainSwitch(aaveLendingSupportedChains[0]);
 
   useEffect(() => {
     setActiveSwapSection("lend");
   }, [setActiveSwapSection]);
 
-  const handleChainChange = (value: string | string[]) => {
+  const handleChainChange = async (value: string | string[]) => {
     const newValue = typeof value === "string" ? value : "";
     if (newValue !== "") {
       setSelectedChain(newValue);
+
+      const newChain = getChainById(newValue);
+      if (newChain) {
+        await switchToChain(newChain);
+      }
     }
   };
 


### PR DESCRIPTION
branch off #200, will rebase after approval and merge

Please see a62586f824a6fcbe08930ca6b21d600dde20224d for the changes relevant to this PR.

This PR syncs up the connect EVM wallet network with the `ChainPicker` component in the lending `page.tsx`.

This is done through use of the `switchToChain` function from the `useChainSwitch` hook. Works seamlessly and extremely fast without any unnecessary user prompt.

The next step is to fetch the Aave assets associated with the newly switched chain.