### PR TITLE
chore: toAmount now shows -- instead of NaN

### DIFF
--- a/src/components/ui/SwapHistorySheet.tsx
+++ b/src/components/ui/SwapHistorySheet.tsx
@@ -23,6 +23,7 @@ import { WalletType, SwapData } from "@/types/web3";
 import { getChainByMayanChainId, getChainByMayanName } from "@/config/chains";
 import { getExplorerUrl } from "@/utils/common";
 import type { WalletFilterType } from "@/types/web3";
+import { truncateAddress } from "@/utils/formatters";
 
 interface SwapHistorySheetProps {
   isOpen: boolean;
@@ -107,7 +108,7 @@ const mapSwapToTransaction = (swap: SwapData): TransactionDisplay => {
     fromChain: getChainName(swap.sourceChain),
     toChain: getChainName(swap.destChain),
     fromAmount: `${parseFloat(swap.fromAmount).toFixed(4)} ${swap.fromTokenSymbol}`,
-    toAmount: `${parseFloat(swap.toAmount).toFixed(6)} ${swap.toTokenSymbol}`,
+    toAmount: `${swap.toAmount ? parseFloat(swap.toAmount).toFixed(6) : "--"} ${swap.toTokenSymbol}`,
     status: swap.clientStatus.toLowerCase(),
     timestamp: formatTimeAgo(swap.initiatedAt),
     txHash: swap.sourceTxHash,
@@ -419,7 +420,7 @@ export function SwapHistorySheet({
 
       <div className="flex items-center justify-between pt-3 border-t border-amber-500/20 group-hover:border-amber-500/30 transition-colors">
         <span className="text-xs text-muted-foreground font-mono bg-white/5 px-3 py-2 rounded-lg group-hover:bg-white/10 transition-all">
-          {tx.txHash.slice(0, 8)}...{tx.txHash.slice(-6)}
+          {truncateAddress(tx.txHash)}
         </span>
         <div className="flex gap-2">
           <Button


### PR DESCRIPTION
This PR changes the displayed `toAmount` of a swap in the swap history sheet to show "--" instead of "NaN" tokens. Unfortunately we aren't given an estimated `toAmount` when querying the swap tx hash so this is the best we can do.

I have also refactored the slicing the transaction hash to use the `truncateAddress` util.

**Screenshot**
<img width="722" height="486" alt="Screenshot 2025-08-10 at 10 03 08 am" src="https://github.com/user-attachments/assets/c2e8e1e6-607d-4af5-b24c-96bf56e54b80" />
