### PR TITLE
feature: created aave client and provider

### DIFF
--- a/src/components/meta/AaveClientProvider.tsx
+++ b/src/components/meta/AaveClientProvider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { AaveProvider } from "@aave/react";
+import { aaveClient } from "@/config/aave/aaveClient";
+
+interface AaveClientProviderProps {
+  children: React.ReactNode;
+}
+
+export function AaveClientProvider({ children }: AaveClientProviderProps) {
+  return <AaveProvider client={aaveClient}>{children}</AaveProvider>;
+}

--- a/src/config/aave/aaveClient.ts
+++ b/src/config/aave/aaveClient.ts
@@ -1,0 +1,3 @@
+import { AaveClient } from "@aave/react";
+
+export const aaveClient = AaveClient.create();


### PR DESCRIPTION
This PR sets up the base for our Aave v3 SDK client configuration.

I have chosen to split the `aaveClient` creation into a separate file entirely to keep it as modular as possible.

The `AaveClientProvider` will act similarly to our `WalletContext` or `TokensInitializer` components, which sit as high level wrappers for pages such that the hooks they define can be accessed anywhere within their children, without having to messily control state between them.

This approach is based on the documentation found in the [Aave React SDK | Getting started](https://aave.com/docs/developers/aave-v3/getting-started/react) documentation