### PR TITLE
refactor: consolidated position interfaces

### DIFF
--- a/src/components/meta/SingleMarketUserSupplies.tsx
+++ b/src/components/meta/SingleMarketUserSupplies.tsx
@@ -1,30 +1,7 @@
 import { useEffect } from "react";
 import { evmAddress, chainId } from "@aave/react";
 import { useAaveUserSupplies } from "@/hooks/aave/useAaveUserData";
-import { ChainId, EvmAddress, AaveMarket } from "@/types/aave";
-
-interface MarketUserReserveSupplyPosition {
-  currency: {
-    symbol: string;
-  };
-  balance: {
-    usd: string;
-  };
-  apy: {
-    value: string;
-  };
-  isCollateral: boolean;
-}
-
-interface UserSupplyData {
-  marketAddress: string;
-  marketName: string;
-  chainId: ChainId;
-  supplies: MarketUserReserveSupplyPosition[];
-  loading: boolean;
-  error: boolean;
-  hasData: boolean;
-}
+import { ChainId, EvmAddress, AaveMarket, UserSupplyData } from "@/types/aave";
 
 interface SingleMarketUserSuppliesProps {
   market: AaveMarket;

--- a/src/components/ui/lending/AggregatedMarketUserSupplies.tsx
+++ b/src/components/ui/lending/AggregatedMarketUserSupplies.tsx
@@ -1,30 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { SingleMarketUserSupplies } from "@/components/meta/SingleMarketUserSupplies";
-import { ChainId, EvmAddress, AaveMarket } from "@/types/aave";
+import { EvmAddress, AaveMarket, UserSupplyData } from "@/types/aave";
 import { formatCurrency, formatAPY } from "@/utils/formatters";
-
-interface MarketUserReserveSupplyPosition {
-  currency: {
-    symbol: string;
-  };
-  balance: {
-    usd: string;
-  };
-  apy: {
-    value: string;
-  };
-  isCollateral: boolean;
-}
-
-interface UserSupplyData {
-  marketAddress: string;
-  marketName: string;
-  chainId: ChainId;
-  supplies: MarketUserReserveSupplyPosition[];
-  loading: boolean;
-  error: boolean;
-  hasData: boolean;
-}
 
 interface AggregatedMarketUserSuppliesProps {
   activeMarkets: AaveMarket[];

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -85,3 +85,20 @@ export interface AaveMarket {
   chainId: number;
   isActive: boolean;
 }
+
+export interface UserSupplyPosition {
+  marketAddress: string;
+  marketName: string;
+  chainId: ChainId;
+  supply: MarketUserReserveSupplyPosition;
+}
+
+export interface UserSupplyData {
+  marketAddress: string;
+  marketName: string;
+  chainId: ChainId;
+  supplies: MarketUserReserveSupplyPosition[];
+  loading: boolean;
+  error: boolean;
+  hasData: boolean;
+}


### PR DESCRIPTION
this PR consolidates some of the interface definition that was getting repetitive and unnecessary.

- removed `MarketUserReserveSupplyPosition` entirely as it is already defined for us by aave
- moved `UserSupplyData` definition to `types/aave.ts`
- moved `UserSupplyPosition` definition to `types/aave.ts`