### PR TITLE
feat: improved UX for missing receive address in swap

### DIFF
--- a/src/components/ui/TokenTransfer.tsx
+++ b/src/components/ui/TokenTransfer.tsx
@@ -30,6 +30,8 @@ interface TokenTransferProps {
   receiveAmount?: string;
   isLoadingQuote?: boolean;
   estimatedTimeSeconds?: number | null;
+  showTransactionDetails: boolean;
+  onToggleTransactionDetails: () => void;
   // Token selection state
   hasSourceToken?: boolean;
   hasDestinationToken?: boolean;
@@ -54,6 +56,8 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
   receiveAmount = "",
   isLoadingQuote = false,
   estimatedTimeSeconds = null,
+  showTransactionDetails = false,
+  onToggleTransactionDetails,
   // Token selection state
   hasSourceToken = false,
   hasDestinationToken = false,
@@ -63,7 +67,6 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
 }) => {
   // State to track if the input should be enabled
   const [isInputEnabled, setIsInputEnabled] = useState(false);
-  const [showDetails, setShowDetails] = useState(false);
   const [sourceAmountValue, setSourceAmountValue] = useState(0);
   const [destinationAmountValue, setDestinationAmountValue] = useState(0);
   const tokensByCompositeKey = useWeb3Store(
@@ -107,7 +110,7 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
   ]);
 
   const defaultSettingsButton = (
-    <button onClick={() => setShowDetails(!showDetails)}>
+    <button onClick={onToggleTransactionDetails}>
       <Settings className="h-5 w-5 text-zinc-400 hover:text-zinc-50 transition-colors" />
     </button>
   );
@@ -212,9 +215,9 @@ export const TokenTransfer: React.FC<TokenTransferProps> = ({
           protocolFeeUsd={protocolFeeUsd}
           relayerFeeUsd={relayerFeeUsd}
           totalFeeUsd={totalFeeUsd}
-          detailsOpen={showDetails}
-          onDetailsToggle={() => setShowDetails(!showDetails)}
-          isLoadingQuote={isLoadingQuote} // Pass the loading state to SwapInterface
+          detailsOpen={showTransactionDetails}
+          onDetailsToggle={onToggleTransactionDetails}
+          isLoadingQuote={isLoadingQuote}
         >
           {transferContent}
         </SwapInterface>

--- a/src/store/storeVersion.ts
+++ b/src/store/storeVersion.ts
@@ -1,1 +1,1 @@
-export const STORE_VERSION = 7;
+export const STORE_VERSION = 8;

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -961,6 +961,10 @@ export const useGetWalletBySourceChain = (): WalletInfo | null => {
   return useWeb3Store((state) => state.getWalletBySourceChain());
 };
 
+export const useGetWalletByDestinationChain = (): WalletInfo | null => {
+  return useWeb3Store((state) => state.getWalletByDestinationChain());
+};
+
 export const useLoadTokens = () => {
   return useWeb3Store((state) => state.loadTokens);
 };


### PR DESCRIPTION
This PR improves the UX when a receive address is not set (the destination wallet is not connected, or the user has not entered a valid destination address).

The flow is now:
1. user clicks the swap button
2. the transaction details modal will open
3. the user will be able to clearly see the connect wallet button
4. the user will be presented with an info toast telling them to connect the destination wallet or enter an address

This involved shifting the state management of the transaction details open state back to the `SwapComponent`, rather than being handled through a `useState` variable at the `TokenTransfer` component.

I have also added a `useGetWalletByDestinationChain` function for ease of use.