### PR TITLE
feature: lending supply header

### DIFF
--- a/src/components/meta/SingleMarketUserSupplies.tsx
+++ b/src/components/meta/SingleMarketUserSupplies.tsx
@@ -4,40 +4,16 @@ import { useAaveUserSupplies } from "@/hooks/aave/useAaveUserData";
 import { ChainId, EvmAddress, AaveMarket } from "@/types/aave";
 
 interface MarketUserReserveSupplyPosition {
-  __typename: "MarketUserReserveSupplyPosition";
-  market: {
-    __typename: "MarketInfo";
-    name: string;
-    address: string;
-    chain: {
-      __typename: "Chain";
-      name: string;
-      chainId: number;
-    };
-  };
   currency: {
-    __typename: "Currency";
-    address: string;
-    name: string;
     symbol: string;
-    decimals: number;
-    chainId: number;
   };
   balance: {
-    __typename: "TokenAmount";
     usd: string;
-    amount: {
-      __typename: "DecimalValue";
-      value: string;
-    };
   };
   apy: {
-    __typename: "PercentValue";
     value: string;
-    formatted: string;
   };
   isCollateral: boolean;
-  canBeCollateral: boolean;
 }
 
 interface UserSupplyData {

--- a/src/components/meta/SingleMarketUserSupplies.tsx
+++ b/src/components/meta/SingleMarketUserSupplies.tsx
@@ -1,0 +1,125 @@
+import { useEffect } from "react";
+import { evmAddress, chainId } from "@aave/react";
+import { useAaveUserSupplies } from "@/hooks/aave/useAaveUserData";
+import { ChainId, EvmAddress, AaveMarket } from "@/types/aave";
+
+interface MarketUserReserveSupplyPosition {
+  __typename: "MarketUserReserveSupplyPosition";
+  market: {
+    __typename: "MarketInfo";
+    name: string;
+    address: string;
+    chain: {
+      __typename: "Chain";
+      name: string;
+      chainId: number;
+    };
+  };
+  currency: {
+    __typename: "Currency";
+    address: string;
+    name: string;
+    symbol: string;
+    decimals: number;
+    chainId: number;
+  };
+  balance: {
+    __typename: "TokenAmount";
+    usd: string;
+    amount: {
+      __typename: "DecimalValue";
+      value: string;
+    };
+  };
+  apy: {
+    __typename: "PercentValue";
+    value: string;
+    formatted: string;
+  };
+  isCollateral: boolean;
+  canBeCollateral: boolean;
+}
+
+interface UserSupplyData {
+  marketAddress: string;
+  marketName: string;
+  chainId: ChainId;
+  supplies: MarketUserReserveSupplyPosition[];
+  loading: boolean;
+  error: boolean;
+  hasData: boolean;
+}
+
+interface SingleMarketUserSuppliesProps {
+  market: AaveMarket;
+  onDataChange: (supplyData: UserSupplyData) => void;
+  userWalletAddress: EvmAddress;
+}
+
+export const SingleMarketUserSupplies: React.FC<
+  SingleMarketUserSuppliesProps
+> = ({ market, onDataChange, userWalletAddress }) => {
+  console.log(
+    `[SingleMarketUserSupplies] Initializing for market: ${market.name} (${market.address})`,
+  );
+  console.log(`[SingleMarketUserSupplies] User wallet: ${userWalletAddress}`);
+  console.log(
+    `[SingleMarketUserSupplies] Market chainId: ${market.chainId}, converted chainId:`,
+    chainId(market.chainId),
+  );
+
+  // Always call hooks at the top level - never conditionally
+  const { data } = useAaveUserSupplies({
+    markets: [
+      {
+        chainId: chainId(market.chainId),
+        address: evmAddress(market.address),
+      },
+    ],
+    user: userWalletAddress,
+  });
+
+  console.log(`[SingleMarketUserSupplies] Hook returned data:`, data);
+
+  const loading = false;
+  const error = false;
+
+  useEffect(() => {
+    console.log(
+      `[SingleMarketUserSupplies] useEffect triggered for market: ${market.name}`,
+    );
+    console.log(`[SingleMarketUserSupplies] Data in useEffect:`, data);
+    console.log(`[SingleMarketUserSupplies] Data length:`, data?.length);
+    console.log(
+      `[SingleMarketUserSupplies] Loading: ${loading}, Error: ${error}`,
+    );
+
+    const supplyData: UserSupplyData = {
+      marketAddress: market.address,
+      marketName: market.name,
+      chainId: market.chainId as ChainId,
+      supplies: data || [],
+      error,
+      loading,
+      hasData: !!(data && data.length > 0),
+    };
+
+    console.log(
+      `[SingleMarketUserSupplies] Constructed supplyData:`,
+      supplyData,
+    );
+    console.log(`[SingleMarketUserSupplies] Has data: ${supplyData.hasData}`);
+
+    onDataChange(supplyData);
+  }, [
+    data,
+    loading,
+    error,
+    market.address,
+    market.name,
+    market.chainId,
+    onDataChange,
+  ]);
+
+  return null;
+};

--- a/src/components/ui/lending/AggregatedMarketUserSupplies.tsx
+++ b/src/components/ui/lending/AggregatedMarketUserSupplies.tsx
@@ -1,0 +1,246 @@
+import { useState, useMemo, useCallback, useEffect } from "react";
+import { SingleMarketUserSupplies } from "@/components/meta/SingleMarketUserSupplies";
+import { ChainId, EvmAddress, AaveMarket } from "@/types/aave";
+import { formatCurrency, formatAPY } from "@/utils/formatters";
+
+interface MarketUserReserveSupplyPosition {
+  __typename: "MarketUserReserveSupplyPosition";
+  market: {
+    __typename: "MarketInfo";
+    name: string;
+    address: string;
+    chain: {
+      __typename: "Chain";
+      name: string;
+      chainId: number;
+    };
+  };
+  currency: {
+    __typename: "Currency";
+    address: string;
+    name: string;
+    symbol: string;
+    decimals: number;
+    chainId: number;
+  };
+  balance: {
+    __typename: "TokenAmount";
+    usd: string;
+    amount: {
+      __typename: "DecimalValue";
+      value: string;
+    };
+  };
+  apy: {
+    __typename: "PercentValue";
+    value: string;
+    formatted: string;
+  };
+  isCollateral: boolean;
+  canBeCollateral: boolean;
+}
+
+interface UserSupplyData {
+  marketAddress: string;
+  marketName: string;
+  chainId: ChainId;
+  supplies: MarketUserReserveSupplyPosition[];
+  loading: boolean;
+  error: boolean;
+  hasData: boolean;
+}
+
+interface AggregatedMarketUserSuppliesProps {
+  activeMarkets: AaveMarket[];
+  userWalletAddress: EvmAddress;
+  children: (props: {
+    supplyData: {
+      balance: string;
+      apy: string;
+      collateral: string;
+    };
+    loading: boolean;
+    error: boolean;
+    hasData: boolean;
+    marketCount: number;
+    marketSupplyData: Record<string, UserSupplyData>;
+  }) => React.ReactNode;
+}
+
+export const AggregatedMarketUserSupplies: React.FC<
+  AggregatedMarketUserSuppliesProps
+> = ({ activeMarkets, children, userWalletAddress }) => {
+  const [marketSupplyDataMap, setMarketSupplyDataMap] = useState<
+    Record<string, UserSupplyData>
+  >({});
+
+  const currentMarketKeys = useMemo(() => {
+    return new Set(
+      activeMarkets.map((market) => `${market.chainId}-${market.address}`),
+    );
+  }, [activeMarkets]);
+
+  useEffect(() => {
+    setMarketSupplyDataMap((prev) => {
+      const filtered: Record<string, UserSupplyData> = {};
+
+      Object.entries(prev).forEach(([key, data]) => {
+        if (currentMarketKeys.has(key)) {
+          filtered[key] = data;
+        }
+      });
+
+      return filtered;
+    });
+  }, [currentMarketKeys]);
+
+  const handleMarketSupplyDataChange = useCallback(
+    (supplyData: UserSupplyData) => {
+      const key = `${supplyData.chainId}-${supplyData.marketAddress}`;
+
+      if (currentMarketKeys.has(key)) {
+        setMarketSupplyDataMap((prev) => ({
+          ...prev,
+          [key]: supplyData,
+        }));
+      }
+    },
+    [currentMarketKeys],
+  );
+
+  const aggregatedData = useMemo(() => {
+    console.log(`[AggregatedMarketUserSupplies] Recalculating aggregated data`);
+    console.log(
+      `[AggregatedMarketUserSupplies] Current market keys:`,
+      Array.from(currentMarketKeys),
+    );
+    console.log(
+      `[AggregatedMarketUserSupplies] Market supply data map:`,
+      marketSupplyDataMap,
+    );
+
+    const currentMarketSupplyData = Object.entries(marketSupplyDataMap)
+      .filter(([key]) => currentMarketKeys.has(key))
+      .map(([, data]) => data);
+
+    console.log(
+      `[AggregatedMarketUserSupplies] Current market supply data:`,
+      currentMarketSupplyData,
+    );
+
+    const isLoading = currentMarketSupplyData.some(
+      (marketData) => marketData.loading,
+    );
+
+    const hasError = currentMarketSupplyData.some(
+      (marketData) => marketData.error,
+    );
+
+    const validSupplyStates = currentMarketSupplyData.filter(
+      (marketData) =>
+        marketData.supplies && !marketData.loading && !marketData.error,
+    );
+
+    console.log(
+      `[AggregatedMarketUserSupplies] Valid supply states:`,
+      validSupplyStates,
+    );
+    console.log(
+      `[AggregatedMarketUserSupplies] Loading: ${isLoading}, Error: ${hasError}`,
+    );
+
+    let supplyData = {
+      balance: formatCurrency(0),
+      apy: formatAPY(0),
+      collateral: formatCurrency(0),
+    };
+
+    if (validSupplyStates.length > 0) {
+      console.log(
+        `[AggregatedMarketUserSupplies] Processing ${validSupplyStates.length} valid supply states`,
+      );
+      let totalBalance = 0;
+      let totalCollateral = 0;
+      let weightedAPYNumerator = 0;
+      let totalBalanceForAPY = 0;
+
+      validSupplyStates.forEach((state, stateIndex) => {
+        console.log(
+          `[AggregatedMarketUserSupplies] Processing state ${stateIndex} for market ${state.marketName}:`,
+          state.supplies,
+        );
+        state.supplies.forEach((supply, supplyIndex) => {
+          const balanceUsd = parseFloat(supply.balance.usd) || 0;
+          const apyValue = parseFloat(supply.apy.value) || 0;
+
+          console.log(
+            `[AggregatedMarketUserSupplies] Supply ${supplyIndex} - ${supply.currency.symbol}: balance=${balanceUsd}, apy=${apyValue}, isCollateral=${supply.isCollateral}`,
+          );
+
+          totalBalance += balanceUsd;
+
+          if (supply.isCollateral) {
+            totalCollateral += balanceUsd;
+          }
+
+          if (balanceUsd > 0) {
+            weightedAPYNumerator += balanceUsd * apyValue;
+            totalBalanceForAPY += balanceUsd;
+          }
+        });
+      });
+
+      const weightedAPY =
+        totalBalanceForAPY > 0 ? weightedAPYNumerator / totalBalanceForAPY : 0;
+
+      console.log(`[AggregatedMarketUserSupplies] Final calculations:`);
+      console.log(`  - Total Balance: ${totalBalance}`);
+      console.log(`  - Total Collateral: ${totalCollateral}`);
+      console.log(`  - Weighted APY: ${weightedAPY}`);
+      console.log(`  - Total Balance for APY: ${totalBalanceForAPY}`);
+
+      supplyData = {
+        balance: formatCurrency(totalBalance),
+        apy: formatAPY(weightedAPY * 100),
+        collateral: formatCurrency(totalCollateral),
+      };
+
+      console.log(
+        `[AggregatedMarketUserSupplies] Final formatted supply data:`,
+        supplyData,
+      );
+    }
+
+    const hasData = validSupplyStates.some((state) => state.hasData);
+
+    const filteredMarketSupplyData = Object.fromEntries(
+      Object.entries(marketSupplyDataMap).filter(([key]) =>
+        currentMarketKeys.has(key),
+      ),
+    );
+
+    return {
+      supplyData,
+      loading: isLoading,
+      error: hasError,
+      hasData,
+      marketCount: activeMarkets.length,
+      marketSupplyData: filteredMarketSupplyData,
+    };
+  }, [marketSupplyDataMap, activeMarkets.length, currentMarketKeys]);
+
+  return (
+    <>
+      {activeMarkets.map((market) => (
+        <SingleMarketUserSupplies
+          key={`${market.chainId}-${market.address}`}
+          market={market}
+          onDataChange={handleMarketSupplyDataChange}
+          userWalletAddress={userWalletAddress}
+        />
+      ))}
+
+      {children(aggregatedData)}
+    </>
+  );
+};

--- a/src/components/ui/lending/AggregatedMarketUserSupplies.tsx
+++ b/src/components/ui/lending/AggregatedMarketUserSupplies.tsx
@@ -4,40 +4,16 @@ import { ChainId, EvmAddress, AaveMarket } from "@/types/aave";
 import { formatCurrency, formatAPY } from "@/utils/formatters";
 
 interface MarketUserReserveSupplyPosition {
-  __typename: "MarketUserReserveSupplyPosition";
-  market: {
-    __typename: "MarketInfo";
-    name: string;
-    address: string;
-    chain: {
-      __typename: "Chain";
-      name: string;
-      chainId: number;
-    };
-  };
   currency: {
-    __typename: "Currency";
-    address: string;
-    name: string;
     symbol: string;
-    decimals: number;
-    chainId: number;
   };
   balance: {
-    __typename: "TokenAmount";
     usd: string;
-    amount: {
-      __typename: "DecimalValue";
-      value: string;
-    };
   };
   apy: {
-    __typename: "PercentValue";
     value: string;
-    formatted: string;
   };
   isCollateral: boolean;
-  canBeCollateral: boolean;
 }
 
 interface UserSupplyData {

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -6,8 +6,8 @@ import { Info } from "lucide-react";
 import { evmAddress } from "@aave/react";
 import { Chain } from "@/types/web3";
 import { AaveMarket } from "@/types/aave";
-import { AggregatedMarketUserState } from "./AggregatedMarketUserState";
-import { AggregatedMarketUserSupplies } from "./AggregatedMarketUserSupplies";
+import { AggregatedMarketUserState } from "@/components/ui/lending/AggregatedMarketUserState";
+import { AggregatedMarketUserSupplies } from "@/components/ui/lending/AggregatedMarketUserSupplies";
 import { formatHealthFactor } from "@/utils/formatters";
 
 interface DashboardContentProps {

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -7,6 +7,7 @@ import { evmAddress } from "@aave/react";
 import { Chain } from "@/types/web3";
 import { AaveMarket } from "@/types/aave";
 import { AggregatedMarketUserState } from "./AggregatedMarketUserState";
+import { AggregatedMarketUserSupplies } from "./AggregatedMarketUserSupplies";
 import { formatHealthFactor } from "@/utils/formatters";
 
 interface DashboardContentProps {
@@ -33,13 +34,27 @@ export default function DashboardContent({
       userWalletAddress={evmAddress(userAddress)}
     >
       {({ globalData, healthFactorData, eModeStatus, loading, error }) => (
-        <DashboardContentInner
-          globalData={globalData}
-          healthFactorData={healthFactorData}
-          eModeStatus={eModeStatus}
-          loading={loading}
-          error={error}
-        />
+        <AggregatedMarketUserSupplies
+          activeMarkets={activeMarkets}
+          userWalletAddress={evmAddress(userAddress)}
+        >
+          {({ supplyData, loading: supplyLoading, error: supplyError }) => {
+            console.log(`[DashboardContent] Supply data received:`, supplyData);
+            console.log(
+              `[DashboardContent] Supply loading: ${supplyLoading}, error: ${supplyError}`,
+            );
+            return (
+              <DashboardContentInner
+                globalData={globalData}
+                healthFactorData={healthFactorData}
+                eModeStatus={eModeStatus}
+                supplyData={supplyData}
+                loading={loading || supplyLoading}
+                error={error || supplyError}
+              />
+            );
+          }}
+        </AggregatedMarketUserSupplies>
       )}
     </AggregatedMarketUserState>
   );
@@ -57,6 +72,11 @@ interface DashboardContentInnerProps {
     value: string | null;
   };
   eModeStatus: EModeStatus;
+  supplyData: {
+    balance: string;
+    apy: string;
+    collateral: string;
+  };
   loading: boolean;
   error: boolean;
 }
@@ -65,6 +85,7 @@ function DashboardContentInner({
   globalData,
   healthFactorData,
   eModeStatus,
+  supplyData,
   loading,
   error,
 }: DashboardContentInnerProps) {
@@ -89,12 +110,6 @@ function DashboardContentInner({
       </div>
     );
   }
-
-  const supplyData = {
-    balance: "$8,234.56",
-    apy: "4.2%",
-    collateral: "$7,890.12",
-  };
 
   const borrowData = {
     balance: "$3,456.78",


### PR DESCRIPTION
This PR is concerned with populating the supply header of the lending section.

<img width="1231" height="220" alt="image" src="https://github.com/user-attachments/assets/7db0f889-3255-4d60-82bd-8aacb43c8436" />
<img width="1195" height="211" alt="image" src="https://github.com/user-attachments/assets/e94c64ad-199c-4293-af29-48c5eed9471f" />

<img width="581" height="357" alt="image" src="https://github.com/user-attachments/assets/fec3c102-2cd0-4426-a841-dc9594e0e4e7" />
<img width="562" height="301" alt="image" src="https://github.com/user-attachments/assets/ca8e7060-6b15-4d57-be34-1be4ce303716" />
