### PR TITLE
feat: lending calculate e mode

### DIFF
--- a/src/components/meta/SingleMarketUserState.tsx
+++ b/src/components/meta/SingleMarketUserState.tsx
@@ -8,6 +8,7 @@ interface MarketUserStateData {
   marketName: string;
   chainId: ChainId;
   data: MarketUserState | null;
+  eModeEnabled: boolean | null;
   loading: boolean;
   error: boolean;
   hasData: boolean;
@@ -52,6 +53,7 @@ export const SingleMarketUserState: React.FC<SingleMarketUserStateProps> = ({
       marketName: market.name,
       chainId: market.chainId as ChainId,
       data: data || null,
+      eModeEnabled: data?.eModeEnabled ?? null,
       error: !!error,
       loading,
       hasData: !!data,

--- a/src/components/ui/lending/AggregatedMarketUserState.tsx
+++ b/src/components/ui/lending/AggregatedMarketUserState.tsx
@@ -8,10 +8,13 @@ interface MarketUserStateData {
   marketName: string;
   chainId: ChainId;
   data: MarketUserState | null;
+  eModeEnabled: boolean | null;
   loading: boolean;
   error: boolean;
   hasData: boolean;
 }
+
+type EModeStatus = "enabled" | "disabled" | "mixed";
 
 interface AggregatedMarketUserStateProps {
   activeMarkets: AaveMarket[];
@@ -21,6 +24,7 @@ interface AggregatedMarketUserStateProps {
       netWorth: string;
       netAPY: string;
     };
+    eModeStatus: EModeStatus;
     loading: boolean;
     error: boolean;
     hasData: boolean;
@@ -94,6 +98,24 @@ export const AggregatedMarketUserState: React.FC<
         marketData.data && !marketData.loading && !marketData.error,
     );
 
+    // Calculate e-mode status
+    let eModeStatus: EModeStatus = "disabled";
+    if (validStates.length > 0) {
+      const eModeStatuses = validStates.map(
+        (state) => state.data!.eModeEnabled,
+      );
+      const allEnabled = eModeStatuses.every((enabled) => enabled === true);
+      const allDisabled = eModeStatuses.every((enabled) => enabled === false);
+
+      if (allEnabled) {
+        eModeStatus = "enabled";
+      } else if (allDisabled) {
+        eModeStatus = "disabled";
+      } else {
+        eModeStatus = "mixed";
+      }
+    }
+
     // Calculate aggregated global data
     let globalData = {
       netWorth: formatCurrency(0),
@@ -164,6 +186,7 @@ export const AggregatedMarketUserState: React.FC<
 
     return {
       globalData,
+      eModeStatus,
       loading: isLoading,
       error: hasError,
       hasData,

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -31,9 +31,10 @@ export default function DashboardContent({
       activeMarkets={activeMarkets}
       userWalletAddress={evmAddress(userAddress)}
     >
-      {({ globalData, loading, error }) => (
+      {({ globalData, eModeStatus, loading, error }) => (
         <DashboardContentInner
           globalData={globalData}
+          eModeStatus={eModeStatus}
           loading={loading}
           error={error}
         />
@@ -42,17 +43,21 @@ export default function DashboardContent({
   );
 }
 
+type EModeStatus = "enabled" | "disabled" | "mixed";
+
 interface DashboardContentInnerProps {
   globalData: {
     netWorth: string;
     netAPY: string;
   };
+  eModeStatus: EModeStatus;
   loading: boolean;
   error: boolean;
 }
 
 function DashboardContentInner({
   globalData,
+  eModeStatus,
   loading,
   error,
 }: DashboardContentInnerProps) {
@@ -131,7 +136,7 @@ function DashboardContentInner({
             <button
               className={`px-2 py-0.5 bg-[#27272A] hover:bg-[#3F3F46] border border-[#3F3F46] rounded text-xs text-white ${isSupplyMode ? "invisible" : "visible"}`}
             >
-              e-mode
+              e-mode: {eModeStatus}
             </button>
           </div>
           <div className="grid grid-cols-3 gap-3">


### PR DESCRIPTION
please see just https://github.com/altverseweb3/site/pull/313/commits/f531f269cbf174dfde5ab3aa996b455d1331dd51

This PR is concerned with calculating e-mode. If all markets' statuses e-mode are enabled, then e-mode is displayed as enabled, if all markets' statuses e-mode are disabled, then e-mode is displayed as disabled, but otherwise it is displayed as mixed.

 
<img width="566" height="132" alt="image" src="https://github.com/user-attachments/assets/843714c1-5bba-44c1-ab3e-e29f2f675b68" />
