### PR TITLE
chore: manually toLowerCase all instances of asset.address in fetch

### DIFF
--- a/src/utils/aave/fetch.ts
+++ b/src/utils/aave/fetch.ts
@@ -338,7 +338,7 @@ export async function fetchUserPositions(
         try {
           // Get user reserve data using the ABI function
           const userReserveData = await poolDataProvider.getUserReserveData(
-            reserve.asset.address,
+            reserve.asset.address.toLowerCase(),
             userAddress,
           );
 
@@ -436,7 +436,7 @@ export async function fetchUserBorrowPositions(
         try {
           // Get user reserve data using the ABI function
           const userReserveData = await poolDataProvider.getUserReserveData(
-            reserve.asset.address,
+            reserve.asset.address.toLowerCase(),
             userAddress,
           );
 
@@ -538,7 +538,7 @@ export async function fetchUserWalletBalances(
         try {
           // Get user's wallet balance for this token
           const tokenContract = new ethers.Contract(
-            reserve.asset.address,
+            reserve.asset.address.toLowerCase(),
             ERC20_ABI,
             provider,
           );


### PR DESCRIPTION
This PR forces all references to `reserve.asset.address` to be suffixed with a `.toLowerCase()` to patch the known checksum issue encountered when loading `/lending`.

This should be considered a temporary patch to aid debugging efforts of other errors - the root cause of why mixed case addresses are being assigned to `Token` objects is still under investigation.