### PR TITLE
chore: stopped tab deselection in lending

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -82,7 +82,10 @@ export default function LendingPage() {
   }, [setActiveSwapSection]);
 
   const handleTabChange = (value: LendingTabType) => {
-    setActiveTab(value);
+    // Only update if a valid value is provided (prevents deselection)
+    if (value) {
+      setActiveTab(value);
+    }
   };
 
   // Show wallet connection requirement for dashboard and history tabs


### PR DESCRIPTION
this PR resolves a minor bug where the selected tab can be deselected by clicking on it, effectively leaving the user on a blank page.