### PR TITLE
feature: select chain button variant

### DIFF
--- a/src/components/ui/SelectChainButton.tsx
+++ b/src/components/ui/SelectChainButton.tsx
@@ -80,7 +80,7 @@ export const SelectChainButton: React.FC<SelectChainButtonProps> = ({
     (state) => state.setDestinationChain,
   );
 
-  // Determine the chain to display (from store or props)
+  // Determine the chain to display (from store)
   const selectedChain = storeType
     ? storeType === "source"
       ? sourceChain


### PR DESCRIPTION
this PR adds a new style variant to the `SelectChainButton.tsx` called `compact`. This is done through a prop named `style` with two options: `default` and `compact`. Any implementation of the `SelectChainButton` will default to the `default` style, so no changes are needed anywhere else for now.

The plan is to use the `compact` style in the `SelectTokenButton.tsx`, coming in the next PR.

### Screenshots
<img width="208" height="156" alt="Screenshot 2025-08-16 at 2 38 51 pm" src="https://github.com/user-attachments/assets/6f5b060b-2232-435d-8979-63eecc81a2a0" />
<img width="420" height="820" alt="Screenshot 2025-08-16 at 2 38 57 pm" src="https://github.com/user-attachments/assets/c4c49574-3017-4df1-bfcc-0e43d7af80b3" />
