### PR TITLE
refactor: single source of truth for aave chain config

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -14,10 +14,9 @@ import {
 } from "@/store/web3Store";
 import useWeb3Store from "@/store/web3Store";
 import { WalletType } from "@/types/web3";
-import { chainList } from "@/config/chains";
-import { isChainSupported } from "@/utils/aave/fetch";
+import { chainList, getChainById } from "@/config/chains";
+import { isChainSupported } from "@/config/aave";
 import { useChainSwitch } from "@/utils/swap/walletMethods";
-import { getChainById } from "@/config/chains";
 
 const BorrowLendComponent: React.FC = () => {
   const [activeTab, setActiveTab] = useState("borrow");

--- a/src/components/ui/lending/SupplyCollateralModal.tsx
+++ b/src/components/ui/lending/SupplyCollateralModal.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils";
 import { useAaveInteract } from "@/utils/aave/interact";
 import { toast } from "sonner";
 import { useState, useEffect, FC, ReactNode } from "react";
-import { chainNames, SupportedChainId } from "@/config/aave";
+import { getChainName, SupportedChainId } from "@/config/aave";
 import { useWalletConnection } from "@/utils/swap/walletMethods";
 import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { getHealthFactorColor } from "@/utils/aave/utils";
@@ -98,7 +98,7 @@ const CollateralModal: FC<CollateralModalProps> = ({
   const { getEvmSigner } = useReownWalletProviderAndSigner();
   const { setCollateral } = useAaveInteract();
 
-  const chainName = chainNames[chainId] || "ethereum";
+  const chainName = getChainName(chainId);
   const fallbackIcon = tokenSymbol.charAt(0).toUpperCase();
 
   const getImagePath = () => {

--- a/src/components/ui/lending/WithdrawModal.tsx
+++ b/src/components/ui/lending/WithdrawModal.tsx
@@ -18,7 +18,7 @@ import { cn } from "@/lib/utils";
 import { useAaveInteract } from "@/utils/aave/interact";
 import { toast } from "sonner";
 import { useState, useEffect, FC, ReactNode, ChangeEvent } from "react";
-import { chainNames, SupportedChainId } from "@/config/aave";
+import { getChainName, SupportedChainId } from "@/config/aave";
 import { useWalletConnection } from "@/utils/swap/walletMethods";
 import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { getHealthFactorColor } from "@/utils/aave/utils";
@@ -97,7 +97,7 @@ const WithdrawModal: FC<WithdrawModalProps> = ({
   const { getEvmSigner } = useReownWalletProviderAndSigner();
   const { withdraw } = useAaveInteract();
 
-  const chainName = chainNames[chainId] || "ethereum";
+  const chainName = getChainName(chainId);
   const fallbackIcon = tokenSymbol.charAt(0).toUpperCase();
 
   const getImagePath = () => {

--- a/src/config/aave.ts
+++ b/src/config/aave.ts
@@ -1,26 +1,22 @@
 import * as markets from "@bgd-labs/aave-address-book";
 
-export const chainNames: Record<number, string> = {
-  1: "ethereum",
-  137: "polygon",
-  42161: "arbitrum",
-  10: "optimism",
-  43114: "avalanche",
-  8453: "base",
-  100: "gnosis",
-  56: "bsc",
-};
+const CHAIN_CONFIG = {
+  1: { name: "ethereum", market: markets.AaveV3Ethereum },
+  137: { name: "polygon", market: markets.AaveV3Polygon },
+  42161: { name: "arbitrum", market: markets.AaveV3Arbitrum },
+  10: { name: "optimism", market: markets.AaveV3Optimism },
+  43114: { name: "avalanche", market: markets.AaveV3Avalanche },
+  8453: { name: "base", market: markets.AaveV3Base },
+  100: { name: "gnosis", market: markets.AaveV3Gnosis },
+  56: { name: "bsc", market: markets.AaveV3BNB },
+  11155111: { name: "sepolia", market: markets.AaveV3Sepolia },
+} as const;
 
-export type SupportedChainId =
-  | 1
-  | 137
-  | 42161
-  | 10
-  | 43114
-  | 8453
-  | 100
-  | 56
-  | 11155111;
+export type SupportedChainId = keyof typeof CHAIN_CONFIG;
+
+export const chainNames: Record<SupportedChainId, string> = Object.fromEntries(
+  Object.entries(CHAIN_CONFIG).map(([id, config]) => [Number(id), config.name]),
+) as Record<SupportedChainId, string>;
 
 export interface ChainConfig {
   poolAddress: string;
@@ -30,28 +26,21 @@ export interface ChainConfig {
   wethGatewayAddress?: string;
 }
 
-// Helper function to get the correct market based on chain ID
 export function getAaveMarket(chainId: number) {
-  switch (chainId) {
-    case 1:
-      return markets.AaveV3Ethereum;
-    case 137:
-      return markets.AaveV3Polygon;
-    case 42161:
-      return markets.AaveV3Arbitrum;
-    case 10:
-      return markets.AaveV3Optimism;
-    case 43114:
-      return markets.AaveV3Avalanche;
-    case 8453:
-      return markets.AaveV3Base;
-    case 100:
-      return markets.AaveV3Gnosis;
-    case 56:
-      return markets.AaveV3BNB;
-    case 11155111:
-      return markets.AaveV3Sepolia;
-    default:
-      throw new Error(`Aave V3 not supported on chain ${chainId}`);
+  const config = CHAIN_CONFIG[chainId as SupportedChainId];
+  if (!config) {
+    throw new Error(`Aave V3 not supported on chain ${chainId}`);
   }
+  return config.market;
+}
+
+export function isChainSupported(chainId: number): chainId is SupportedChainId {
+  return chainId in CHAIN_CONFIG;
+}
+
+export function getChainName(
+  chainId: number,
+  fallback: string = "ethereum",
+): string {
+  return CHAIN_CONFIG[chainId as SupportedChainId]?.name || fallback;
 }

--- a/src/utils/aave/fetch.ts
+++ b/src/utils/aave/fetch.ts
@@ -3,7 +3,7 @@ import { ethers } from "ethers";
 import { useReownWalletProviderAndSigner } from "@/utils/wallet/reownEthersUtils";
 import { POOL_DATA_PROVIDER_ABI, POOL_ABI } from "@/types/aaveV3ABIs";
 import { Token, Chain } from "@/types/web3";
-import { getAaveMarket, SupportedChainId, ChainConfig } from "@/config/aave";
+import { getAaveMarket, SupportedChainId, ChainConfig, isChainSupported } from "@/config/aave";
 import { rayToPercentage } from "@/utils/aave/utils";
 import { ERC20_ABI } from "@/types/ERC20ABI";
 import { useCallback } from "react";
@@ -830,16 +830,6 @@ export const fetchExtendedAssetDetails = async (
 };
 
 /**
- * Check if a chain is supported by Aave V3
- */
-export function isChainSupported(chainId: number): chainId is SupportedChainId {
-  const supportedChains: number[] = [
-    1, 137, 42161, 10, 43114, 8453, 100, 56, 11155111,
-  ];
-  return supportedChains.includes(chainId);
-}
-
-/**
  * Get the Pool contract address for a chain
  */
 export function getPoolAddress(chainId: SupportedChainId): string {
@@ -1215,7 +1205,6 @@ export function useAaveFetch() {
     checkCollateralSafety,
 
     // SDK utility functions
-    isChainSupported: (chainId: number) => isChainSupported(chainId),
     getPoolAddress: (chainId: SupportedChainId) => getPoolAddress(chainId),
     getDataProviderAddress: (chainId: SupportedChainId) =>
       getDataProviderAddress(chainId),

--- a/src/utils/aave/interact.ts
+++ b/src/utils/aave/interact.ts
@@ -5,13 +5,13 @@ import { POOL_ABI } from "@/types/aaveV3ABIs";
 import { SupportedChainId } from "@/config/aave";
 import { ERC20_ABI } from "@/types/ERC20ABI";
 import {
-  isChainSupported,
   getPoolAddress,
   checkBalance,
   getAllowance,
   getUserAccountData,
   canDisableCollateral,
 } from "@/utils/aave/fetch";
+import { isChainSupported } from "@/config/aave";
 import {
   WithdrawParams,
   WithdrawResult,


### PR DESCRIPTION
please https://github.com/altverseweb3/site/commit/0607112599fd8c7aef05369add5a5d711b9191d5

This PR is concerned with consolidating everything to do with `aave` configurations into a single object to serve as a single source of truth to avoid repetition or divergences and to promote extendability. Most notably `isChainSupported` function which had the chain numbers hard-coded in the function were moved up from the `fetch` hook into the configuration.