### PR TITLE
fix: lending history txs underlying asset

### DIFF
--- a/src/utils/lending/transactions.ts
+++ b/src/utils/lending/transactions.ts
@@ -109,16 +109,20 @@ const formatTransactionUsdValue = (
 
 const getTransactionKey = (transaction: UserTransactionItem): string => {
   let chainName: string;
+  let underlyingTokenAddress = "";
 
   if (isUserLiquidationCallTransaction(transaction)) {
     chainName = transaction.collateral.reserve.market.chain.name;
+    underlyingTokenAddress =
+      transaction.collateral.reserve.underlyingToken.address;
   } else if (hasReserve(transaction)) {
     chainName = transaction.reserve.market.chain.name;
+    underlyingTokenAddress = transaction.reserve.underlyingToken.address;
   } else {
     chainName = "unknown";
   }
 
-  return `${transaction.txHash}-${chainName}-${transaction.timestamp}-${transaction.__typename}`;
+  return `${transaction.txHash}-${chainName}-${transaction.timestamp}-${transaction.__typename}-${underlyingTokenAddress}`;
 };
 
 const getReserveInfo = (transaction: UserTransactionItem) => {


### PR DESCRIPTION
Please see just https://github.com/altverseweb3/site/commit/a632f81455d92de27151f22b9159be8f29c590a1

this PR is concerned with accounting for the underlying reserve as part of the unique transaction key for lending.

<img width="1489" height="125" alt="image" src="https://github.com/user-attachments/assets/9fb6b4e1-bdbe-4296-aaed-75b8c2906b13" />

It was discovered that `__typename` and `txHash` along with other parameters were not enough to uniquely identify transactions because multiple different collateral txs can be bundled into a single tx as can be seen in the above screenshot.