### PR TITLE
feat: added web3store property for selected aave chains

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -6,14 +6,19 @@ import { Chain } from "@/types/web3";
 import { chainList } from "@/config/chains";
 import ChainPicker from "@/components/ui/ChainPicker";
 import { useAaveChainsData } from "@/hooks/aave/useAaveChainsData";
+import {
+  useSelectedAaveChains,
+  useSetSelectedAaveChains,
+} from "@/store/web3Store";
 
 type LendingTabType = "markets" | "dashboard" | "staking" | "history";
 
 export default function LendingPage() {
   const [activeTab, setActiveTab] = useState<LendingTabType>("markets");
-  const [selectedChains, setSelectedChains] = useState<Chain[]>([]);
 
   const { data: aaveChains } = useAaveChainsData({});
+  const selectedChains = useSelectedAaveChains();
+  const setSelectedChains = useSetSelectedAaveChains();
 
   const supportedChains = useMemo(() => {
     if (!aaveChains) return [];

--- a/src/store/storeVersion.ts
+++ b/src/store/storeVersion.ts
@@ -1,1 +1,1 @@
-export const STORE_VERSION = 10;
+export const STORE_VERSION = 11;

--- a/src/store/web3Store.ts
+++ b/src/store/web3Store.ts
@@ -74,7 +74,7 @@ const useWeb3Store = create<Web3StoreState>()(
       tokenBalancesByWallet: {},
       tokenPricesUsd: {},
 
-      aaveChain: getChainByChainId(1),
+      selectedAaveChains: [],
 
       // New integration management methods
       getSwapStateForSection: () => {
@@ -790,8 +790,8 @@ const useWeb3Store = create<Web3StoreState>()(
         set({ tokensLoading: loading });
       },
 
-      setAaveChain(chain: Chain) {
-        set({ aaveChain: chain });
+      setSelectedAaveChains(chains: Chain[]) {
+        set({ selectedAaveChains: chains });
       },
     }),
     {
@@ -860,7 +860,7 @@ const useWeb3Store = create<Web3StoreState>()(
             chainId: wallet.chainId,
           })),
           swapIntegrations: serializedIntegrations,
-          aaveChain: state.aaveChain,
+          selectedAaveChains: state.selectedAaveChains,
         };
       },
     },
@@ -1024,12 +1024,12 @@ export const useSetActiveSwapSection = () => {
   return useWeb3Store((state) => state.setActiveSwapSection);
 };
 
-export const useAaveChain = (): Chain => {
-  return useWeb3Store((state) => state.aaveChain);
+export const useSelectedAaveChains = (): Chain[] => {
+  return useWeb3Store((state) => state.selectedAaveChains);
 };
 
-export const useSetAaveChain = () => {
-  return useWeb3Store((state) => state.setAaveChain);
+export const useSetSelectedAaveChains = () => {
+  return useWeb3Store((state) => state.setSelectedAaveChains);
 };
 
 export const useExtractUserWallets = (

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -108,7 +108,7 @@ export interface Web3StoreState {
   tokenBalancesByWallet: Record<string, Record<string, string>>;
   tokenPricesUsd: Record<string, string>;
 
-  aaveChain: Chain;
+  selectedAaveChains: Chain[];
 
   // Wallet actions (remain the same)
   addWallet: (wallet: WalletInfo) => void;
@@ -149,7 +149,7 @@ export interface Web3StoreState {
   updateTokenPrices: (priceResults: TokenPriceResult[]) => void;
   addCustomToken: (token: Token) => void;
   setTokensLoading: (loading: boolean) => void;
-  setAaveChain: (chain: Chain) => void;
+  setSelectedAaveChains: (chains: Chain[]) => void;
 }
 
 export enum Network {


### PR DESCRIPTION
This PR replaces the `aaveChain` web3Store property with `selectedAaveChains`, which is instead a persisted property of type `Chain[]`. When the `ChainPicker` is used, the state is stored and will persist across refreshes.

The default selected is an empty list, meaning all chains will be shown as a default.