### PR TITLE
feat: truncated markets symbols

### DIFF
--- a/src/components/ui/TruncatedText.tsx
+++ b/src/components/ui/TruncatedText.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React, { useState } from "react";
+
+interface TruncatedTextProps {
+  text: string;
+  maxLength?: number;
+  className?: string;
+}
+
+const TruncatedText: React.FC<TruncatedTextProps> = ({
+  text,
+  maxLength = 6,
+  className = "",
+}) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const shouldTruncate = text.length > maxLength;
+  const displayText = shouldTruncate ? `${text.slice(0, maxLength)}...` : text;
+
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      <span className={className}>{displayText}</span>
+      {shouldTruncate && showTooltip && (
+        <div className="absolute z-50 px-2 py-1 text-sm text-white bg-black rounded shadow-lg -top-8 left-1/2 transform -translate-x-1/2 whitespace-nowrap">
+          {text}
+          <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-black"></div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TruncatedText;

--- a/src/components/ui/lending/MarketCard.tsx
+++ b/src/components/ui/lending/MarketCard.tsx
@@ -10,6 +10,7 @@ import {
   CardDescription,
 } from "@/components/ui/Card";
 import BrandedButton from "@/components/ui/BrandedButton";
+import TruncatedText from "@/components/ui/TruncatedText";
 import Image from "next/image";
 import { formatCurrency, formatAPY, formatBalance } from "@/utils/formatters";
 import { Reserve, Market } from "@/types/aave";
@@ -147,7 +148,12 @@ const MarketCard: React.FC<MarketCardProps> = ({ market, onDetails }) => {
           <div className="text-[#A1A1AA] text-sm">total supplied</div>
           <div className="text-right">
             <div className="text-[#FAFAFA] text-sm font-semibold font-mono">
-              {formatBalance(totalSupplied)} {market.underlyingToken.symbol}
+              {formatBalance(totalSupplied)}{" "}
+              <TruncatedText
+                text={market.underlyingToken.symbol}
+                maxLength={6}
+                className="text-[#FAFAFA] text-sm font-semibold font-mono"
+              />
             </div>
             <div className="text-[#A1A1AA] text-xs font-mono">
               {formatCurrency(totalSuppliedUsd)}
@@ -168,7 +174,12 @@ const MarketCard: React.FC<MarketCardProps> = ({ market, onDetails }) => {
           <div className="text-[#A1A1AA] text-sm">total borrowed</div>
           <div className="text-right">
             <div className="text-[#FAFAFA] text-sm font-semibold font-mono">
-              {formatBalance(totalBorrowed)} {market.underlyingToken.symbol}
+              {formatBalance(totalBorrowed)}{" "}
+              <TruncatedText
+                text={market.underlyingToken.symbol}
+                maxLength={6}
+                className="text-[#FAFAFA] text-sm font-semibold font-mono"
+              />
             </div>
             <div className="text-[#A1A1AA] text-xs font-mono">
               {formatCurrency(totalBorrowedUsd)}


### PR DESCRIPTION
branched off from https://github.com/altverseweb3/site/pull/290

please consider only https://github.com/altverseweb3/site/commit/fdfe153e56f5e1e3bd40d8af094bb25033f4efe6

---

The purpose of this PR to create a `TruncatedText` component which will truncate the length of the text displayed if it reaches the maximum and finish it with an ellipsis. A tooltip on hover of the truncated text will display the full text.

This was motivated by the absurdly long symbol names of some PT tokens.

<img width="1395" height="523" alt="image" src="https://github.com/user-attachments/assets/3414c987-c95c-432b-b20d-dbc5c26914ee" />

 