### PR TITLE
fix: lending history duplicate keys

### DIFF
--- a/src/components/ui/lending/TransactionContent.tsx
+++ b/src/components/ui/lending/TransactionContent.tsx
@@ -4,6 +4,7 @@ import CardsList from "@/components/ui/CardsList";
 import TransactionCard from "@/components/ui/lending/TransactionCard";
 import TransactionTable from "@/components/ui/lending/TransactionTable";
 import { UserTransactionItem } from "@/types/aave";
+import { getTransactionKey } from "@/utils/lending/transactions";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -108,7 +109,7 @@ const HistoryContent: React.FC<HistoryContentProps> = ({ data, loading }) => {
           data={paginatedData}
           renderCard={(transaction) => (
             <TransactionCard
-              key={`${transaction.txHash.toString()}-${transaction.timestamp}`}
+              key={getTransactionKey(transaction)}
               transaction={transaction}
             />
           )}

--- a/src/components/ui/lending/TransactionTable.tsx
+++ b/src/components/ui/lending/TransactionTable.tsx
@@ -6,6 +6,7 @@ import {
   getTransactionLabel,
   formatTransactionAmount,
   formatTransactionUsdValue,
+  getTransactionKey,
 } from "@/utils/lending/transactions";
 import TransactionIcon from "@/components/ui/lending/TransactionIcon";
 import Image from "next/image";
@@ -36,7 +37,7 @@ const TransactionTable: React.FC<{ transactions: UserTransactionItem[] }> = ({
 
             return (
               <tr
-                key={transaction.txHash}
+                key={getTransactionKey(transaction)}
                 className="hover:bg-[#1C1C1F] transition-colors"
               >
                 <td className="px-4 py-3">

--- a/src/utils/lending/transactions.ts
+++ b/src/utils/lending/transactions.ts
@@ -107,6 +107,20 @@ const formatTransactionUsdValue = (
   return formatCurrency(amount.usd);
 };
 
+const getTransactionKey = (transaction: UserTransactionItem): string => {
+  let chainName: string;
+
+  if (isUserLiquidationCallTransaction(transaction)) {
+    chainName = transaction.collateral.reserve.market.chain.name;
+  } else if (hasReserve(transaction)) {
+    chainName = transaction.reserve.market.chain.name;
+  } else {
+    chainName = "unknown";
+  }
+
+  return `${transaction.txHash}-${chainName}-${transaction.timestamp}`;
+};
+
 const getReserveInfo = (transaction: UserTransactionItem) => {
   if (!hasReserve(transaction)) {
     return {
@@ -132,6 +146,7 @@ export {
   getTransactionLabel,
   formatTransactionAmount,
   formatTransactionUsdValue,
+  getTransactionKey,
   getReserveInfo,
   isUserBorrowTransaction,
   isUserWithdrawTransaction,


### PR DESCRIPTION
This PR is concerned with creating a utility function to generate unique keys for transactions based on their hash, chain, and timestamp. This is leveraged to populate a set when retrieving transactions and as a key to the transaction table and cards list.