### PR TITLE
feat: transaction history pagination

### DIFF
--- a/src/components/ui/CardsList.tsx
+++ b/src/components/ui/CardsList.tsx
@@ -28,7 +28,7 @@ const CardsList = <T,>({
   className,
 }: CardsListProps<T>) => {
   const startItem = (currentPage - 1) * itemsPerPage + 1;
-  const endItem = Math.min(currentPage * itemsPerPage, data.length);
+  const endItem = Math.min(currentPage * itemsPerPage, totalItems);
 
   return (
     <div className={cn("w-full", className)}>


### PR DESCRIPTION
branch off #303, #304, please see d8cb67837cd388e58ce076ce472902054a51cac2

---

this PR adds pagination for the transaction history (in both the table and card view), as inspired by the component level implementation in `MarketContent.tsx`.

I did also find a minor bug in `CardsList.tsx` which led to incorrect text about the indexes of items being shown which I have resolved in this PR:

**Example of erroneous indexes (this is now resolved)**
<img width="2018" height="276" alt="Screenshot 2025-08-29 at 8 29 10 pm" src="https://github.com/user-attachments/assets/75610e6b-1047-4556-acf4-cb46d2e1d93b" />

This was caused by setting `endItem` to the min of `currentPage * itemsPerPage, data.length` as opposed to `currentPage * itemsPerPage, totalItems`
