### PR TITLE
feat: enable asset details modal

### DIFF
--- a/src/components/ui/lending/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetailsModal.tsx
@@ -493,7 +493,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                 <div>
                   <span className="text-sm text-zinc-400">max LTV</span>
                   <div className="text-sm font-medium">
-                    {extendedDetails?.ltv || "Loading..."}
+                    {currentAsset.ltv || "N/A"}
                   </div>
                 </div>
                 <div>
@@ -501,7 +501,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                     liquidation threshold
                   </span>
                   <div className="text-sm font-medium">
-                    {extendedDetails?.liquidationThreshold || "Loading..."}
+                    {currentAsset.liquidationThreshold || "N/A"}
                   </div>
                 </div>
                 <div>
@@ -509,7 +509,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                     liquidation penalty
                   </span>
                   <div className="text-sm font-medium">
-                    {extendedDetails?.liquidationPenalty || "Loading..."}
+                    {currentAsset.liquidationPenalty || "N/A"}
                   </div>
                 </div>
               </div>

--- a/src/components/ui/lending/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetailsModal.tsx
@@ -158,7 +158,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogPortal>
         <DialogOverlay />
-        <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-2xl bg-[#18181B] border-[#27272A] text-white max-h-[90vh] overflow-y-auto">
+        <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-2xl bg-[#18181B] border-[#27272A] text-white max-h-[90vh] overflow-hidden flex flex-col rounded-lg">
           <DialogHeader className="pb-4">
             <div className="flex items-center gap-3">
               <TokenImage token={token} chain={chain} size="sm" />
@@ -180,7 +180,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
             </div>
           </DialogHeader>
 
-          <div className="space-y-6">
+          <div className="space-y-6 overflow-y-auto flex-1 scrollbar-hide">
             {isLoading && (
               <div className="flex items-center justify-center py-8">
                 <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-400"></div>

--- a/src/components/ui/lending/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetailsModal.tsx
@@ -158,34 +158,25 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogPortal>
         <DialogOverlay />
-        <DialogContent className="sm:max-w-2xl bg-[#131313] border-[#232326] text-white max-h-[90vh] overflow-y-auto">
-          <DialogHeader className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <div className="rounded-full overflow-hidden">
-                  <TokenImage token={token} chain={chain} size="sm" />
-                </div>
-                <div>
-                  <div className="flex items-center gap-2">
-                    <DialogTitle className="text-lg font-semibold">
-                      {currentAsset.symbol} Details
-                    </DialogTitle>
-                    <button
-                      onClick={() =>
-                        window.open(
-                          `${chain.explorerUrl}/token/${currentAsset.asset}`,
-                          "_blank",
-                        )
-                      }
-                      className="p-1 hover:bg-[#1A1A1A] rounded-md transition-colors"
-                      title="view on block explorer"
-                    >
-                      <ExternalLink className="h-3 w-3 text-zinc-400" />
-                    </button>
-                  </div>
-                  <p className="text-sm text-zinc-400">{currentAsset.name}</p>
-                </div>
-              </div>
+        <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-2xl bg-[#18181B] border-[#27272A] text-white max-h-[90vh] overflow-y-auto">
+          <DialogHeader className="pb-4">
+            <div className="flex items-center gap-3">
+              <TokenImage token={token} chain={chain} size="sm" />
+              <DialogTitle className="text-lg font-semibold">
+                {currentAsset.symbol.toLowerCase()} details
+              </DialogTitle>
+              <button
+                onClick={() =>
+                  window.open(
+                    `${chain.explorerUrl}/token/${currentAsset.asset}`,
+                    "_blank",
+                  )
+                }
+                className="p-1 hover:bg-[#1A1A1A] rounded-md transition-colors"
+                title="view on block explorer"
+              >
+                <ExternalLink className="h-3 w-3 text-zinc-400" />
+              </button>
             </div>
           </DialogHeader>
 
@@ -223,12 +214,12 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                       </div>
                       <div className="text-sm text-zinc-500 mb-1">
                         {formatBalance(metrics.reserveSize)}{" "}
-                        {currentAsset.symbol}
+                        {currentAsset.symbol.toLowerCase()}
                       </div>
                       <div className="text-xs text-zinc-400 mb-3">
                         {metrics.supplyCapFormatted !== "Unlimited"
-                          ? `of ${metrics.supplyCapFormatted} ${currentAsset.symbol} possible`
-                          : "Unlimited supply cap"}
+                          ? `of ${metrics.supplyCapFormatted} ${currentAsset.symbol.toLowerCase()} possible`
+                          : "unlimited supply cap"}
                       </div>
 
                       <div className="space-y-2">
@@ -271,11 +262,11 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                       </div>
                       <div className="text-sm text-zinc-500 mb-1">
                         {formatBalance(metrics.totalBorrowed)}{" "}
-                        {currentAsset.symbol}
+                        {currentAsset.symbol.toLowerCase()}
                       </div>
                       <div className="text-xs text-zinc-400 mb-3">
                         {metrics.borrowCapFormatted !== "No cap"
-                          ? `of ${metrics.borrowCapFormatted} ${currentAsset.symbol} possible`
+                          ? `of ${metrics.borrowCapFormatted} ${currentAsset.symbol.toLowerCase()} possible`
                           : "no borrow cap"}
                       </div>
 
@@ -346,15 +337,15 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                     <div className="flex items-center justify-between">
                       <div>
                         <div className="text-sm text-zinc-400 mb-2">
-                          Oracle price
+                          oracle price
                         </div>
                         <div className="text-2xl font-bold text-white">
                           {formatCurrency(tokenPrice)}
                         </div>
                       </div>
                       <div className="text-right">
-                        <div className="text-sm text-zinc-400 mb-2">Market</div>
-                        <div className="text-lg text-zinc-300">Aave V3</div>
+                        <div className="text-sm text-zinc-400 mb-2">market</div>
+                        <div className="text-lg text-zinc-300">aave v3</div>
                       </div>
                     </div>
                   </div>
@@ -366,11 +357,11 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                       </h3>
                       <div className="space-y-4">
                         <div className="flex justify-between items-center">
-                          <span className="text-zinc-400">Total supplied</span>
+                          <span className="text-zinc-400">total supplied</span>
                           <div className="text-right">
                             <div className="text-white font-medium">
                               {formatBalance(metrics.reserveSize)}{" "}
-                              {currentAsset.symbol}
+                              {currentAsset.symbol.toLowerCase()}
                             </div>
                             <div className="text-sm text-zinc-500">
                               {formatCurrency(
@@ -413,7 +404,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                                 : "text-red-500",
                             )}
                           >
-                            {currentAsset.canBeCollateral ? "Yes" : "No"}
+                            {currentAsset.canBeCollateral ? "yes" : "no"}
                           </span>
                         </div>
                       </div>
@@ -421,7 +412,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
 
                     <div className="bg-[#1A1A1A] rounded-xl border border-[#232326] p-6">
                       <h3 className="text-lg font-semibold text-white mb-4">
-                        borrow Info
+                        borrow info
                       </h3>
                       <div className="space-y-4">
                         <div className="flex justify-between items-center">
@@ -429,7 +420,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                           <div className="text-right">
                             <div className="text-white font-medium">
                               {formatBalance(metrics.totalBorrowed)}{" "}
-                              {currentAsset.symbol}
+                              {currentAsset.symbol.toLowerCase()}
                             </div>
                             <div className="text-sm text-zinc-500">
                               {formatCurrency(
@@ -477,7 +468,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                                 : "text-red-500",
                             )}
                           >
-                            {currentAsset.borrowingEnabled ? "Yes" : "No"}
+                            {currentAsset.borrowingEnabled ? "yes" : "no"}
                           </span>
                         </div>
                       </div>
@@ -531,7 +522,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                           : "text-red-500",
                       )}
                     >
-                      {currentAsset.canBeCollateral ? "Yes" : "No"}
+                      {currentAsset.canBeCollateral ? "yes" : "no"}
                     </span>
                   </div>
                   <div className="flex justify-between">
@@ -546,7 +537,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                           : "text-red-500",
                       )}
                     >
