### PR TITLE
feature: parameterised default chains for swap section creation

### DIFF
--- a/src/store/storeVersion.ts
+++ b/src/store/storeVersion.ts
@@ -1,1 +1,1 @@
-export const STORE_VERSION = 8;
+export const STORE_VERSION = 9;

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -18,6 +18,7 @@ import {
   defaultSourceChain,
   defaultDestinationChain,
   getChainByChainId,
+  getChainById,
 } from "@/config/chains";
 import {
   loadAllTokens,
@@ -27,9 +28,9 @@ import { chains } from "@/config/chains";
 import { TokenPrice } from "@/types/web3";
 import { STORE_VERSION } from "@/store/storeVersion";
 
-const createDefaultSwapStateForSection = (): SwapStateForSection => ({
-  sourceChain: defaultSourceChain,
-  destinationChain: defaultDestinationChain,
+const createDefaultSwapStateForSection = (sourceChain?: Chain, destinationChain?: Chain): SwapStateForSection => ({
+  sourceChain: sourceChain || defaultSourceChain,
+  destinationChain: destinationChain || defaultDestinationChain,
   sourceToken: null,
   destinationToken: null,
   transactionDetails: {
@@ -48,8 +49,8 @@ const useWeb3Store = create<Web3StoreState>()(
       // Initialize with default integrations
       swapIntegrations: {
         swap: createDefaultSwapStateForSection(),
-        earn: createDefaultSwapStateForSection(),
-        lend: createDefaultSwapStateForSection(),
+        earn: createDefaultSwapStateForSection(getChainById('ethereum'), getChainById('ethereum')),
+        lend: createDefaultSwapStateForSection(getChainById('ethereum'), getChainById('ethereum')),
       },
 
       activeSwapSection: "swap" as SectionKey,


### PR DESCRIPTION
This PR parameterises the default `sourceChain` and `destinationChain` values for swap sections. The issue is that the `defaultDestinationChain` is currently Solana - which obviously does not make sense for either Earn or Lending, given that in Earn we only support Ethereum vaults currently, and in Lending we only support EVM positions.

This should resolve the error logs we see when on the Earn or Lending sections regarding Solana balance/price fetching.