### PR TITLE
chore: lowercase etherfi assets

### DIFF
--- a/src/utils/tokens/tokenMethods.ts
+++ b/src/utils/tokens/tokenMethods.ts
@@ -237,7 +237,7 @@ export const loadTokensForChain = async (
           name: key.toLowerCase(),
           ticker: key.toUpperCase(),
           icon: asset.imagePath,
-          address: asset.contractAddress,
+          address: asset.contractAddress.toLowerCase(),
           decimals: asset.decimals,
           chainId: numericChainId,
           stringChainId: chainId,


### PR DESCRIPTION
This PR lowercases etherfi assets in `loadTokensForChain` in alignment with how we apply lowercasing for all other assets.