### PR TITLE
feat: added components for aggregating transaction history across markets

### DIFF
--- a/src/components/meta/SingleMarketTransactionHistory.tsx
+++ b/src/components/meta/SingleMarketTransactionHistory.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+import { evmAddress, chainId, PageSize, OrderDirection } from "@aave/react";
+import { useAaveUserTransactionHistory } from "@/hooks/aave/useAaveUserData";
+import { ChainId, AaveMarket, UserTransactionItem } from "@/types/aave";
+import { WalletType } from "@/types/web3";
+import { useWalletByType } from "@/store/web3Store";
+
+interface MarketTransactionData {
+  marketAddress: string;
+  marketName: string;
+  chainId: ChainId;
+  data: UserTransactionItem[] | null;
+  loading: boolean;
+  error: boolean;
+  hasData: boolean;
+}
+
+interface SingleMarketTransactionHistoryProps {
+  market: AaveMarket;
+  onDataChange: (marketData: MarketTransactionData) => void;
+}
+
+export const SingleMarketTransactionHistory: React.FC<
+  SingleMarketTransactionHistoryProps
+> = ({ market, onDataChange }) => {
+  const userWalletAddress = useWalletByType(WalletType.REOWN_EVM)?.address;
+
+  const { data, loading, error } = useAaveUserTransactionHistory({
+    market: evmAddress(market.address),
+    user: userWalletAddress ? evmAddress(userWalletAddress) : undefined,
+    chainId: chainId(market.chainId),
+    orderBy: { date: OrderDirection.Desc },
+    pageSize: PageSize.Fifty,
+  });
+
+  useEffect(() => {
+    const marketData: MarketTransactionData = {
+      marketAddress: market.address,
+      marketName: market.name,
+      chainId: market.chainId as ChainId,
+      data: data?.items || null,
+      error: !!error,
+      loading,
+      hasData: !!(data?.items && data.items.length > 0),
+    };
+
+    onDataChange(marketData);
+  }, [
+    data,
+    loading,
+    error,
+    market.address,
+    market.name,
+    market.chainId,
+    onDataChange,
+  ]);
+
+  // This component doesn't render anything it's just for data fetching
+  return null;
+};

