### PR TITLE
chore: fix bad accordion headers

### DIFF
--- a/src/components/ui/lending/BorrowComponent.tsx
+++ b/src/components/ui/lending/BorrowComponent.tsx
@@ -19,6 +19,7 @@ import {
   AaveReservesResult,
   UserBorrowPosition,
 } from "@/types/aave";
+import SupplyAvailablePositionsHeader from "./SupplyAvailablePositionsHeader";
 
 const BorrowComponent: React.FC = () => {
   const [borrowableReserves, setBorrowableReserves] = useState<
@@ -223,16 +224,7 @@ const BorrowComponent: React.FC = () => {
           className="border-[1px] border-[#232326] rounded-md overflow-hidden"
         >
           <AccordionTrigger className="p-0 hover:no-underline data-[state=open]:bg-transparent hover:bg-[#131313] rounded-t-md">
-            <div className="flex items-center justify-between w-full px-4 py-3">
-              <div className="flex items-center gap-3">
-                <div className="text-[#FAFAFA] font-medium">Your Borrows</div>
-                {hasBorrowPositions && (
-                  <div className="bg-red-500/20 text-red-400 text-xs px-2 py-1 rounded">
-                    {userBorrowPositions.length}
-                  </div>
-                )}
-              </div>
-            </div>
+            <SupplyAvailablePositionsHeader text="your borrows" />
           </AccordionTrigger>
           <AccordionContent>
             <ScrollBoxSupplyBorrowAssets>
@@ -285,18 +277,7 @@ const BorrowComponent: React.FC = () => {
           className="border-[1px] border-[#232326] rounded-md overflow-hidden"
         >
           <AccordionTrigger className="p-0 hover:no-underline data-[state=open]:bg-transparent hover:bg-[#131313] rounded-t-md">
-            <div className="flex items-center justify-between w-full px-4 py-3">
-              <div className="flex items-center gap-3">
-                <div className="text-[#FAFAFA] font-medium">
-                  Assets to Borrow
-                </div>
-                {borrowableReserves.length > 0 && (
-                  <div className="bg-red-500/20 text-red-400 text-xs px-2 py-1 rounded">
-                    {borrowableReserves.length}
-                  </div>
-                )}
-              </div>
-            </div>
+            <SupplyAvailablePositionsHeader text="assets to borrow" />
           </AccordionTrigger>
           <AccordionContent>
             <ScrollBoxSupplyBorrowAssets>

--- a/src/components/ui/lending/BorrowComponent.tsx
+++ b/src/components/ui/lending/BorrowComponent.tsx
@@ -19,7 +19,7 @@ import {
   AaveReservesResult,
   UserBorrowPosition,
 } from "@/types/aave";
-import SupplyAvailablePositionsHeader from "./SupplyAvailablePositionsHeader";
+import SupplyAvailablePositionsHeader from "@/components/ui/lending/SupplyAvailablePositionsHeader";
 
 const BorrowComponent: React.FC = () => {
   const [borrowableReserves, setBorrowableReserves] = useState<

--- a/src/components/ui/lending/SupplyAvailablePositionsHeader.tsx
+++ b/src/components/ui/lending/SupplyAvailablePositionsHeader.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 
-const SupplyAvailablePositionsHeader = ({ ...props }) => {
+const SupplyAvailablePositionsHeader = ({
+  text = "available positions",
+  ...props
+}) => {
   return (
     <div className="w-full flex items-center h-[65px]" {...props}>
       {/* Title - fixed width with more padding */}
       <div className="w-40 flex-shrink-0 pl-6">
-        <span className="text-base font-bold text-white">
-          available positions
-        </span>
+        <span className="text-base font-bold text-white">{text}</span>
       </div>
       <div className="w-12 flex-shrink-0"></div>
     </div>

--- a/src/components/ui/lending/SupplyComponent.tsx
+++ b/src/components/ui/lending/SupplyComponent.tsx
@@ -226,7 +226,7 @@ const SupplyComponent: React.FC = () => {
           className="border-[1px] border-[#232326] rounded-md  overflow-hidden"
         >
           <AccordionTrigger className="p-0 hover:no-underline data-[state=open]:bg-transparent hover:bg-[#131313] rounded-t-md">
-            <SupplyAvailablePositionsHeader />
+            <SupplyAvailablePositionsHeader text="available positions" />
           </AccordionTrigger>
           <AccordionContent>
             <ScrollBoxSupplyBorrowAssets>


### PR DESCRIPTION
Updated lending to be consistent with supply and borrow headers for accordions

Borrow and Supply for available positions and borrow owned positions now follow consistent styling 

The headers for every single accordion is incorrect in borrow. As such I have made the supply available positions header a reusable component which is now used for the borrow headers.

<img width="1594" height="436" alt="image" src="https://github.com/user-attachments/assets/5cc850e0-3de5-45e2-b7c3-3dc6f7b5a94d" />
<img width="1576" height="438" alt="image" src="https://github.com/user-attachments/assets/34086378-56da-4dc3-9bba-482dea5f63fa" />
