### PR TITLE
feature: aave transaction history integration

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -19,8 +19,10 @@ import {
 } from "@/store/web3Store";
 import { useAaveMarketsWithLoading } from "@/hooks/aave/useAaveMarketsData";
 import MarketContent from "@/components/ui/lending/MarketContent";
+import TransactionContent from "@/components/ui/lending/TransactionContent";
 import { ChainId } from "@/types/aave";
-
+import { evmAddress, chainId, PageSize, OrderDirection } from "@aave/react";
+import { useAaveUserTransactionHistory } from "@/hooks/aave/useAaveUserData";
 type LendingTabType = "markets" | "dashboard" | "staking" | "history";
 
 export default function LendingPage() {
@@ -46,6 +48,15 @@ export default function LendingPage() {
   const { markets, loading } = useAaveMarketsWithLoading({
     chainIds: [1 as ChainId],
     user: undefined,
+  });
+
+  // Fetch transaction history data
+  const { data: transactions, loading: transactionsLoading } = useAaveUserTransactionHistory({
+    market: evmAddress("0x794a61358D6845594F94dc1DB02A252b5b4814aD"), // Polygon V3 Ethereum
+    user: evmAddress("0xf5d8777EA028Ad29515aA81E38e9B85afb7d6303"), // Hardcoded
+    chainId: chainId(137), // Polygon mainnet
+    orderBy: { date: OrderDirection.Desc },
+    pageSize: PageSize.Fifty,
   });
 
   useEffect(() => {
@@ -158,13 +169,7 @@ export default function LendingPage() {
                   </div>
                 </div>
               )}
-              {activeTab === "history" && (
-                <div className="p-8 text-center">
-                  <div className="text-[#A1A1AA] text-lg">
-                    History content coming soon...
-                  </div>
-                </div>
-              )}
+              { activeTab === "history" && <TransactionContent data={transactions} loading={transactionsLoading} /> }
             </>
           )}
         </div>

--- a/src/components/ui/lending/TransactionContent.tsx
+++ b/src/components/ui/lending/TransactionContent.tsx
@@ -1,0 +1,55 @@
+import CardsList from "@/components/ui/CardsList";
+import TransactionCard from "@/components/ui/lending/TransactionCard";
+import TransactionTable from "@/components/ui/lending/TransactionTable";
+import { PaginatedUserTransactionHistoryResult } from "@aave/react";
+
+interface HistoryContentProps {
+  data: PaginatedUserTransactionHistoryResult | undefined;
+  loading: boolean;
+}
+
+const HistoryContent = ({ data, loading }: HistoryContentProps) => {
+  if (loading) {
+    return (<div className="text-center py-16">
+      <div className="text-[#A1A1AA]">loading transaction history...</div>
+    </div>)
+  }
+  
+  if (!data || !data.items || data.items.length === 0) {
+    return (
+      <div className="text-center py-16">
+        <div className="text-[#A1A1AA]">no transaction history found</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      {/* Desktop Table View */}
+      <div className="hidden md:block">
+        <TransactionTable transactions={data.items} />
+      </div>
+
+      {/* Mobile Card View */}
+      <div className="block md:hidden space-y-3">
+        <CardsList
+          data={data.items}
+          renderCard={(transaction) => (
+            <TransactionCard
+              key={`${transaction.txHash.toString()}-${transaction.timestamp.toString()}`}
+              transaction={transaction}
+            />
+          )}
+          gridCols="grid-cols-1"
+          currentPage={1}
+          totalPages={1}
+          onPageChange={() => {}}
+          itemsPerPage={data.items.length}
+          totalItems={data.items.length}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default HistoryContent;

--- a/src/hooks/aave/useAaveUserData.ts
+++ b/src/hooks/aave/useAaveUserData.ts
@@ -72,7 +72,7 @@ export const useAaveUserMarketState = (args: UseUserStateArgs) => {
 export const useAaveUserTransactionHistory = (
   args: UseUserTransactionHistoryArgs,
 ) => {
-  const { data } = useUserTransactionHistory({
+  const { data, loading } = useUserTransactionHistory({
     market: args.market,
     user: args.user,
     chainId: args.chainId,
@@ -80,5 +80,5 @@ export const useAaveUserTransactionHistory = (
     pageSize: args.pageSize,
   });
 
-  return { data };
+  return { data, loading };
 };


### PR DESCRIPTION
note: branch off #294, #295 - please see 2c0e7e03bb6701530ccb22bdfc2380e45e4347f7

---
this PR integrates the Aave Transaction History components into the lending `page.tsx`. I have followed a similar pattern as was implemented for Markets by creating a `TransactionContent` component, with just the Transaction History hook call being done in the lending `page.tsx`.

> [!IMPORTANT]
> This integration is currently using a hardcoded EVM address, Market address, and chain ID. This is purely to establish the initial integration with the Transaction History components. In the interest of keeping the PR concise I will parameterise those to the actual values in a subsequent PR.

