### PR TITLE
fix: ltv asset details and total supplied calculations

### DIFF
--- a/src/components/ui/lending/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetailsModal.tsx
@@ -134,7 +134,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
             )}
 
             {(() => {
-              const metrics = getReserveMetrics(currentAsset, extendedDetails);
+              const metrics = getReserveMetrics(currentAsset);
               const tokenPrice = extendedDetails?.oraclePrice || 1;
 
               return (
@@ -161,7 +161,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
 
                       <div className="space-y-2">
                         {metrics.supplyCapFormatted !== "Unlimited" &&
-                        metrics.supplyCapUtilization > 0 ? (
+                          metrics.supplyCapUtilization > 0 ? (
                           <>
                             <div className="flex items-center justify-between text-xs">
                               <span className="text-zinc-400">
@@ -209,7 +209,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
 
                       <div className="space-y-2">
                         {metrics.borrowCapFormatted !== "No cap" &&
-                        metrics.borrowCapUtilization > 0 ? (
+                          metrics.borrowCapUtilization > 0 ? (
                           <>
                             <div className="flex items-center justify-between text-xs">
                               <span className="text-zinc-400">
@@ -421,7 +421,7 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                 <div>
                   <span className="text-sm text-zinc-400">max LTV</span>
                   <div className="text-sm font-medium">
-                    {extendedDetails?.ltv || "N/A"}
+                    {currentAsset?.ltv || extendedDetails?.ltv || "N/A"}
                   </div>
                 </div>
                 <div>
@@ -429,7 +429,9 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                     liquidation threshold
                   </span>
                   <div className="text-sm font-medium">
-                    {extendedDetails?.liquidationThreshold || "N/A"}
+                    {currentAsset?.liquidationThreshold ||
+                      extendedDetails?.liquidationThreshold ||
+                      "N/A"}
                   </div>
                 </div>
                 <div>
@@ -437,7 +439,9 @@ const AssetDetailsModal: FC<AssetDetailsModalProps> = ({
                     liquidation penalty
                   </span>
                   <div className="text-sm font-medium">
-                    {extendedDetails?.liquidationPenalty || "N/A"}
+                    {currentAsset?.liquidationPenalty ||
+                      extendedDetails?.liquidationPenalty ||
+                      "N/A"}
                   </div>
                 </div>
               </div>

--- a/src/components/ui/lending/BorrowUnownedCard.tsx
+++ b/src/components/ui/lending/BorrowUnownedCard.tsx
@@ -33,7 +33,7 @@ const BorrowUnownedCard: FC<BorrowUnownedCardProps> = ({
   currentAsset,
   availableToBorrow = "0.00",
   availableToBorrowUSD = "0.00",
-  onBorrow = () => {},
+  onBorrow = () => { },
   healthFactor = "1.24",
   totalCollateralUSD = 0,
   totalDebtUSD = 0,

--- a/src/components/ui/lending/SupplyOwnedCard.tsx
+++ b/src/components/ui/lending/SupplyOwnedCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import {
   BlueButton,
+  GrayButton,
   PrimaryButton,
 } from "@/components/ui/lending/SupplyButtonComponents";
 import { TokenImage } from "@/components/ui/TokenImage";
@@ -49,7 +50,7 @@ const SupplyOwnedCard = ({
   healthFactor = "1.24",
   totalCollateralUSD = 0,
   totalDebtUSD = 0,
-  onSwitch = () => {},
+  onSwitch = () => { },
   onCollateralChange = async () => true,
   onWithdrawComplete = async () => true,
 }: SupplyOwnedCardProps) => {
@@ -166,7 +167,7 @@ const SupplyOwnedCard = ({
               </button>
             </CollateralModal>
           ) : (
-            <SupplyCollateralSwitch isCollateral={false} onToggle={() => {}} />
+            <SupplyCollateralSwitch isCollateral={false} onToggle={() => { }} />
           )}
         </div>
       </CardContent>
@@ -199,7 +200,7 @@ const SupplyOwnedCard = ({
           <BlueButton>withdraw</BlueButton>
         </WithdrawModal>
         <AssetDetailsModal currentAsset={currentAsset}>
-          <BlueButton>details</BlueButton>
+          <GrayButton>details</GrayButton>
         </AssetDetailsModal>
       </CardFooter>
     </Card>

--- a/src/components/ui/lending/SupplyUnownedCard.tsx
+++ b/src/components/ui/lending/SupplyUnownedCard.tsx
@@ -30,7 +30,7 @@ const SupplyUnownedCard: FC<SupplyUnownedCardProps> = ({
   currentAsset,
   userBalance = "0",
   dollarAmount = "0.00",
-  onSupply = () => {},
+  onSupply = () => { },
 }) => {
   // Determine collateral status and isolation mode
   const canBeCollateral = currentAsset.canBeCollateral ?? true;

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -51,12 +51,24 @@ export interface AaveReserveData {
   formattedAvailableLiquidity: string;
   borrowCap: string;
   formattedBorrowCap: string;
+  supplyCap: string;
+  formattedSupplyCap: string;
 
   // General data
   isActive: boolean;
   isFrozen: boolean;
   isIsolationModeAsset?: boolean;
   debtCeiling?: number;
+  userBalance?: string;
+  userBalanceFormatted?: string;
+  userBalanceUsd?: string;
+  tokenIcon?: string;
+  chainId?: number;
+
+  // Risk parameters
+  ltv?: string;
+  liquidationThreshold?: string;
+  liquidationPenalty?: string;
 }
 
 export interface AaveReservesResult {

--- a/src/utils/aave/fetch.ts
+++ b/src/utils/aave/fetch.ts
@@ -229,6 +229,11 @@ export async function fetchAllReservesData(
                   reserveCaps.borrowCap,
                   decimals,
                 ),
+                supplyCap: reserveCaps.supplyCap.toString(),
+                formattedSupplyCap: ethers.formatUnits(
+                  reserveCaps.supplyCap,
+                  decimals,
+                ),
 
                 // General data
                 isActive: configData.isActive,
@@ -620,7 +625,6 @@ export async function fetchUserWalletBalances(
 
 export const getReserveMetrics = (
   currentAsset: AaveReserveData,
-  extendedDetails: ExtendedAssetDetails | null,
 ): ReserveMetrics => {
   const reserveSize = currentAsset.formattedSupply || "0";
   const availableLiquidity = currentAsset.formattedAvailableLiquidity || "0";
@@ -653,13 +657,9 @@ export const getReserveMetrics = (
   let supplyCapFormatted = "Unlimited";
   let borrowCapFormatted = "No cap";
 
-  if (
-    extendedDetails?.supplyCap &&
-    extendedDetails.supplyCap !== "Unlimited" &&
-    extendedDetails.supplyCap !== "0"
-  ) {
+  if (currentAsset.supplyCap && currentAsset.supplyCap !== "0") {
     try {
-      const supplyCapInTokens = parseFloat(extendedDetails.supplyCap);
+      const supplyCapInTokens = parseFloat(currentAsset.supplyCap);
 
       if (supplyCapInTokens > 0) {
         supplyCapUtilization = (totalSupplyNum / supplyCapInTokens) * 100;
@@ -1067,11 +1067,8 @@ export function useAaveFetch() {
   );
 
   const getReserveMetricsMemoized = useCallback(
-    (
-      currentAsset: AaveReserveData,
-      extendedDetails: ExtendedAssetDetails | null,
-    ) => {
-      return getReserveMetrics(currentAsset, extendedDetails);
+    (currentAsset: AaveReserveData) => {
+      return getReserveMetrics(currentAsset);
     },
     [],
   );


### PR DESCRIPTION
LTV calculations were using default values and were not being calculated properly additionally this was also the case for a % of total supplied. These have been addressed in this PR as well as standardising the color of the details button.
<img width="745" height="1149" alt="image" src="https://github.com/user-attachments/assets/451b4544-1e11-4fdf-8e1e-13b63f239675" />
<img width="641" height="380" alt="image" src="https://github.com/user-attachments/assets/4a3e4d29-353f-4ae0-8ebf-904650756c5c" />
