### PR TITLE
feat: calculate and display health factor/risk details in lending

### DIFF
--- a/src/components/meta/SingleMarketUserState.tsx
+++ b/src/components/meta/SingleMarketUserState.tsx
@@ -1,7 +1,14 @@
 import { useEffect } from "react";
 import { evmAddress, chainId } from "@aave/react";
 import { useAaveUserMarketStateWithLoading } from "@/hooks/aave/useAaveUserData";
-import { ChainId, EvmAddress, AaveMarket, MarketUserState } from "@/types/aave";
+import {
+  ChainId,
+  EvmAddress,
+  AaveMarket,
+  MarketUserState,
+  PercentValue,
+  BigDecimal,
+} from "@/types/aave";
 
 interface MarketUserStateData {
   marketAddress: string;
@@ -9,6 +16,9 @@ interface MarketUserStateData {
   chainId: ChainId;
   data: MarketUserState | null;
   eModeEnabled: boolean | null;
+  healthFactor: BigDecimal | null;
+  ltv: PercentValue | null;
+  currentLiquidationThreshold: PercentValue | null;
   loading: boolean;
   error: boolean;
   hasData: boolean;
@@ -54,6 +64,9 @@ export const SingleMarketUserState: React.FC<SingleMarketUserStateProps> = ({
       chainId: market.chainId as ChainId,
       data: data || null,
       eModeEnabled: data?.eModeEnabled ?? null,
+      healthFactor: data?.healthFactor ?? null,
+      ltv: data?.ltv ?? null,
+      currentLiquidationThreshold: data?.currentLiquidationThreshold ?? null,
       error: !!error,
       loading,
       hasData: !!data,

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -7,6 +7,7 @@ import { evmAddress } from "@aave/react";
 import { Chain } from "@/types/web3";
 import { AaveMarket } from "@/types/aave";
 import { AggregatedMarketUserState } from "./AggregatedMarketUserState";
+import { formatHealthFactor } from "@/utils/formatters";
 
 interface DashboardContentProps {
   userAddress?: string;
@@ -31,9 +32,10 @@ export default function DashboardContent({
       activeMarkets={activeMarkets}
       userWalletAddress={evmAddress(userAddress)}
     >
-      {({ globalData, eModeStatus, loading, error }) => (
+      {({ globalData, healthFactorData, eModeStatus, loading, error }) => (
         <DashboardContentInner
           globalData={globalData}
+          healthFactorData={healthFactorData}
           eModeStatus={eModeStatus}
           loading={loading}
           error={error}
@@ -50,6 +52,10 @@ interface DashboardContentInnerProps {
     netWorth: string;
     netAPY: string;
   };
+  healthFactorData: {
+    show: boolean;
+    value: string | null;
+  };
   eModeStatus: EModeStatus;
   loading: boolean;
   error: boolean;
@@ -57,6 +63,7 @@ interface DashboardContentInnerProps {
 
 function DashboardContentInner({
   globalData,
+  healthFactorData,
   eModeStatus,
   loading,
   error,
@@ -105,11 +112,15 @@ function DashboardContentInner({
             <h3 className="text-sm font-medium text-white">
               global overview (all selected chains)
             </h3>
-            <button className="px-2 py-0.5 bg-[#27272A] hover:bg-[#3F3F46] border border-[#3F3F46] rounded text-xs text-white">
-              risk details
-            </button>
+            {healthFactorData.show && (
+              <button className="px-2 py-0.5 bg-[#27272A] hover:bg-[#3F3F46] border border-[#3F3F46] rounded text-xs text-white">
+                risk details
+              </button>
+            )}
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div
+            className={`grid ${healthFactorData.show ? "grid-cols-3" : "grid-cols-2"} gap-3`}
+          >
             <div className="text-center">
               <div className="text-xs text-[#A1A1AA] mb-1">net worth</div>
               <div className="text-sm font-semibold text-white">
@@ -122,6 +133,16 @@ function DashboardContentInner({
                 {globalData.netAPY}
               </div>
             </div>
+            {healthFactorData.show && (
+              <div className="text-center">
+                <div className="text-xs text-[#A1A1AA] mb-1">health factor</div>
+                <div
+                  className={`text-sm font-semibold ${formatHealthFactor(healthFactorData.value).colorClass}`}
+                >
+                  {formatHealthFactor(healthFactorData.value).value}
+                </div>
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -108,10 +108,28 @@ export const formatNetWorth = (netWorth: number): string => {
   });
 };
 
-export const formatHealthFactor = (healthFactor: number | null): string => {
-  if (healthFactor === null) return "--";
-  if (healthFactor === Infinity) return "∞";
-  return healthFactor.toFixed(2);
+export const formatHealthFactor = (
+  healthFactor: number | string | null,
+): { value: string; colorClass: string } => {
+  if (healthFactor === null) {
+    return { value: "--", colorClass: "text-gray-400" };
+  }
+
+  if (healthFactor === "mixed") {
+    return { value: "mixed", colorClass: "text-amber-400" };
+  }
+
+  const numericValue =
+    typeof healthFactor === "string" ? parseFloat(healthFactor) : healthFactor;
+
+  if (numericValue === Infinity) {
+    return { value: "∞", colorClass: "text-green-400" };
+  }
+
+  const formattedValue = numericValue.toFixed(2);
+  const colorClass = numericValue < 1.5 ? "text-red-400" : "text-green-400";
+
+  return { value: formattedValue, colorClass };
 };
 
 export const calculateUSDValue = (


### PR DESCRIPTION
This PR is concerned with conditionally rendering the third column of the global lending header which will display the health factor and conditionally rendering the corresponding risk details button.

If health factor for at least one chain is not null, then the third column and button is displayed. If exactly one health factor is returned due to one selected chain, it's value is used. If more than one health factor is available, since there is no weighted average we could display, "mixed" is displayed. Otherwise the column and button are absent.

UI verification:

<img width="599" height="153" alt="image" src="https://github.com/user-attachments/assets/fb5a12b5-5a2e-4368-ab65-d4954a79f5b9" />
<img width="331" height="116" alt="image" src="https://github.com/user-attachments/assets/4e0d1a2b-129a-4a8b-967c-343e964ab5c6" />


> [!WARNING]
> The Net APY calculation appears to be broken. this will be fixed in a separate PR