-                      {currentAsset.borrowingEnabled ? "Yes" : "No"}
+                      {currentAsset.borrowingEnabled ? "yes" : "no"}
                     </span>
                   </div>
                   <div className="flex justify-between">
@@ -562,10 +553,10 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                       )}
                     >
                       {currentAsset.isFrozen
-                        ? "Frozen"
+                        ? "frozen"
                         : currentAsset.isActive
-                          ? "Active"
-                          : "Inactive"}
+                          ? "active"
+                          : "inactive"}
                     </span>
                   </div>
                 </div>
@@ -582,7 +573,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                           : "text-red-500",
                       )}
                     >
-                      {currentAsset.stableBorrowEnabled ? "Yes" : "No"}
+                      {currentAsset.stableBorrowEnabled ? "yes" : "no"}
                     </span>
                   </div>
                   <div className="flex justify-between">
@@ -598,8 +589,8 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                       )}
                     >
                       {currentAsset.isIsolationModeAsset
-                        ? "Enabled"
-                        : "Disabled"}
+                        ? "enabled"
+                        : "disabled"}
                     </span>
                   </div>
                   {currentAsset.isIsolationModeAsset &&
@@ -618,10 +609,10 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
             </div>
 
             <div className="p-4 bg-[#1A1A1A] rounded-lg border border-[#232326]">
-              <h3 className="text-sm font-semibold mb-3">Contract Addresses</h3>
+              <h3 className="text-sm font-semibold mb-3">contract addresses</h3>
               <div className="space-y-2 text-xs">
                 <div className="flex justify-between items-center">
-                  <span className="text-zinc-400">Token</span>
+                  <span className="text-zinc-400">token</span>
                   <div className="flex items-center gap-2">
                     <span className="font-mono">
                       {currentAsset.asset.slice(0, 10)}...
@@ -638,7 +629,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                 </div>
                 {currentAsset.aTokenAddress && (
                   <div className="flex justify-between items-center">
-                    <span className="text-zinc-400">aToken</span>
+                    <span className="text-zinc-400">atoken</span>
                     <div className="flex items-center gap-2">
                       <span className="font-mono">
                         {currentAsset.aTokenAddress.slice(0, 10)}...
@@ -658,7 +649,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                 )}
                 {extendedDetails?.variableDebtTokenAddress && (
                   <div className="flex justify-between items-center">
-                    <span className="text-zinc-400">Variable Debt Token</span>
+                    <span className="text-zinc-400">variable debt token</span>
                     <div className="flex items-center gap-2">
                       <span className="font-mono">
                         {extendedDetails.variableDebtTokenAddress.slice(0, 10)}

--- a/src/components/ui/lending/BorrowOwnedCard.tsx
+++ b/src/components/ui/lending/BorrowOwnedCard.tsx
@@ -41,7 +41,6 @@ const BorrowOwnedCard = ({
   totalDebtUSD = 0,
   walletBalance = "0.00",
   onRepay = async () => true,
-  onDetailsClick = () => {},
 }: BorrowOwnedCardProps) => {
   const { asset } = borrowPosition;
 

--- a/src/components/ui/lending/BorrowOwnedCard.tsx
+++ b/src/components/ui/lending/BorrowOwnedCard.tsx
@@ -18,6 +18,7 @@ import { formatBalance } from "@/utils/formatters";
 import { getChainByChainId } from "@/config/chains";
 import RepayModal from "@/components/ui/lending/RepayModal";
 import { RateMode } from "@/utils/aave/interact";
+import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
 
 interface BorrowOwnedCardProps {
   borrowPosition: UserBorrowPosition;
@@ -70,10 +71,6 @@ const BorrowOwnedCard = ({
       console.error("Error completing repay:", error);
       return false;
     }
-  };
-
-  const handleDetailsClick = () => {
-    onDetailsClick(borrowPosition);
   };
 
   const debtTypeDisplay = () => {
@@ -152,7 +149,9 @@ const BorrowOwnedCard = ({
           <BlueButton>repay</BlueButton>
         </RepayModal>
 
-        <GrayButton onClick={handleDetailsClick}>details</GrayButton>
+        <AssetDetailsModal assetData={asset}>
+          <GrayButton>details</GrayButton>
+        </AssetDetailsModal>
       </CardFooter>
     </Card>
   );

--- a/src/components/ui/lending/BorrowUnownedCard.tsx
+++ b/src/components/ui/lending/BorrowUnownedCard.tsx
@@ -16,6 +16,7 @@ import { AaveReserveData } from "@/utils/aave/fetch";
 import { BorrowModal } from "@/components/ui/lending/BorrowModal";
 import { getChainByChainId } from "@/config/chains";
 import type { Token, Chain } from "@/types/web3";
+import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
 
 interface BorrowUnownedCardProps {
   asset?: AaveReserveData;
@@ -33,7 +34,6 @@ const BorrowUnownedCard: FC<BorrowUnownedCardProps> = ({
   availableToBorrow = "0.00",
   availableToBorrowUSD = "0.00",
   onBorrow = () => {},
-  onDetails = () => {},
   healthFactor = "1.24",
   totalCollateralUSD = 0,
   totalDebtUSD = 0,
@@ -185,7 +185,9 @@ const BorrowUnownedCard: FC<BorrowUnownedCardProps> = ({
             {canBorrow ? "borrow" : "unavailable"}
           </PrimaryButton>
         </BorrowModal>
-        <GrayButton onClick={() => onDetails(currentAsset)}>details</GrayButton>
+        <AssetDetailsModal assetData={asset}>
+          <GrayButton>details</GrayButton>
+        </AssetDetailsModal>
       </CardFooter>
     </Card>
   );

--- a/src/components/ui/lending/SupplyComponent.tsx
+++ b/src/components/ui/lending/SupplyComponent.tsx
@@ -156,11 +156,6 @@ const SupplyComponent: React.FC = () => {
     // TODO: Implement supply functionality
   };
 
-  const handleDetails = (asset: AaveReserveData) => {
-    console.log("View asset details:", asset);
-    // TODO: Implement details modal
-  };
-
   const handleSwitch = (asset: AaveReserveData) => {
     console.log("Switch collateral for asset:", asset);
     // TODO: Implement collateral switch functionality
@@ -286,7 +281,6 @@ const SupplyComponent: React.FC = () => {
                     userBalance={reserve.userBalanceFormatted || "0.00"}
                     dollarAmount={reserve.userBalanceUsd || "0.00"}
                     onSupply={handleSupply}
-                    onDetails={handleDetails}
                   />
                 ))}
             </ScrollBoxSupplyBorrowAssets>

--- a/src/components/ui/lending/SupplyOwnedCard.tsx
+++ b/src/components/ui/lending/SupplyOwnedCard.tsx
@@ -17,6 +17,7 @@ import type { Token, Chain } from "@/types/web3";
 import { WithdrawModal } from "@/components/ui/lending/WithdrawModal";
 import { AaveReserveData } from "@/utils/aave/fetch";
 import { formatBalance, formatAPY } from "@/utils/formatters";
+import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
 import { getChainByChainId } from "@/config/chains";
 import { CollateralModal } from "@/components/ui/lending/SupplyCollateralModal";
 
@@ -244,6 +245,9 @@ const SupplyOwnedCard = ({
         >
           <BlueButton>withdraw</BlueButton>
         </WithdrawModal>
+        <AssetDetailsModal assetData={asset}>
+          <BlueButton>details</BlueButton>
+        </AssetDetailsModal>
       </CardFooter>
     </Card>
   );

--- a/src/components/ui/lending/SupplyUnownedCard.tsx
+++ b/src/components/ui/lending/SupplyUnownedCard.tsx
@@ -17,13 +17,13 @@ import { SupplyModal } from "@/components/ui/lending/SupplyModal";
 import { formatBalance, formatAPY } from "@/utils/formatters";
 import { getChainByChainId } from "@/config/chains";
 import type { Token, Chain } from "@/types/web3";
+import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
 
 interface SupplyUnownedCardProps {
   asset?: AaveReserveData;
   userBalance?: string; // Optional user balance for this asset
   dollarAmount?: string; // Optional USD value of user balance
   onSupply?: (asset: AaveReserveData) => void;
-  onDetails?: (asset: AaveReserveData) => void;
 }
 
 const SupplyUnownedCard: FC<SupplyUnownedCardProps> = ({
@@ -31,7 +31,6 @@ const SupplyUnownedCard: FC<SupplyUnownedCardProps> = ({
   userBalance = "0",
   dollarAmount = "0.00",
   onSupply = () => {},
-  onDetails = () => {},
 }) => {
   // Default asset for demo purposes
   const defaultAsset: AaveReserveData = {
@@ -168,7 +167,9 @@ const SupplyUnownedCard: FC<SupplyUnownedCardProps> = ({
         >
           <PrimaryButton>supply</PrimaryButton>
         </SupplyModal>
-        <GrayButton onClick={() => onDetails(currentAsset)}>details</GrayButton>
+        <AssetDetailsModal assetData={currentAsset}>
+          <GrayButton>details</GrayButton>
+        </AssetDetailsModal>
       </CardFooter>
     </Card>
   );

--- a/src/types/aaveV3ABIs.ts
+++ b/src/types/aaveV3ABIs.ts
@@ -140,6 +140,7 @@ export const POOL_ABI = [
   "function getUserAccountData(address user) external view returns (uint256 totalCollateralBase, uint256 totalDebtBase, uint256 availableBorrowsBase, uint256 currentLiquidationThreshold, uint256 ltv, uint256 healthFactor)",
   "function getReservesList() external view returns (address[])",
   "function getReserveData(address asset) external view returns (uint256 configuration, uint128 liquidityIndex, uint128 currentLiquidationRate, uint128 variableBorrowIndex, uint128 currentVariableBorrowRate, uint128 currentStableBorrowRate, uint40 lastUpdateTimestamp, uint16 id, address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress, address interestRateStrategyAddress, uint128 accruedToTreasury, uint128 unbacked, uint128 isolationModeTotalDebt)",
+  "function getConfiguration(address asset) external view returns (uint256)",
 ];
 
 export const DATA_PROVIDER_ABI = POOL_DATA_PROVIDER_ABI;

--- a/src/utils/aave/fetch.ts
+++ b/src/utils/aave/fetch.ts
@@ -1,11 +1,7 @@
 // aaveFetch.ts - Essential Aave fetch functionality using wallet provider
 import { ethers } from "ethers";
 import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
-import {
-  POOL_DATA_PROVIDER_ABI,
-  ERC20_ABI,
-  POOL_ABI,
-} from "@/types/aaveV3ABIs";
+import { POOL_DATA_PROVIDER_ABI, POOL_ABI } from "@/types/aaveV3ABIs";
 import { Token, Chain } from "@/types/web3";
 import { getAaveMarket } from "@/config/aave";
 import { rayToPercentage } from "@/utils/aave/utils";

--- a/src/utils/aave/fetch.ts
+++ b/src/utils/aave/fetch.ts
@@ -1,7 +1,11 @@
 // aaveFetch.ts - Essential Aave fetch functionality using wallet provider
 import { ethers } from "ethers";
 import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
-import { POOL_DATA_PROVIDER_ABI } from "@/types/aaveV3ABIs";
+import {
+  POOL_DATA_PROVIDER_ABI,
+  ERC20_ABI,
+  POOL_ABI,
+} from "@/types/aaveV3ABIs";
 import { Token, Chain } from "@/types/web3";
 import { getAaveMarket } from "@/config/aave";
 import { rayToPercentage } from "@/utils/aave/utils";
@@ -46,6 +50,11 @@ export interface AaveReserveData {
   userBalanceUsd?: string;
   tokenIcon?: string;
   chainId?: number;
+
+  // Risk parameters
+  ltv?: string;
+  liquidationThreshold?: string;
+  liquidationPenalty?: string;
 }
 
 export interface AaveReservesResult {
@@ -151,6 +160,39 @@ export async function fetchAllReservesData(
               const isIsolationModeAsset = Number(debtCeiling) > 0;
               const canBeCollateral = configData.usageAsCollateralEnabled;
 
+              let ltvBps = 0;
+              let liquidationThresholdBps = 0;
+              let liquidationBonusBps = 0;
+
+              try {
+                const market = getAaveMarket(aaveChain.chainId);
+                if (market?.POOL) {
+                  const poolContract = new ethers.Contract(
+                    market.POOL,
+                    POOL_ABI,
+                    provider,
+                  );
+
+                  const configBitmask = await poolContract.getConfiguration(
+                    token.tokenAddress,
+                  );
+
+                  ltvBps = Number(configBitmask & BigInt(0xffff));
+                  liquidationThresholdBps = Number(
+                    (configBitmask >> BigInt(16)) & BigInt(0xffff),
+                  );
+                  liquidationBonusBps = Number(
+                    (configBitmask >> BigInt(32)) & BigInt(0xffff),
+                  );
+                }
+              } catch {
+                ltvBps = Number(configData.ltv || 0);
+                liquidationThresholdBps = Number(
+                  configData.liquidationThreshold || 0,
+                );
+                liquidationBonusBps = Number(configData.liquidationBonus || 0);
+              }
+
               const supplyAPY = rayToPercentage(
                 reserveData.liquidityRate.toString(),
               );
@@ -247,6 +289,12 @@ export async function fetchAllReservesData(
                 userBalanceUsd: "0.00",
                 tokenIcon: tokenIcon,
                 chainId: aaveChain.chainId,
+
+                ltv: (ltvBps / 100).toFixed(2) + "%",
+                liquidationThreshold:
+                  (liquidationThresholdBps / 100).toFixed(2) + "%",
+                liquidationPenalty:
+                  ((liquidationBonusBps - 10000) / 100).toFixed(2) + "%",
               };
             } catch (error) {
               console.log(


### PR DESCRIPTION
this change enables all details components to show the asset extra details
Token navigation example 
<img width="1518" height="851" alt="image" src="https://github.com/user-attachments/assets/4438e34c-2584-4f73-a25a-c66270899abb" />
computer
<img width="1308" height="1237" alt="image" src="https://github.com/user-attachments/assets/5bd77d9d-0b2e-41fd-8a69-006dbb0625e7" />
iphone
<img width="608" height="963" alt="image" src="https://github.com/user-attachments/assets/32234570-fb75-4b5c-870b-173bafb04002" />
