### PR TITLE
bugfix: resolved incorrect address on sdeusd

### DIFF
--- a/src/config/etherFi.ts
+++ b/src/config/etherFi.ts
@@ -608,7 +608,7 @@ export const DEPOSIT_ASSETS: Record<string, DepositAsset> = {
   },
   sdeusd: {
     chain: "ethereum",
-    contractAddress: "0x9D39A5DE30e57443BfF2A8307A4256c8797A3497",
+    contractAddress: "0x5C5b196aBE0d54485975D1Ec29617D42D9198326",
     decimals: 18,
     imagePath: "/images/etherFi/ethereum-assets/sdeusd.png",
     stable: true,


### PR DESCRIPTION
this PR resolves an incorrect address used on the vault deposit assets for sdeusd. It was set to the address of [sUSDe](https://etherscan.io/address/0x9d39a5de30e57443bff2a8307a4256c8797a3497), which is NOT an approved deposit asset for Market Neutral USD.

This resolves the below bug:
<img width="2298" height="1828" alt="image (29)" src="https://github.com/user-attachments/assets/dfd398ff-15b8-468f-8795-0574863bba9b" />

now:
<img width="468" height="585" alt="Screenshot 2025-08-30 at 3 26 07 pm" src="https://github.com/user-attachments/assets/1a51e9f5-2a5c-4e8d-8b83-382956bae333" />
