### PR TITLE
chore: updated solana RPC url

### DIFF
--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -1287,7 +1287,7 @@ export function useTokenTransfer(
         // Get Solana signer
         const solanaSigner = await getSolanaSigner();
         const connection = new Connection(
-          `https://solana-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
+          `https://solana-rpc.publicnode.com`,
           "confirmed",
         );
         // Execute Solana swap


### PR DESCRIPTION
This PR updates the Solana RPC url used for executing swaps from Solana. I have tested that this works and have not found any issues with rate limiting.

We can also remove the `NEXT_PUBLIC_ALCHEMY_API_KEY` from our Vercel config now.