### PR TITLE
bugfix: earn vault balances

### DIFF
--- a/src/app/(dapp)/earn/page.tsx
+++ b/src/app/(dapp)/earn/page.tsx
@@ -89,10 +89,8 @@ export default function EarnPage() {
     setActiveSwapSection("earn");
   }, [setActiveSwapSection]);
 
-  // ✅ Enhanced chain switching with attempt tracking
   useEffect(() => {
     const attemptChainSwitch = async () => {
-      // Only attempt if we haven't tried yet for this wallet connection
       if (chainSwitchAttempted) return;
 
       const walletForEthereum = useWeb3Store
@@ -100,33 +98,19 @@ export default function EarnPage() {
         .getWalletByChain(ethereumChain);
 
       if (isEvmWalletConnected && switchToChain && walletForEthereum) {
-        console.log("Switching to Ethereum chain...", {
-          isEvmWalletConnected,
-          walletForEthereum,
-          ethereumChain: ethereumChain.name,
-        });
-
         setChainSwitchAttempted(true);
 
         try {
           await switchToChain(ethereumChain);
-          console.log("Successfully switched to Ethereum chain");
         } catch (error) {
           console.error("Failed to switch to Ethereum chain:", error);
         }
-      } else {
-        console.log("Not switching to Ethereum chain:", {
-          isEvmWalletConnected,
-          hasWalletForEthereum: !!walletForEthereum,
-          hasSwitchFunction: !!switchToChain,
-        });
       }
     };
 
     attemptChainSwitch();
-  }, [isEvmWalletConnected, switchToChain, chainSwitchAttempted]); // ✅ Include all dependencies safely
+  }, [isEvmWalletConnected, switchToChain, chainSwitchAttempted]);
 
-  // ✅ Reset attempt flag when wallet disconnects
   useEffect(() => {
     if (!isEvmWalletConnected) {
       setChainSwitchAttempted(false);

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -566,7 +566,6 @@ export function useChainSwitch(sourceChain: Chain) {
     error,
     switchToSourceChain,
     switchToChain,
-    // ✅ Return wallet info for debugging
     requiredWallet,
     hasRequiredWallet: !!requiredWallet,
   };


### PR DESCRIPTION
This PR resolves a bug in which the Earn vault balances were not loading. I noticed that the RPC calls were giving a generic error, and quickly realised the root cause was that the EVM wallet chain (metamask) was not set to Ethereum.

Unfortunately, it wasn't as simple as just calling `switchToChain(ethereumChain` on render of the earn `page.tsx`.

There are a number of things that messed with me here:
1. There is a bit of a race condition with setting the active swap section to `earn`. If the user was on the `/swap` page, and their `sourceChain` was not Ethereum, upon loading Earn their `sourceChain` would still be that non-ethereum chain until active swap section had updated to `earn` - but by this time the `const sourceChain` had already been instantiated leading to a stale chain reference.
2. the dependencies on `switchToChain` led to some nasty infinite loops

The approach I have taken here is to very safely call `switchToChain` on loading the Earn page. I do this through a very React friendly `useState` management approach where I track attempts to switch to the ethereum chain - if we have already attempted it and it has failed, we DO NOT continue trying to force it to switch.

I have also added in some extra guardrails into the `switchToChain` function to check if wallet connections are active/hydrated, otherwise skip the chain switch.

I feel as though this chain has highlighted some issues with our approach to swap section management. However, this is a fairly critical bug that we should get through and we can look at architecting these components down the line.