### PR TITLE
feat: aggregated transactions integration

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-# npm run build
+npm run build

--- a/src/components/ui/lending/TransactionContent.tsx
+++ b/src/components/ui/lending/TransactionContent.tsx
@@ -1,10 +1,10 @@
 import CardsList from "@/components/ui/CardsList";
 import TransactionCard from "@/components/ui/lending/TransactionCard";
 import TransactionTable from "@/components/ui/lending/TransactionTable";
-import { PaginatedUserTransactionHistoryResult } from "@aave/react";
+import { UserTransactionItem } from "@/types/aave";
 
 interface HistoryContentProps {
-  data: PaginatedUserTransactionHistoryResult | undefined;
+  data: UserTransactionItem[] | undefined;
   loading: boolean;
 }
 
@@ -17,7 +17,7 @@ const HistoryContent = ({ data, loading }: HistoryContentProps) => {
     );
   }
 
-  if (!data || !data.items || data.items.length === 0) {
+  if (!data || !data || data.length === 0) {
     return (
       <div className="text-center py-16">
         <div className="text-[#A1A1AA]">no transaction history found</div>
@@ -29,16 +29,16 @@ const HistoryContent = ({ data, loading }: HistoryContentProps) => {
     <div className="p-6">
       {/* Desktop Table View */}
       <div className="hidden md:block">
-        <TransactionTable transactions={data.items} />
+        <TransactionTable transactions={data} />
       </div>
 
       {/* Mobile Card View */}
       <div className="block md:hidden space-y-3">
         <CardsList
-          data={data.items}
+          data={data}
           renderCard={(transaction) => (
             <TransactionCard
-              key={`${transaction.txHash.toString()}-${transaction.timestamp.toString()}`}
+              key={`${transaction.txHash.toString()}-${transaction.timestamp}`}
               transaction={transaction}
             />
           )}
@@ -46,8 +46,8 @@ const HistoryContent = ({ data, loading }: HistoryContentProps) => {
           currentPage={1}
           totalPages={1}
           onPageChange={() => {}}
-          itemsPerPage={data.items.length}
-          totalItems={data.items.length}
+          itemsPerPage={data.length}
+          totalItems={data.length}
         />
       </div>
     </div>


### PR DESCRIPTION
branch off #303, please see 4e975587751d59a223834b3a0ecba4617f320e49

---

this PR integrates the `SingleMarketTransactionHistory` and `AggregatedTransactionHistory` components into the lending `page.tsx`.

Since are now aggregating the user transactions across multiple markets and chains as opposed to a single call, we now pass in a `UserTransactionItem[]` to the `TransactionContent` as opposed to `PaginatedUserTransactionHistoryResult` (which is returned from a single hook call).

This obviously removes a lot of calls being done in the `page.tsx` itself as well.