### PR TITLE
refactor: use reown wallet provider in place of window.ethereum

### DIFF
--- a/src/components/ui/earning/DepositModal.tsx
+++ b/src/components/ui/earning/DepositModal.tsx
@@ -54,7 +54,7 @@ import useVaultDepositStore, {
   useActiveVaultDepositProcess,
 } from "@/store/vaultDepositStore";
 import { GasDrop } from "@/components/ui/GasDrop";
-import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import TokenImage from "@/components/ui/TokenImage";
 import {
   queryVaultConversionRate,
@@ -121,7 +121,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
   );
 
   // Wallet hooks for address retrieval
-  const { getEvmSigner } = useWalletProviderAndSigner();
+  const { getEvmSigner } = useReownWalletProviderAndSigner();
 
   // Vault Deposit Store integration
   const {

--- a/src/components/ui/lending/BorrowModal.tsx
+++ b/src/components/ui/lending/BorrowModal.tsx
@@ -16,12 +16,12 @@ import { Input } from "@/components/ui/Input";
 import { TokenImage } from "@/components/ui/TokenImage";
 import { cn } from "@/lib/utils";
 import { AaveTransactions } from "@/utils/aave/interact";
-import { ethers } from "ethers";
 import { toast } from "sonner";
 import { useState, useEffect, FC, ReactNode, ChangeEvent } from "react";
 import { SupportedChainId } from "@/config/aave";
 import type { Token } from "@/types/web3";
 import { useWalletConnection } from "@/utils/swap/walletMethods";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { getHealthFactorColor } from "@/utils/aave/utils";
 import { formatBalance } from "@/utils/common";
 import { getChainByChainId } from "@/config/chains";
@@ -98,6 +98,7 @@ const BorrowModal: FC<BorrowModalProps> = ({
 
   // Get wallet connection info
   const { evmNetwork, isEvmConnected } = useWalletConnection();
+  const { getEvmSigner } = useReownWalletProviderAndSigner();
 
   // Create Token and Chain objects for TokenImage component
   const token: Token = {
@@ -191,22 +192,13 @@ const BorrowModal: FC<BorrowModalProps> = ({
     setIsSubmitting(true);
 
     try {
-      // Get current chain ID
       const currentChainId = evmNetwork?.chainId
         ? typeof evmNetwork.chainId === "string"
           ? parseInt(evmNetwork.chainId, 10)
           : evmNetwork.chainId
         : 1;
 
-      // Get signer
-      if (!window.ethereum) {
-        throw new Error("MetaMask not found");
-      }
-
-      const provider = new ethers.BrowserProvider(
-        window.ethereum as unknown as ethers.Eip1193Provider,
-      );
-      const signer = await provider.getSigner();
+      const signer = await getEvmSigner();
       const userAddress = await signer.getAddress();
 
       // Show initial toast

--- a/src/components/ui/lending/RepayModal.tsx
+++ b/src/components/ui/lending/RepayModal.tsx
@@ -20,8 +20,8 @@ import { Input } from "@/components/ui/Input";
 import { cn } from "@/lib/utils";
 import { AaveTransactions, RateMode } from "@/utils/aave/interact";
 import { useWalletConnection } from "@/utils/swap/walletMethods";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { getExplorerUrl } from "@/utils/ui/uiHelpers";
-import { ethers } from "ethers";
 import { toast } from "sonner";
 import { useState, useEffect, FC, ReactNode, ChangeEvent } from "react";
 import { SupportedChainId } from "@/config/aave";
@@ -105,6 +105,7 @@ const RepayModal: FC<RepayModalProps> = ({
   const [repayMode, setRepayMode] = useState<RateMode>(RateMode.Variable); // Default to variable
 
   const { isEvmConnected, evmNetwork } = useWalletConnection();
+  const { getEvmSigner } = useReownWalletProviderAndSigner();
 
   // Determine the appropriate repay mode based on debt composition
   useEffect(() => {
@@ -234,25 +235,7 @@ const RepayModal: FC<RepayModalProps> = ({
           : evmNetwork.chainId
         : 1;
 
-      // Get signer from window.ethereum
-      if (!window.ethereum) {
-        throw new Error("no wallet detected");
-      }
-
-      const ethereum = window.ethereum as {
-        request: (args: {
-          method: string;
-          params?: unknown[];
-        }) => Promise<unknown>;
-        on?: (event: string, callback: (...args: unknown[]) => void) => void;
-        removeListener?: (
-          event: string,
-          callback: (...args: unknown[]) => void,
-        ) => void;
-      };
-
-      const provider = new ethers.BrowserProvider(ethereum);
-      const signer = await provider.getSigner();
+      const signer = await getEvmSigner();
       const userAddress = await signer.getAddress();
 
       console.log(

--- a/src/components/ui/lending/SupplyComponent.tsx
+++ b/src/components/ui/lending/SupplyComponent.tsx
@@ -121,23 +121,23 @@ const SupplyComponent: React.FC = () => {
     }
   }, [sourceChain.chainId, lastChainId]);
 
-  // Add direct MetaMask chain change listener for immediate refresh
+  // Add direct wallet chain change listener for immediate refresh
   useEffect(() => {
     const handleChainChanged = () => {
-      console.log("MetaMask chain changed, clearing data and refreshing...");
+      console.log("Wallet chain changed, clearing data and refreshing...");
       // Immediately clear cards and show loading state
       setAaveReserves([]);
       setUserPositions([]);
       setError(null);
       setLoading(true);
 
-      // Force refresh when MetaMask chain changes
+      // Force refresh when wallet chain changes
       setTimeout(() => {
         loadAaveReserves(true);
       }, 200); // Small delay to ensure store has updated
     };
 
-    // Listen for MetaMask chain changes
+    // Listen for wallet chain changes (if available)
     if (typeof window !== "undefined" && window.ethereum) {
       const ethereum = window.ethereum as {
         on?: (event: string, callback: () => void) => void;

--- a/src/components/ui/lending/SupplyModal.tsx
+++ b/src/components/ui/lending/SupplyModal.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/components/ui/Input";
 import { cn } from "@/lib/utils";
 import { AaveTransactions } from "@/utils/aave/interact";
 import { useWalletConnection } from "@/utils/swap/walletMethods";
-import { ethers } from "ethers";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { toast } from "sonner";
 import { useState, useEffect, FC, ReactNode, ChangeEvent } from "react";
 import { SupportedChainId } from "@/config/aave";
@@ -96,6 +96,7 @@ const SupplyModal: FC<SupplyModalProps> = ({
 
   // Get wallet connection info
   const { evmNetwork, isEvmConnected } = useWalletConnection();
+  const { getEvmSigner } = useReownWalletProviderAndSigner();
 
   // Create Token and Chain objects for TokenImage component
   const token: Token = {
@@ -201,22 +202,13 @@ const SupplyModal: FC<SupplyModalProps> = ({
     setIsSubmitting(true);
 
     try {
-      // Get current chain ID
       const currentChainId = evmNetwork?.chainId
         ? typeof evmNetwork.chainId === "string"
           ? parseInt(evmNetwork.chainId, 10)
           : evmNetwork.chainId
         : 1; // Default to Ethereum mainnet
 
-      // Get signer from window.ethereum
-      if (!window.ethereum) {
-        throw new Error("MetaMask not found");
-      }
-
-      const provider = new ethers.BrowserProvider(
-        window.ethereum as unknown as ethers.Eip1193Provider,
-      );
-      const signer = await provider.getSigner();
+      const signer = await getEvmSigner();
       const userAddress = await signer.getAddress();
 
       // Show initial toast

--- a/src/components/ui/lending/WithdrawModal.tsx
+++ b/src/components/ui/lending/WithdrawModal.tsx
@@ -16,11 +16,11 @@ import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { cn } from "@/lib/utils";
 import { AaveTransactions } from "@/utils/aave/interact";
-import { ethers } from "ethers";
 import { toast } from "sonner";
 import { useState, useEffect, FC, ReactNode, ChangeEvent } from "react";
 import { chainNames, SupportedChainId } from "@/config/aave";
 import { useWalletConnection } from "@/utils/swap/walletMethods";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { getHealthFactorColor } from "@/utils/aave/utils";
 import { formatBalance } from "@/utils/common";
 
@@ -93,13 +93,12 @@ const WithdrawModal: FC<WithdrawModalProps> = ({
   const [isMounted, setIsMounted] = useState(false);
   const [hasImageError, setHasImageError] = useState(false);
 
-  // Get wallet connection info
   const { evmNetwork, isEvmConnected } = useWalletConnection();
+  const { getEvmSigner } = useReownWalletProviderAndSigner();
 
   const chainName = chainNames[chainId] || "ethereum";
   const fallbackIcon = tokenSymbol.charAt(0).toUpperCase();
 
-  // Image path logic (same as other modals)
   const getImagePath = () => {
     if (!tokenIcon || tokenIcon === "unknown.png" || hasImageError) {
       return null;
@@ -197,15 +196,7 @@ const WithdrawModal: FC<WithdrawModalProps> = ({
           : evmNetwork.chainId
         : 1; // Default to Ethereum mainnet
 
-      // Get signer from window.ethereum
-      if (!window.ethereum) {
-        throw new Error("MetaMask not found");
-      }
-
-      const provider = new ethers.BrowserProvider(
-        window.ethereum as unknown as ethers.Eip1193Provider,
-      );
-      const signer = await provider.getSigner();
+      const signer = await getEvmSigner();
       const userAddress = await signer.getAddress();
 
       // Show initial toast

--- a/src/utils/aave/extendedDetails.ts
+++ b/src/utils/aave/extendedDetails.ts
@@ -3,7 +3,7 @@ import { useCallback } from "react";
 import { POOL_DATA_PROVIDER_ABI } from "@/types/aaveV3ABIs";
 import { getChainByChainId } from "@/config/chains";
 import { altverseAPI } from "@/api/altverse";
-import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { AaveReserveData } from "@/utils/aave/fetch";
 import { ExtendedAssetDetails } from "@/utils/aave/calculations";
 import { getAaveMarket } from "@/config/aave";
@@ -121,7 +121,7 @@ export const fetchExtendedAssetDetails = async (
 };
 
 export function useAaveFetch() {
-  const { getEvmSigner } = useWalletProviderAndSigner();
+  const { getEvmSigner } = useReownWalletProviderAndSigner();
 
   const fetchExtendedAssetDetailsMemoized = useCallback(
     async (currentAsset: AaveReserveData, chainId: number) => {

--- a/src/utils/aave/fetch.ts
+++ b/src/utils/aave/fetch.ts
@@ -1,6 +1,6 @@
 // aaveFetch.ts - Essential Aave fetch functionality using wallet provider
 import { ethers } from "ethers";
-import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { POOL_DATA_PROVIDER_ABI } from "@/types/aaveV3ABIs";
 import { loadTokensForChain } from "@/utils/tokens/tokenMethods";
 import { Token } from "@/types/web3";
@@ -623,7 +623,7 @@ export async function fetchUserWalletBalances(
  * Updated React hook
  */
 export function useAaveFetch() {
-  const { getEvmSigner } = useWalletProviderAndSigner();
+  const { getEvmSigner } = useReownWalletProviderAndSigner();
   return {
     fetchAllReservesData: async () => {
       const signer = await getEvmSigner();

--- a/src/utils/aave/interact.ts
+++ b/src/utils/aave/interact.ts
@@ -392,11 +392,9 @@ export class AaveTransactions {
     userAddress: string,
     amount: string,
     tokenDecimals: number,
+    provider: ethers.Provider,
   ): Promise<boolean> {
     try {
-      const provider = new ethers.BrowserProvider(
-        window.ethereum as unknown as ethers.Eip1193Provider,
-      );
       const tokenContract = new ethers.Contract(
         tokenAddress,
         ERC20_ABI,
@@ -421,17 +419,15 @@ export class AaveTransactions {
     userAddress: string,
     chainId: SupportedChainId,
     tokenDecimals: number,
+    signer: ethers.Signer,
   ): Promise<string> {
     try {
       const poolAddress = AaveSDK.getPoolAddress(chainId);
 
-      const provider = new ethers.BrowserProvider(
-        window.ethereum as unknown as ethers.Eip1193Provider,
-      );
       const tokenContract = new ethers.Contract(
         tokenAddress,
         ERC20_ABI,
-        provider,
+        signer,
       );
 
       const allowance = await tokenContract.allowance(userAddress, poolAddress);
@@ -448,6 +444,7 @@ export class AaveTransactions {
   static async getUserAccountData(
     userAddress: string,
     chainId: SupportedChainId,
+    provider: ethers.Provider,
   ): Promise<UserAccountData | null> {
     try {
       if (!AaveSDK.isChainSupported(chainId)) {
@@ -455,9 +452,6 @@ export class AaveTransactions {
       }
 
       const poolAddress = AaveSDK.getPoolAddress(chainId);
-      const provider = new ethers.BrowserProvider(
-        window.ethereum as unknown as ethers.Eip1193Provider,
-      );
       const poolContract = new ethers.Contract(poolAddress, POOL_ABI, provider);
 
       const accountData = await poolContract.getUserAccountData(userAddress);
@@ -484,10 +478,15 @@ export class AaveTransactions {
     tokenAddress: string,
     userAddress: string,
     chainId: SupportedChainId,
+    provider: ethers.Provider,
   ): Promise<{ canDisable: boolean; reason?: string }> {
     try {
       // Get current account data
-      const accountData = await this.getUserAccountData(userAddress, chainId);
+      const accountData = await this.getUserAccountData(
+        userAddress,
+        chainId,
+        provider,
+      );
       if (!accountData) {
         return { canDisable: false, reason: "Unable to fetch account data" };
       }

--- a/src/utils/etherFi/fetch.ts
+++ b/src/utils/etherFi/fetch.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 import { useCallback } from "react"; // Add this import
-import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { TELLER_PAUSED_ABI } from "@/types/etherFiABIs";
 import { ETHERFI_VAULTS, DEPOSIT_ASSETS } from "@/config/etherFi";
 import { createEthersJsonRpcProviderFromUrls } from "@/utils/wallet/ethersJsonRpcProvider";
@@ -212,7 +212,7 @@ export async function getUserVaultBalance(
  * React hook for etherFi fetch functions with wallet integration
  */
 export function useEtherFiFetch() {
-  const { getEvmSigner } = useWalletProviderAndSigner();
+  const { getEvmSigner } = useReownWalletProviderAndSigner();
 
   const fetchVaultTVLMemoized = useCallback(
     async (vaultId: number) => {

--- a/src/utils/etherFi/interact.ts
+++ b/src/utils/etherFi/interact.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { TELLER_ABI } from "@/types/etherFiABIs";
 import { ETHERFI_VAULTS, DEPOSIT_ASSETS } from "@/config/etherFi";
 import { ERC20_ABI } from "@/types/ERC20ABI";
@@ -149,7 +149,7 @@ export async function depositTokens(
  * React hook for etherFi interaction functions with wallet integration
  */
 export function useEtherFiInteract() {
-  const { getEvmSigner } = useWalletProviderAndSigner();
+  const { getEvmSigner } = useReownWalletProviderAndSigner();
 
   return {
     approveToken: async (

--- a/src/utils/etherFi/vaultShares.ts
+++ b/src/utils/etherFi/vaultShares.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 import { useCallback } from "react";
-import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import {
   ETHERFI_VAULTS,
   DEPOSIT_ASSETS,
@@ -227,7 +227,7 @@ export async function queryAllVaultsForAsset(
 // React hook for vault share conversion queries with wallet integration
 
 export function useVaultShares() {
-  const { getEvmSigner } = useWalletProviderAndSigner();
+  const { getEvmSigner } = useReownWalletProviderAndSigner();
 
   const queryVaultConversionRateMemoized = useCallback(
     async (vaultId: number, depositAsset: string, depositAmount: string) => {

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -20,7 +20,7 @@ import {
 } from "@/utils/swap/mayanSwapMethods";
 import { Quote } from "@mayanfinance/swap-sdk";
 import { toast } from "sonner";
-import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { Connection } from "@solana/web3.js";
 import { useWallet } from "@suiet/wallet-kit"; // Import Suiet hook
 import { SwapStatus } from "@/types/web3";
@@ -713,7 +713,7 @@ export function useTokenTransfer(
   const receiveAddress = options.transactionDetails.receiveAddress;
 
   // Get wallet providers and signers
-  const { getEvmSigner, getSolanaSigner } = useWalletProviderAndSigner();
+  const { getEvmSigner, getSolanaSigner } = useReownWalletProviderAndSigner();
 
   // Add the chain switch hook
   const { switchToSourceChain, isLoading: isChainSwitching } = useChainSwitch(

--- a/src/utils/tokens/nativeAssetBalancesLocal.ts
+++ b/src/utils/tokens/nativeAssetBalancesLocal.ts
@@ -5,7 +5,7 @@ import { Connection, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { SuiClient } from "@mysten/sui/client";
 import { chains, chainList } from "@/config/chains";
 import { WalletType, Chain } from "@/types/web3";
-import { useWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
+import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { useWallet } from "@suiet/wallet-kit";
 import { createEthersJsonRpcProvider } from "@/utils/wallet/ethersJsonRpcProvider";
 
@@ -325,7 +325,7 @@ export function formatNativeBalance(
  */
 export function useNativeBalances() {
   const { evmProvider, solanaProvider, getEvmSigner, getSolanaSigner } =
-    useWalletProviderAndSigner();
+    useReownWalletProviderAndSigner();
   const { address: suiAddress, connected: suiConnected } = useWallet();
 
   const fetchBalances = async (): Promise<NativeBalanceResult> => {

--- a/src/utils/wallet/reownEthersUtils.ts
+++ b/src/utils/wallet/reownEthersUtils.ts
@@ -13,7 +13,7 @@ import { Transaction } from "@solana/web3.js";
  * Enhanced hook for accessing wallet providers and signers for both EVM and Solana
  * Returns appropriate providers and signing functions based on current wallet type
  */
-export function useWalletProviderAndSigner() {
+export function useReownWalletProviderAndSigner() {
   // Get providers for both EVM and Solana namespaces
   const { walletProvider: evmProvider } = useAppKitProvider("eip155");
   const { walletProvider: solanaProvider } = useAppKitProvider("solana");


### PR DESCRIPTION
Please see https://github.com/altverseweb3/site/commit/73b2094a31b19cfb421e227f8ee2bccc326eb261

In this PR, instantiations of the `ethers` provider which leveraged `window.ethereum` are now utilizing the (renamed) `useReownWalletProviderAndSigner` for consistency.