### PR TITLE
bugfix: balance prices infinite loop

### DIFF
--- a/src/components/meta/TokensInitializer.tsx
+++ b/src/components/meta/TokensInitializer.tsx
@@ -24,8 +24,8 @@ const TokenInitializer: React.FC = () => {
   const requiredWallet = useWeb3Store((state) =>
     state.getWalletBySourceChain(),
   );
-  const destinationToken = useDestinationToken();
-  const sourceToken = useSourceToken();
+  const destinationTokenId = useDestinationToken()?.id;
+  const sourceTokenId = useSourceToken()?.id;
 
   // Track whether the user is active or idle
   const [isIdle, setIsIdle] = useState(false);
@@ -67,8 +67,8 @@ const TokenInitializer: React.FC = () => {
     requiredWallet,
     connectedWallets,
     isIdle,
-    destinationToken,
-    sourceToken,
+    destinationTokenId,
+    sourceTokenId,
   ]);
 
   return null;

--- a/src/components/ui/SelectTokenButton.tsx
+++ b/src/components/ui/SelectTokenButton.tsx
@@ -30,6 +30,7 @@ import { SkeletonTokenList } from "@/components/ui/SkeletonTokenList";
 import { getTokenMetadata } from "@/utils/tokens/tokenApiMethods";
 import useUIStore from "@/store/uiStore";
 import { parseDecimalNumber } from "@/utils/tokens/tokenMethods";
+import { truncateAddress, formatBalance } from "@/utils/formatters";
 
 interface TokenListItemProps {
   token: Token;
@@ -41,14 +42,6 @@ interface TokenListItemProps {
 
 const TokenListItem: React.FC<TokenListItemProps> = React.memo(
   ({ token, onSelect, copiedAddresses, onCopy, chain }) => {
-    const formatAddress = (address: string) => {
-      if (!address) return "";
-      if (address.length <= 8) return address;
-      return `${address.substring(0, 6)}...${address.substring(
-        address.length - 4,
-      )}`;
-    };
-
     const handleClick = useCallback(() => {
       onSelect(token);
     }, [onSelect, token]);
@@ -95,7 +88,7 @@ const TokenListItem: React.FC<TokenListItemProps> = React.memo(
                 </span>
                 <div className="flex items-center">
                   <span className="numeric-input text-sm flex items-center">
-                    {formatAddress(token.address)}
+                    {truncateAddress(token.address)}
                   </span>
                   <button
                     className="ml-1 text-[#FAFAFA40] hover:text-[#FAFAFA80] focus:outline-none transition-colors opacity-0 group-hover:opacity-100"
@@ -127,7 +120,9 @@ const TokenListItem: React.FC<TokenListItemProps> = React.memo(
           </div>
           <div className="text-right">
             <div className="font-regular text-[#FAFAFA] numeric-input">
-              {token.userBalanceUsd ? `$${token.userBalanceUsd}` : ""}
+              {token.userBalanceUsd
+                ? `$${formatBalance(token.userBalanceUsd)}`
+                : ""}
             </div>
             <div className="text-sm text-[#FAFAFA55] numeric-input">
               <FormattedNumber value={token.userBalance || "0"} />


### PR DESCRIPTION
branch off #236, will rebase

The only file change relevant to this PR is `TokensInitializer.tsx`

This PR resolves the infinite loop on loading balances and prices. The issue was that the recent fix to the balance display #231. Since #231 we update the `sourceToken` and `destinationToken` objects when the token balances/prices are updated. The issue is that these are also dependencies on our `getPricesAndBalances` call in `TokensInitializer.tsx`... meaning each time the function completes it re-triggers itself.

The fix is to instead use the `sourceToken.id` and `destinationToken.id` instead of the entire objects as dependencies - that way the `getPricesAndBalances` will only run when the actual selected values change, not just ANY property on the token (such as the balance or price).