### PR TITLE
fix: use ticker instead of icon name for description

### DIFF
--- a/src/components/ui/lending/SupplyUnownedCard.tsx
+++ b/src/components/ui/lending/SupplyUnownedCard.tsx
@@ -67,7 +67,7 @@ const SupplyUnownedCard: FC<SupplyUnownedCardProps> = ({
             {currentAsset.asset.name}
           </CardTitle>
           <CardDescription className="text-gray-400 text-xs mt-1">
-            {currentAsset.asset.icon}
+            {currentAsset.asset.ticker}
           </CardDescription>
         </div>
       </CardHeader>


### PR DESCRIPTION
This PR resolves a bug where the icon name was erroneously used as the description for an asset on `SupplyUnownedCard.tsx`.