--- a/src/components/ui/lending/AggregatedTransactionHistory.tsx
+++ b/src/components/ui/lending/AggregatedTransactionHistory.tsx
@@ -1,0 +1,151 @@
+import { useState, useMemo, useCallback, useEffect } from "react";
+import { SingleMarketTransactionHistory } from "@/components/meta/SingleMarketTransactionHistory";
+import { getActiveAaveMarketsByChainId } from "@/utils/lending/marketConfig";
+import { ChainId, UserTransactionItem } from "@/types/aave";
+
+interface MarketTransactionData {
+  marketAddress: string;
+  marketName: string;
+  chainId: ChainId;
+  data: UserTransactionItem[] | null;
+  loading: boolean;
+  error: boolean;
+  hasData: boolean;
+}
+
+interface AggregatedTransactionHistoryProps {
+  chainIds: ChainId[];
+  children: (props: {
+    transactions: UserTransactionItem[];
+    loading: boolean;
+    error: boolean;
+    hasData: boolean;
+    marketCount: number;
+    marketData: Record<string, MarketTransactionData>;
+  }) => React.ReactNode;
+}
+
+export const AggregatedTransactionHistory: React.FC<
+  AggregatedTransactionHistoryProps
+> = ({ chainIds, children }) => {
+  const [marketDataMap, setMarketDataMap] = useState<
+    Record<string, MarketTransactionData>
+  >({});
+
+  // get all active markets for selected chains
+  const activeMarkets = useMemo(() => {
+    return chainIds.flatMap((chainId) =>
+      getActiveAaveMarketsByChainId(chainId).map((market) => ({
+        ...market,
+        chainId,
+      })),
+    );
+  }, [chainIds]);
+
+  // create a set of current market keys for O(1) lookup
+  const currentMarketKeys = useMemo(() => {
+    return new Set(
+      activeMarkets.map((market) => `${market.chainId}-${market.address}`),
+    );
+  }, [activeMarkets]);
+
+  // clean up stale market data when selected chainIds change
+  useEffect(() => {
+    setMarketDataMap((prev) => {
+      const filtered: Record<string, MarketTransactionData> = {};
+
+      // only keep data for markets that are currently active
+      Object.entries(prev).forEach(([key, data]) => {
+        if (currentMarketKeys.has(key)) {
+          filtered[key] = data;
+        }
+      });
+
+      return filtered;
+    });
+  }, [currentMarketKeys]);
+
+  const handleMarketDataChange = useCallback(
+    (marketData: MarketTransactionData) => {
+      const key = `${marketData.chainId}-${marketData.marketAddress}`;
+
+      // only update if this market is currently active
+      if (currentMarketKeys.has(key)) {
+        setMarketDataMap((prev) => ({
+          ...prev,
+          [key]: marketData,
+        }));
+      }
+    },
+    [currentMarketKeys],
+  );
+
+  const aggregatedData = useMemo(() => {
+    // filter marketDataMap to only include current markets
+    const currentMarketData = Object.entries(marketDataMap)
+      .filter(([key]) => currentMarketKeys.has(key))
+      .map(([, data]) => data);
+
+    // combine all transactions from current markets only
+    const allTransactions = currentMarketData
+      .filter((marketData) => marketData.data && marketData.data.length > 0)
+      .flatMap((marketData) => {
+        // give each transaction market context
+        return marketData.data!.map((transaction) => ({
+          ...transaction,
+          _marketAddress: marketData.marketAddress,
+          _marketName: marketData.marketName,
+          _chainId: marketData.chainId,
+        }));
+      })
+      .sort((a, b) => {
+        // Sort by date descending
+        const dateA = new Date(a.timestamp).getTime();
+        const dateB = new Date(b.timestamp).getTime();
+        return dateB - dateA;
+      });
+
+    // Calculate overall loading state - loading if any current market is loading
+    const isLoading = currentMarketData.some(
+      (marketData) => marketData.loading,
+    );
+
+    // Calculate overall error state - error if any current market has error
+    const hasError = currentMarketData.some((marketData) => marketData.error);
+
+    // Check if we have any data
+    const hasData = allTransactions.length > 0;
+
+    // Create filtered marketData object for children
+    const filteredMarketData = Object.fromEntries(
+      Object.entries(marketDataMap).filter(([key]) =>
+        currentMarketKeys.has(key),
+      ),
+    );
+
+    return {
+      transactions: allTransactions,
+      loading: isLoading,
+      error: hasError,
+      hasData,
+      marketCount: activeMarkets.length,
+      marketData: filteredMarketData,
+    };
+  }, [marketDataMap, activeMarkets.length, currentMarketKeys]);
+
+  return (
+    <>
+      {/* Render individual market components for data fetching */}
+      {activeMarkets.map((market) => (
+        <SingleMarketTransactionHistory
+          key={`${market.chainId}-${market.address}`}
+          market={market}
+          onDataChange={handleMarketDataChange}
+        />
+      ))}
+
+      {/* Render children with aggregated data */}
+      {children(aggregatedData)}
+    </>
+  );
+};

--- a/src/hooks/aave/useAaveUserData.ts
+++ b/src/hooks/aave/useAaveUserData.ts
@@ -72,7 +72,7 @@ export const useAaveUserMarketState = (args: UseUserStateArgs) => {
 export const useAaveUserTransactionHistory = (
   args: UseUserTransactionHistoryArgs,
 ) => {
-  const { data, loading } = useUserTransactionHistory({
+  const { data, loading, error } = useUserTransactionHistory({
     market: args.market,
     user: args.user,
     chainId: args.chainId,
@@ -80,5 +80,5 @@ export const useAaveUserTransactionHistory = (
     pageSize: args.pageSize,
   });
 
-  return { data, loading };
+  return { data, loading, error };
 };


### PR DESCRIPTION
this PR adds two new components designed to allow us to fetch user transactions across multiple chains markets.

`SingleMarketTransactionHistory` can be viewed as simply handling a single instantiation and use of the `useAaveUserTransactionHistory` for a single market/chain combination. This component is purely used to fetch data from that hook, and does not provide any UI elements (hence why I have placed in `/meta` as opposed to `/ui`).

`AggregatedTransactionHistory` creates multiple instances of the `SingleMarketTransactionHistory` component, as it gets passed in a set of selected chain IDs as props, finds out the markets on these chains, allowing it to make the transaction history calls on `SingleMarketTransactionHistory`. This then aggregates the results from all the `SingleMarketTransactionHistory` components and passes it to it's children UI components (which in integration, will be the `HistoryContent` component - shown in the subsequent PR).
