### PR TITLE
chore: lowercase evm addresses

### DIFF
--- a/src/utils/tokens/tokenMethods.ts
+++ b/src/utils/tokens/tokenMethods.ts
@@ -1,6 +1,6 @@
 // src/utils/tokenMethods.ts
 import chains from "@/config/chains";
-import { Token } from "@/types/web3";
+import { Token, WalletType } from "@/types/web3";
 import { getChainById } from "@/config/chains";
 import { FormattedNumberParts } from "@/types/ui";
 import { DEPOSIT_ASSETS } from "@/config/etherFi";
@@ -65,6 +65,7 @@ export const loadTokensForChain = async (
 
     const numericChainId = chainConfig.chainId;
     const isSuiChain = fetchChainId === "sui";
+    const isEvmChain = chainConfig.walletType === WalletType.REOWN_EVM;
     const chainId = chainConfig.id;
 
     // Load standard tokens - filter out native tokens since they're handled separately
@@ -74,7 +75,9 @@ export const loadTokensForChain = async (
         // All remaining tokens have real contract addresses
         const contractAddress = isSuiChain
           ? normalizeSuiAddressToShort(item.contract_address)
-          : item.contract_address;
+          : isEvmChain
+            ? item.contract_address.toLowerCase()
+            : item.contract_address;
 
         return {
           id: item.id,


### PR DESCRIPTION
This PR lowercases EVM `Token` object addresses at the `loadTokensForChain` function.

The reasoning for this is that we have some functions (such as our prices/balances API) that will fail if a lowercased version of the address is not supplied.

There are some other cases where `.toLowerCase()` has been applied when comparing/matching tokens.

We don't want to have to rely on the developers each time to `.toLowerCase()` an address on each call to the prices/balances, or a similar comparison.

Going forward, we should just opt to use lowercased EVM addresses everywhere, ensuring we apply `.toLowerCase()` at the highest level possible to avoid having to do it everywhere.

Following on from this PR we can start to remove the redundant use of `.toLowerCase()` throughout the repo when referencing EVM addresses, but this should be done slowly and with extreme caution.