### PR TITLE
refactor: removed debugging console logs from swap history

### DIFF
--- a/src/hooks/useSwapHistory.ts
+++ b/src/hooks/useSwapHistory.ts
@@ -133,10 +133,6 @@ export const useSwapHistory = (): UseSwapHistoryReturn => {
     }));
 
     try {
-      // Use the userWallets that were extracted at the top level
-      console.log("Connected Wallets Summary:", walletSummary);
-      console.log("Querying swap history for wallets:", userWallets);
-
       // Check if any wallets are connected
       if (connectedWallets.length === 0) {
         throw new Error("No wallets connected");
@@ -179,13 +175,9 @@ export const useSwapHistory = (): UseSwapHistoryReturn => {
 
       // Flatten all swaps from all results
       const allSwapsRaw = result.results.flatMap((r) => r.response.data);
-      console.log(`Raw swaps before deduplication: ${allSwapsRaw.length}`);
 
       // Deduplicate swaps to remove duplicates from multiple referrer queries
       const deduplicatedSwaps = deduplicateSwaps(allSwapsRaw);
-      console.log(
-        `Swaps after deduplication: ${deduplicatedSwaps.length} (removed ${allSwapsRaw.length - deduplicatedSwaps.length} duplicates)`,
-      );
 
       // Sort by initiation date (most recent first)
       deduplicatedSwaps.sort(
@@ -208,15 +200,6 @@ export const useSwapHistory = (): UseSwapHistoryReturn => {
         error: null,
         summary: updatedSummary,
       });
-
-      console.log("✅ Swap history successfully loaded:", {
-        connectedWallets: connectedWallets.length,
-        totalQueries: result.summary.totalQueries,
-        totalSwapsRaw: allSwapsRaw.length,
-        totalSwapsUnique: deduplicatedSwaps.length,
-        duplicatesRemoved: allSwapsRaw.length - deduplicatedSwaps.length,
-        swapsByChain: result.summary.swapsByChain,
-      });
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "Failed to fetch swap history";
@@ -229,7 +212,7 @@ export const useSwapHistory = (): UseSwapHistoryReturn => {
       }));
       console.error("❌ Error fetching swap history:", error);
     }
-  }, [connectedWallets, walletSummary, userWallets]); // Added userWallets to dependencies
+  }, [connectedWallets, userWallets]); // Added userWallets to dependencies
 
   return {
     ...state,

--- a/src/hooks/useSwapTracking.ts
+++ b/src/hooks/useSwapTracking.ts
@@ -19,7 +19,6 @@ export function useSwapTracking(
   const startTracking = useCallback(async () => {
     if (!swapId) return;
 
-    console.log("Starting tracking for:", swapId);
     setIsLoading(true);
     setError(null);
     setStatus(null);
@@ -38,13 +37,8 @@ export function useSwapTracking(
         optionsRef.current.onStatusUpdate?.(newStatus);
       },
       onComplete: (finalStatus: SwapStatus) => {
-        console.log("Tracking completed:", finalStatus.clientStatus);
-
         // Prevent multiple completion calls
-        if (hasCompletedRef.current) {
-          console.log("Already completed, ignoring duplicate completion");
-          return;
-        }
+        if (hasCompletedRef.current) return;
 
         hasCompletedRef.current = true;
         setIsLoading(false);
@@ -54,10 +48,9 @@ export function useSwapTracking(
         optionsRef.current.onComplete?.(finalStatus);
       },
       onError: (err: Error) => {
-        console.log("Tracking error:", err.message);
+        console.error("Tracking error:", err.message);
 
         if (hasCompletedRef.current) {
-          console.log("Already completed, ignoring error");
           return;
         }
 
@@ -82,7 +75,6 @@ export function useSwapTracking(
   }, [swapId]); // Now only depends on swapId
 
   const stopTracking = useCallback(() => {
-    console.log("Stopping tracking");
     if (trackerRef.current) {
       trackerRef.current.stopPolling();
       trackerRef.current = null;


### PR DESCRIPTION
This PR removes the debugging `console.log` statements, and corrects some usage to `console.error` in all files related to tracking swap history.

This is part of the initiative to cleanup our incredibly noisy debugging console log - doing it section by section.