### PR TITLE
refactor: removed unnecessary formatErrorMessage function

### DIFF
--- a/src/components/ui/earn/DepositModal.tsx
+++ b/src/components/ui/earn/DepositModal.tsx
@@ -771,34 +771,6 @@ const DepositModal: React.FC<DepositModalProps> = ({
     return "pending";
   };
 
-  const formatErrorMessage = (error: string | Error | unknown): string => {
-    let errorString = "";
-
-    if (error instanceof Error) {
-      errorString = error.message;
-    } else if (typeof error === "string") {
-      errorString = error;
-    } else {
-      errorString = "An unexpected error occurred";
-    }
-
-    // Handle hex data
-    if (errorString.startsWith("0x") && errorString.length > 100) {
-      return "Transaction failed due to invalid data format";
-    }
-
-    if (/^[0-9a-fA-F]+$/.test(errorString) && errorString.length > 100) {
-      return "Transaction failed due to invalid data format";
-    }
-
-    const MAX_LENGTH = 300;
-    if (errorString.length > MAX_LENGTH) {
-      return errorString.substring(0, MAX_LENGTH) + "...";
-    }
-
-    return errorString;
-  };
-
   const StepIndicator = ({
     step,
     title,
@@ -863,8 +835,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
           {activeProcess && activeProcess.state !== "CANCELLED" && (
             <div className="p-4 bg-[#27272A] rounded-lg border border-[#3F3F46]">
               <div className="text-sm font-medium text-[#FAFAFA] mb-3 break-words">
-                {formatErrorMessage(processProgress?.description) ||
-                  "Processing..."}
+                {processProgress?.description || "Processing..."}
               </div>
 
               <div className="space-y-3">
@@ -980,7 +951,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
               {conversionError ? (
                 <div className="mt-1 text-sm text-red-400 flex items-center gap-1">
                   <AlertCircle className="w-4 h-4" />
-                  {conversionError}
+                  {parseDepositError(conversionError)}
                 </div>
               ) : vaultSharesPreview ? (
                 <div className="mt-1">

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -1583,9 +1583,10 @@ export function parseDepositError(error: unknown): string {
         regex: /transfer amount exceeds balance/i,
         message: "Insufficient token balance for this deposit",
       },
-      // Gas errors
+      // More specific gas errors (removed "execution reverted")
       {
-        regex: /gas|fee|ETH balance|execution reverted/i,
+        regex:
+          /insufficient funds|gas required exceeds allowance|out of gas|gas limit|transaction underpriced|max fee per gas|base fee/i,
         message: "Not enough ETH to cover gas fees",
       },
       // Approval errors
@@ -1597,6 +1598,12 @@ export function parseDepositError(error: unknown): string {
       {
         regex: /timeout|timed? out|expired/i,
         message: "Request timed out. Please try again.",
+      },
+      // Generic execution reverted
+      {
+        regex: /execution reverted/i,
+        message:
+          "Smart contract call failed. Please check your transaction details and try again.",
       },
     ];
 


### PR DESCRIPTION
This PR removes the redundant `formatErrorMessage` function and instead uses the more well-defined `parseDepositError` function for errors occuring on the etherfi smart contract call stage of the deposit (or fetching the estimated amount of the vault token received as an RPC call). 

I have also updated the `parseDepositError` function to include a more generic transaction reverted catch when the exact cause of an error is not clear.

## Screenshots

### Before
<img width="2044" height="1216" alt="Screenshot 2025-08-23 at 8 23 24 pm" src="https://github.com/user-attachments/assets/92293443-0cdf-4859-9374-12567d8843d3" />

### After
<img width="1004" height="1298" alt="Screenshot 2025-08-23 at 8 22 44 pm" src="https://github.com/user-attachments/assets/591a5324-47e6-4f0e-a93a-30ca7ec9fbe7" />

