### PR TITLE
fix: lending history account for tx typename

### DIFF
--- a/src/components/ui/lending/AggregatedTransactionHistory.tsx
+++ b/src/components/ui/lending/AggregatedTransactionHistory.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { SingleMarketTransactionHistory } from "@/components/meta/SingleMarketTransactionHistory";
 import { ChainId, EvmAddress, UserTransactionItem } from "@/types/aave";
-import { getTransactionKey } from "@/utils/lending/transactions";
 
 interface MarketTransactionData {
   marketAddress: string;
@@ -85,7 +84,7 @@ export const AggregatedTransactionHistory: React.FC<
       .map(([, data]) => data);
 
     // combine all transactions from current markets only
-    const allTransactionsWithDuplicates = currentMarketData
+    const allTransactions = currentMarketData
       .filter((marketData) => marketData.data && marketData.data.length > 0)
       .flatMap((marketData) => {
         // give each transaction market context
@@ -95,18 +94,6 @@ export const AggregatedTransactionHistory: React.FC<
           _marketName: marketData.marketName,
           _chainId: marketData.chainId,
         }));
-      });
-
-    // deduplicate transactions
-    const seenTransactions = new Set<string>();
-    const allTransactions = allTransactionsWithDuplicates
-      .filter((transaction) => {
-        const key = getTransactionKey(transaction);
-        if (seenTransactions.has(key)) {
-          return false; // duplicate found, filter out
-        }
-        seenTransactions.add(key);
-        return true;
       })
       .sort((a, b) => {
         // Sort by date descending

--- a/src/utils/lending/transactions.ts
+++ b/src/utils/lending/transactions.ts
@@ -118,7 +118,7 @@ const getTransactionKey = (transaction: UserTransactionItem): string => {
     chainName = "unknown";
   }
 
-  return `${transaction.txHash}-${chainName}-${transaction.timestamp}`;
+  return `${transaction.txHash}-${chainName}-${transaction.timestamp}-${transaction.__typename}`;
 };
 
 const getReserveInfo = (transaction: UserTransactionItem) => {


### PR DESCRIPTION
This PR is concerned with accounting for the fact that one tx hash can have two lending operations that need to be separately displayed in the tx history for lending.

As a consequence the transaction key has been updated to include `transaction.__typename`

False positive on duplicates, as a consequence we no longer need deduplication and it has been removed.