### PR TITLE
feat: chain market info transaction history

### DIFF
--- a/src/components/ui/lending/TransactionCard.tsx
+++ b/src/components/ui/lending/TransactionCard.tsx
@@ -48,11 +48,12 @@ export const TransactionCard: React.FC<{
         </div>
       </div>
 
-      <div className="flex items-center justify-between text-sm">
+      {/* Asset and Market Info */}
+      <div className="flex items-center justify-between text-sm mb-2">
         <div className="flex items-center gap-2">
           <Image
-            src={reserveInfo.imageUrl}
-            alt={reserveInfo.symbol}
+            src={reserveInfo.assetImageUrl}
+            alt={reserveInfo.assetSymbol}
             height={32}
             width={32}
             className="w-5 h-5 rounded-full"
@@ -61,14 +62,31 @@ export const TransactionCard: React.FC<{
             }}
           />
           <span className="text-[#A1A1AA] font-mono uppercase">
-            {reserveInfo.symbol}
+            {reserveInfo.assetSymbol}
           </span>
         </div>
+        <div className="flex items-center gap-2">
+          <Image
+            src={reserveInfo.chainIconUrl}
+            alt={reserveInfo.chainSymbol}
+            height={20}
+            width={20}
+            className="w-4 h-4 rounded-full"
+            onError={(e) => {
+              e.currentTarget.src = "/images/chains/default.svg";
+            }}
+          />
+          <span className="text-[#A1A1AA] text-xs">{reserveInfo.market}</span>
+        </div>
+      </div>
+
+      {/* Transaction Link */}
+      <div className="flex justify-end">
         <a
           href={transaction.blockExplorerUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-sky-400 hover:text-sky-300 transition-colors"
+          className="text-sky-400 hover:text-sky-300 transition-colors text-sm"
         >
           view transaction ↗
         </a>

--- a/src/components/ui/lending/TransactionTable.tsx
+++ b/src/components/ui/lending/TransactionTable.tsx
@@ -24,6 +24,9 @@ const TransactionTable: React.FC<{ transactions: UserTransactionItem[] }> = ({
             <th className="text-left py-3 px-4 text-sm font-medium text-[#A1A1AA]">
               asset
             </th>
+            <th className="text-left py-3 px-4 text-sm font-medium text-[#A1A1AA]">
+              market
+            </th>
             <th className="text-right py-3 px-4 text-sm font-medium text-[#A1A1AA]">
               amount
             </th>
@@ -59,8 +62,8 @@ const TransactionTable: React.FC<{ transactions: UserTransactionItem[] }> = ({
                 <td className="py-3 px-4">
                   <div className="flex items-center gap-2">
                     <Image
-                      src={reserveInfo.imageUrl}
-                      alt={reserveInfo.symbol}
+                      src={reserveInfo.assetImageUrl}
+                      alt={reserveInfo.assetSymbol}
                       height={32}
                       width={32}
                       className="w-5 h-5 rounded-full"
@@ -69,7 +72,24 @@ const TransactionTable: React.FC<{ transactions: UserTransactionItem[] }> = ({
                       }}
                     />
                     <span className="text-white font-mono uppercase text-sm">
-                      {reserveInfo.symbol}
+                      {reserveInfo.assetSymbol}
+                    </span>
+                  </div>
+                </td>
+                <td className="py-3 px-4">
+                  <div className="flex items-center gap-2">
+                    <Image
+                      src={reserveInfo.chainIconUrl}
+                      alt={reserveInfo.chainSymbol}
+                      height={20}
+                      width={20}
+                      className="w-4 h-4 rounded-full"
+                      onError={(e) => {
+                        e.currentTarget.src = "/images/chains/default.svg";
+                      }}
+                    />
+                    <span className="text-[#A1A1AA] text-sm">
+                      {reserveInfo.market}
                     </span>
                   </div>
                 </td>

--- a/src/utils/lending/transactions.ts
+++ b/src/utils/lending/transactions.ts
@@ -110,14 +110,20 @@ const formatTransactionUsdValue = (
 const getReserveInfo = (transaction: UserTransactionItem) => {
   if (!hasReserve(transaction)) {
     return {
-      symbol: "UNKNOWN",
-      imageUrl: "",
+      market: "UNKNOWN",
+      assetSymbol: "UNKNOWN",
+      assetImageUrl: "",
+      chainSymbol: "UNKNOWN",
+      chainIconUrl: "",
     };
   }
 
   return {
-    symbol: transaction.reserve?.underlyingToken?.symbol || "UNKNOWN",
-    imageUrl: transaction.reserve?.underlyingToken?.imageUrl || "",
+    market: transaction.reserve?.market?.name || "UNKNOWN",
+    assetSymbol: transaction.reserve?.underlyingToken?.symbol || "UNKNOWN",
+    assetImageUrl: transaction.reserve?.underlyingToken?.imageUrl || "",
+    chainSymbol: transaction.reserve?.market?.chain?.name || "UNKNOWN",
+    chainIconUrl: transaction.reserve?.market?.chain?.icon || "",
   };
 };
 


### PR DESCRIPTION
branch off #303, #304, #305 (_I am sorry_) please see d97a0868794b70bfceff68fa7db25738b63abe4c

---

this PR updates the transaction history cards and table rows to include new details around the market the transaction occurred on, as well as the chain. In the interest of space, I have used just the chain logo and the market name rather than having two separate text fields (market/chain is _usually_ a 1:1 relationship anyway, with the exception of Ethereum).

## Screenshots
### Desktop
<img width="3104" height="1788" alt="Screenshot 2025-08-29 at 10 18 59 pm" src="https://github.com/user-attachments/assets/5241aba4-aa9b-4784-b5e9-ecbad11f011f" />

## Tablet
<img width="1476" height="1968" alt="Screenshot 2025-08-29 at 10 20 49 pm" src="https://github.com/user-attachments/assets/85caf35e-df2d-4ab1-b6e6-f65ecedb77da" />

## Mobile
<img width="856" height="1848" alt="Screenshot 2025-08-29 at 10 21 39 pm" src="https://github.com/user-attachments/assets/6b1d80ae-8101-4b75-9c04-3a4090d5927a" />

