### PR TITLE
chore: added market icon to market card

### DIFF
--- a/src/components/ui/lending/MarketCard.tsx
+++ b/src/components/ui/lending/MarketCard.tsx
@@ -81,7 +81,17 @@ const MarketCard: React.FC<MarketCardProps> = ({ market, onDetails }) => {
           <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
             {market.underlyingToken.name}
           </CardTitle>
-          <CardDescription className="text-[#A1A1AA] text-xs mt-1">
+          <CardDescription className="text-[#A1A1AA] text-xs mt-1 flex items-center gap-1">
+            <Image
+              src={market.market.icon}
+              alt={market.market.chain.name}
+              width={16}
+              height={16}
+              className="object-contain rounded-full"
+              onError={(e) => {
+                e.currentTarget.src = "/images/markets/default.svg";
+              }}
+            />
             {market.marketName}
             {(market.isFrozen || market.isPaused) && (
               <span className="ml-1 text-red-400">


### PR DESCRIPTION
this PR adds the market icon to market cards (like we have done in the user open supply/borrow position cards).

## Screenshots

### Desktop
<img width="1669" height="919" alt="Screenshot 2025-08-31 at 9 47 01 am" src="https://github.com/user-attachments/assets/c875df0c-3271-4578-827b-bdebe2f141fc" />

### Tablet
<img width="501" height="587" alt="Screenshot 2025-08-31 at 9 47 14 am" src="https://github.com/user-attachments/assets/13bf86aa-e159-4734-8915-2d27b56fbefa" />

### Mobile
<img width="429" height="803" alt="Screenshot 2025-08-31 at 9 47 23 am" src="https://github.com/user-attachments/assets/3d8c8d3f-15af-44a7-9a3a-c4769aff6508" />
