### PR TITLE
chore: removed unnecessary duplicated error in price result update

### DIFF
--- a/src/store/storeVersion.ts
+++ b/src/store/storeVersion.ts
@@ -1,1 +1,1 @@
-export const STORE_VERSION = 9;
+export const STORE_VERSION = 10;

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -28,7 +28,10 @@ import { chains } from "@/config/chains";
 import { TokenPrice } from "@/types/web3";
 import { STORE_VERSION } from "@/store/storeVersion";
 
-const createDefaultSwapStateForSection = (sourceChain?: Chain, destinationChain?: Chain): SwapStateForSection => ({
+const createDefaultSwapStateForSection = (
+  sourceChain?: Chain,
+  destinationChain?: Chain,
+): SwapStateForSection => ({
   sourceChain: sourceChain || defaultSourceChain,
   destinationChain: destinationChain || defaultDestinationChain,
   sourceToken: null,
@@ -49,8 +52,14 @@ const useWeb3Store = create<Web3StoreState>()(
       // Initialize with default integrations
       swapIntegrations: {
         swap: createDefaultSwapStateForSection(),
-        earn: createDefaultSwapStateForSection(getChainById('ethereum'), getChainById('ethereum')),
-        lend: createDefaultSwapStateForSection(getChainById('ethereum'), getChainById('ethereum')),
+        earn: createDefaultSwapStateForSection(
+          getChainById("ethereum"),
+          getChainById("ethereum"),
+        ),
+        lend: createDefaultSwapStateForSection(
+          getChainById("ethereum"),
+          getChainById("ethereum"),
+        ),
       },
 
       activeSwapSection: "swap" as SectionKey,
@@ -681,10 +690,6 @@ const useWeb3Store = create<Web3StoreState>()(
 
         priceResults.forEach((result) => {
           if (result.error) {
-            console.error(
-              `Error in price data for ${result.network}/${result.address}:`,
-              result.error,
-            );
             return;
           }
 


### PR DESCRIPTION
This PR removes a duplicated `console.error` that occurs when the fetch price call fails. This is already handled by a `console.warn` in `tokenApiMethods.ts`.

## Screenshots

**Before**
<img width="1870" height="360" alt="Screenshot 2025-08-18 at 6 02 56 am" src="https://github.com/user-attachments/assets/54cd21b7-1f05-40f9-866a-ee759146c7ac" />

**After**
<img width="1832" height="190" alt="Screenshot 2025-08-18 at 6 03 06 am" src="https://github.com/user-attachments/assets/7f52547d-933f-4983-b667-7b26126b792e" />
