### PR TITLE
feat: added featured tokens prop to SelectTokenButton

### DIFF
--- a/src/components/ui/TokenInputGroup.tsx
+++ b/src/components/ui/TokenInputGroup.tsx
@@ -3,6 +3,7 @@ import { SelectTokenButton } from "@/components/ui/SelectTokenButton";
 import { TokenAmountInput } from "@/components/ui/TokenAmountInput";
 import useUIStore from "@/store/uiStore";
 import { useSourceToken, useDestinationToken } from "@/store/web3Store";
+import { Token } from "@/types/web3";
 
 interface TokenInputGroupProps {
   variant: "source" | "destination";
@@ -13,6 +14,8 @@ interface TokenInputGroupProps {
   readOnly?: boolean;
   isLoadingQuote?: boolean;
   isEnabled?: boolean; // New prop to control if input is enabled
+  featuredTokens?: Token[];
+  featuredTokensDescription?: string;
 }
 
 export function TokenInputGroup({
@@ -24,6 +27,8 @@ export function TokenInputGroup({
   readOnly = false,
   isLoadingQuote = false,
   isEnabled = true, // Default to true
+  featuredTokens = [],
+  featuredTokensDescription = "",
 }: TokenInputGroupProps) {
   const setSourceTokenSelectOpen = useUIStore(
     (state) => state.setSourceTokenSelectOpen,
@@ -42,7 +47,13 @@ export function TokenInputGroup({
 
   return (
     <div className="flex justify-between items-start gap-2 sm:gap-4 w-full">
-      {showSelectToken && <SelectTokenButton variant={variant} />}
+      {showSelectToken && (
+        <SelectTokenButton
+          variant={variant}
+          featuredTokens={featuredTokens}
+          featuredTokensDescription={featuredTokensDescription}
+        />
+      )}
       <TokenAmountInput
         amount={amount}
         onChange={onChange}


### PR DESCRIPTION
This PR adds two new props to the `SelectTokenButton.tsx` component: `featuredTokens` and `featuredTokensDescription`. The purpose of this is to create a new section in the token select modal to highlight particular tokens regardless of a users balance - such as a selected vault approved deposit assets, or a selected aave supply modal asset.

featuredTokens will still only show if their chain is selected to avoid confusion.

### Screenshot
**An example of featured tokens being used on the supply WETH modal**
<img width="1026" height="1214" alt="Screenshot 2025-08-17 at 8 19 20 am" src="https://github.com/user-attachments/assets/cd4d0bed-9691-4c76-97e5-6794164433c8" />
