### PR TITLE
feature: aave client provider integration

### DIFF
--- a/src/app/(dapp)/layout.tsx
+++ b/src/app/(dapp)/layout.tsx
@@ -2,7 +2,7 @@ import { SiteHeader } from "@/components/layout/SiteHeader";
 import { SiteFooter } from "@/components/layout/SiteFooter";
 import TokenInitializer from "@/components/meta/TokensInitializer";
 import { CombinedWalletProvider } from "@/components/meta/WalletContext";
-
+import { AaveClientProvider } from "@/components/meta/AaveClientProvider";
 export default async function DAppLayout({
   children,
 }: {
@@ -11,11 +11,13 @@ export default async function DAppLayout({
   return (
     <CombinedWalletProvider>
       <div className="flex flex-col h-dvh">
-        <TokenInitializer />
-        <SiteHeader />
-        <main className="container mx-auto flex-1 pt-6 px-2 sm:px-4 pb-6">
-          {children}
-        </main>
+        <AaveClientProvider>
+          <TokenInitializer />
+          <SiteHeader />
+          <main className="container mx-auto flex-1 pt-6 px-2 sm:px-4 pb-6">
+            {children}
+          </main>
+        </AaveClientProvider>
         <SiteFooter />
       </div>
     </CombinedWalletProvider>

--- a/src/components/meta/AaveClientProvider.tsx
+++ b/src/components/meta/AaveClientProvider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { AaveProvider } from "@aave/react";
+import { aaveClient } from "@/config/aave/aaveClient";
+
+interface AaveClientProviderProps {
+  children: React.ReactNode;
+}
+
+export function AaveClientProvider({ children }: AaveClientProviderProps) {
+  return <AaveProvider client={aaveClient}>{children}</AaveProvider>;
+}

--- a/src/config/aave/aaveClient.ts
+++ b/src/config/aave/aaveClient.ts
@@ -1,0 +1,3 @@
+import { AaveClient } from "@aave/react";
+
+export const aaveClient = AaveClient.create();


### PR DESCRIPTION
branch off #273 

This PR integrates the `AaveClientProvider` into the `(dapp)/layout.tsx` such that the client configuration and state can be easily used throughout the dApp.

**Why are we putting it at `(dapp)/layout.tsx`, not `(dapp)/lending/layout.tsx`?**
This was my initial thought too. However, given that we intend to onboard other Aave features down the line (in particular earn vaults), I figured it would be best to future proof and set this client provider at the dApp level rather than a particular page.

Additionally, the client is extremely resource efficient and will not have an impact on performance. When the client is not being actively called (i.e. we are not on the `/lending` page), it will just sit there as a configured object.