### PR TITLE
feat: lending risk details

### DIFF
--- a/src/app/(dapp)/test/page.tsx
+++ b/src/app/(dapp)/test/page.tsx
@@ -25,14 +25,16 @@ function ConsoleOutput({ data }: { data: unknown }) {
 
 function MarketsDataRenderer() {
   const { markets } = useAaveMarketsData({
-    chainIds: [chainId(1), chainId(42161)],
+    user: evmAddress("0xf5d8777EA028Ad29515aA81E38e9B85afb7d6303"),
+    chainIds: [chainId(137)],
   });
   return <ConsoleOutput data={markets} />;
 }
 function SingleMarketDataRenderer() {
   const { market } = useAaveSingleMarketData({
+    user: evmAddress("0xf5d8777EA028Ad29515aA81E38e9B85afb7d6303"),
+    chainId: chainId(137),
     address: evmAddress("0x794a61358D6845594F94dc1DB02A252b5b4814aD"),
-    chainId: chainId(42161),
   });
   return <ConsoleOutput data={market} />;
 }
@@ -80,14 +82,10 @@ function UserSuppliesRenderer() {
 
 function UserBorrowsRenderer() {
   const { data } = useAaveUserBorrows({
-    user: TEST_USER_ADDRESS,
+    user: evmAddress("0xf5d8777EA028Ad29515aA81E38e9B85afb7d6303"),
     markets: [
       {
-        chainId: chainId(1),
-        address: evmAddress("0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2"),
-      },
-      {
-        chainId: chainId(42161),
+        chainId: chainId(137),
         address: evmAddress("0x794a61358D6845594F94dc1DB02A252b5b4814aD"),
       },
     ],

--- a/src/components/ui/lending/AggregatedMarketUserState.tsx
+++ b/src/components/ui/lending/AggregatedMarketUserState.tsx
@@ -42,6 +42,14 @@ interface AggregatedMarketUserStateProps {
       debt: string;
       collateral: string;
       borrowPercentUsed: string | null;
+      marketData: Record<
+        string,
+        {
+          debt: string;
+          collateral: string;
+          currentLtv: string | null;
+        }
+      >;
     };
     marketRiskData: Record<
       string,
@@ -228,6 +236,14 @@ export const AggregatedMarketUserState: React.FC<
       debt: formatCurrency(0),
       collateral: formatCurrency(0),
       borrowPercentUsed: null as string | null,
+      marketData: {} as Record<
+        string,
+        {
+          debt: string;
+          collateral: string;
+          currentLtv: string | null;
+        }
+      >,
     };
 
     if (validStates.length > 0) {
@@ -238,6 +254,35 @@ export const AggregatedMarketUserState: React.FC<
       const totalCollateralBase = validStates.reduce((sum, state) => {
         return sum + parseFloat(state.data!.totalCollateralBase);
       }, 0);
+
+      // Calculate per-market debt, collateral, and current LTV
+      const marketData: Record<
+        string,
+        {
+          debt: string;
+          collateral: string;
+          currentLtv: string | null;
+        }
+      > = {};
+
+      validStates.forEach((state) => {
+        const marketKey = `${state.chainId}-${state.marketAddress}`;
+        const marketDebt = parseFloat(state.data!.totalDebtBase);
+        const marketCollateral = parseFloat(state.data!.totalCollateralBase);
+
+        // Calculate current LTV as (debt * 100 / collateral)
+        let currentLtv: string | null = null;
+        if (marketCollateral > 0) {
+          const ltvRatio = (marketDebt * 100) / marketCollateral;
+          currentLtv = formatPercentage(ltvRatio);
+        }
+
+        marketData[marketKey] = {
+          debt: formatCurrency(marketDebt),
+          collateral: formatCurrency(marketCollateral),
+          currentLtv,
+        };
+      });
 
       // Calculate borrow % used
       let borrowPercentUsed: string | null = null;
@@ -273,6 +318,7 @@ export const AggregatedMarketUserState: React.FC<
         debt: formatCurrency(totalDebtBase),
         collateral: formatCurrency(totalCollateralBase),
         borrowPercentUsed,
+        marketData,
       };
     }
 

--- a/src/components/ui/lending/AggregatedMarketUserState.tsx
+++ b/src/components/ui/lending/AggregatedMarketUserState.tsx
@@ -50,6 +50,8 @@ interface AggregatedMarketUserStateProps {
         ltv: string | null;
         currentLiquidationThreshold: string | null;
         chainId: ChainId;
+        chainName: string;
+        marketName: string;
       }
     >;
     loading: boolean;
@@ -282,11 +284,19 @@ export const AggregatedMarketUserState: React.FC<
         ltv: string | null;
         currentLiquidationThreshold: string | null;
         chainId: ChainId;
+        chainName: string;
+        marketName: string;
       }
     > = {};
 
     validStates.forEach((state) => {
       const marketKey = `${state.chainId}-${state.marketAddress}`;
+      // Find the corresponding market from activeMarkets to get chain name and market name
+      const market = activeMarkets.find(
+        (m) =>
+          m.chain.chainId === state.chainId &&
+          m.address === state.marketAddress,
+      );
       marketRiskData[marketKey] = {
         healthFactor: state.healthFactor,
         ltv: state.ltv
@@ -298,6 +308,8 @@ export const AggregatedMarketUserState: React.FC<
             )
           : null,
         chainId: state.chainId,
+        chainName: market?.chain.name || "",
+        marketName: market?.name || "",
       };
     });
 
@@ -323,7 +335,7 @@ export const AggregatedMarketUserState: React.FC<
       marketCount: activeMarkets.length,
       marketData: filteredMarketData,
     };
-  }, [marketDataMap, activeMarkets.length, currentMarketKeys]);
+  }, [marketDataMap, activeMarkets, currentMarketKeys]);
 
   return (
     <>

--- a/src/components/ui/lending/AggregatedMarketUserState.tsx
+++ b/src/components/ui/lending/AggregatedMarketUserState.tsx
@@ -59,6 +59,7 @@ interface AggregatedMarketUserStateProps {
         currentLiquidationThreshold: string | null;
         chainId: ChainId;
         chainName: string;
+        chainIcon: string;
         marketName: string;
       }
     >;
@@ -331,6 +332,7 @@ export const AggregatedMarketUserState: React.FC<
         currentLiquidationThreshold: string | null;
         chainId: ChainId;
         chainName: string;
+        chainIcon: string;
         marketName: string;
       }
     > = {};
@@ -355,6 +357,7 @@ export const AggregatedMarketUserState: React.FC<
           : null,
         chainId: state.chainId,
         chainName: market?.chain.name || "",
+        chainIcon: market?.chain.icon || "",
         marketName: market?.name || "",
       };
     });

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -129,6 +129,8 @@ interface DashboardContentInnerProps {
       ltv: string | null;
       currentLiquidationThreshold: string | null;
       chainId: ChainId;
+      chainName: string;
+      marketName: string;
     }
   >;
   activeMarkets: Market[];

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -138,6 +138,7 @@ interface DashboardContentInnerProps {
       currentLiquidationThreshold: string | null;
       chainId: ChainId;
       chainName: string;
+      chainIcon: string;
       marketName: string;
     }
   >;

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -20,6 +20,7 @@ import UserSupplyContent from "@/components/ui/lending/UserSupplyContent";
 import UserBorrowContent from "@/components/ui/lending/UserBorrowContent";
 import AvailableSupplyContent from "@/components/ui/lending/AvailableSupplyContent";
 import AvailableBorrowContent from "@/components/ui/lending/AvailableBorrowContent";
+import RiskDetailsModal from "@/components/ui/lending/RiskDetailsModal";
 
 interface DashboardContentProps {
   userAddress?: string;
@@ -144,6 +145,7 @@ function DashboardContentInner({
   borrowData,
   marketSupplyData,
   marketBorrowData,
+  marketRiskData,
   activeMarkets,
   loading,
   error,
@@ -151,6 +153,7 @@ function DashboardContentInner({
   const [isSupplyMode, setIsSupplyMode] = useState(true);
   const [showAvailable, setShowAvailable] = useState(true);
   const [showZeroBalance, setShowZeroBalance] = useState(false);
+  const [isRiskDetailsModalOpen, setIsRiskDetailsModalOpen] = useState(false);
 
   // Show loading state if any market is still loading
   if (loading) {
@@ -181,7 +184,10 @@ function DashboardContentInner({
               global info (selected chains)
             </h3>
             {healthFactorData.show && (
-              <button className="px-2 py-0.5 bg-[#27272A] hover:bg-[#3F3F46] border border-[#3F3F46] rounded text-xs text-white">
+              <button
+                onClick={() => setIsRiskDetailsModalOpen(true)}
+                className="px-2 py-0.5 bg-[#27272A] hover:bg-[#3F3F46] border border-[#3F3F46] rounded text-xs text-white"
+              >
                 risk details
               </button>
             )}
@@ -366,6 +372,13 @@ function DashboardContentInner({
           />
         )}
       </div>
+
+      {/* Risk Details Modal */}
+      <RiskDetailsModal
+        isOpen={isRiskDetailsModalOpen}
+        onClose={() => setIsRiskDetailsModalOpen(false)}
+        marketRiskData={marketRiskData}
+      />
     </div>
   );
 }

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -119,6 +119,14 @@ interface DashboardContentInnerProps {
     debt: string;
     collateral: string;
     borrowPercentUsed: string | null;
+    marketData: Record<
+      string,
+      {
+        debt: string;
+        collateral: string;
+        currentLtv: string | null;
+      }
+    >;
   };
   marketSupplyData: Record<string, UserSupplyData>;
   marketBorrowData: Record<string, UserBorrowData>;
@@ -380,6 +388,7 @@ function DashboardContentInner({
         isOpen={isRiskDetailsModalOpen}
         onClose={() => setIsRiskDetailsModalOpen(false)}
         marketRiskData={marketRiskData}
+        borrowMarketData={borrowData.marketData}
       />
     </div>
   );

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -26,6 +26,14 @@ interface RiskDetailsModalProps {
   isOpen: boolean;
   onClose: () => void;
   marketRiskData: Record<string, MarketRiskData>;
+  borrowMarketData: Record<
+    string,
+    {
+      debt: string;
+      collateral: string;
+      currentLtv: string | null;
+    }
+  >;
 }
 
 interface DropdownOption {
@@ -38,6 +46,7 @@ export default function RiskDetailsModal({
   isOpen,
   onClose,
   marketRiskData,
+  borrowMarketData,
 }: RiskDetailsModalProps) {
   // Create dropdown options from market risk data
   const dropdownOptions: DropdownOption[] = React.useMemo(() => {
@@ -65,7 +74,14 @@ export default function RiskDetailsModal({
     ? parseFloat(selectedMarketData.healthFactor)
     : 0;
 
-  const ltvValue = selectedMarketData.ltv
+  // Get the current LTV usage from borrowMarketData (calculated as debt/collateral * 100)
+  const currentLtvData = borrowMarketData[selectedMarketKey];
+  const currentLtvValue = currentLtvData?.currentLtv
+    ? parseFloat(currentLtvData.currentLtv)
+    : 0;
+
+  // Get the maximum LTV from market data (protocol limit)
+  const maxLtvValue = selectedMarketData.ltv
     ? parseFloat(selectedMarketData.ltv)
     : 0;
 
@@ -214,7 +230,7 @@ export default function RiskDetailsModal({
               <div className="flex items-center space-x-2 sm:space-x-3">
                 <div className="flex-1 min-w-0">
                   <Slider
-                    value={[ltvValue]}
+                    value={[currentLtvValue]}
                     min={0}
                     max={100}
                     step={0.01}
@@ -229,7 +245,7 @@ export default function RiskDetailsModal({
                   />
                 </div>
                 <div className="text-right text-[#FAFAFA] text-xs font-mono w-10 sm:w-[60px] flex-shrink-0">
-                  {ltvValue.toFixed(2)}%
+                  {currentLtvValue.toFixed(2)}%
                 </div>
               </div>
 
@@ -244,7 +260,10 @@ export default function RiskDetailsModal({
                 if your loan to value goes above the liquidation threshold your
                 collateral supplied may be liquidated. you can borrow up to a
                 maximum LTV of{" "}
-                <span className="text-amber-500">{ltvValue.toFixed(2)}%</span>.
+                <span className="text-amber-500">
+                  {maxLtvValue.toFixed(2)}%
+                </span>
+                .
               </p>
             </div>
           </div>

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -18,6 +18,8 @@ interface MarketRiskData {
   ltv: string | null;
   currentLiquidationThreshold: string | null;
   chainId: ChainId;
+  chainName: string;
+  marketName: string;
 }
 
 interface RiskDetailsModalProps {
@@ -41,7 +43,7 @@ export default function RiskDetailsModal({
   const dropdownOptions: DropdownOption[] = React.useMemo(() => {
     return Object.entries(marketRiskData).map(([key, data]) => ({
       key,
-      label: key, // Using the market key as label for now
+      label: `${data.chainName} - ${data.marketName}`, // Display chain name and market name
       data,
     }));
   }, [marketRiskData]);
@@ -92,7 +94,10 @@ export default function RiskDetailsModal({
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 className="w-full flex items-center justify-between p-2 sm:p-3 bg-[#1F1F23] border border-[#27272A] rounded-lg text-[#FAFAFA] hover:bg-[#27272A]/50 transition-colors text-sm sm:text-base"
               >
-                <span className="truncate pr-2">{selectedMarketKey}</span>
+                <span className="truncate pr-2">
+                  {dropdownOptions.find((opt) => opt.key === selectedMarketKey)
+                    ?.label || selectedMarketKey}
+                </span>
                 <ChevronDown
                   className={`h-3.5 w-3.5 sm:h-4 sm:w-4 text-[#A1A1AA] transition-transform flex-shrink-0 ${
                     isDropdownOpen ? "rotate-180" : ""

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as React from "react";
 import { useState } from "react";
 import { ExternalLink } from "lucide-react";
 import {
@@ -55,15 +54,13 @@ export default function RiskDetailsModal({
   marketRiskData,
   borrowMarketData,
 }: RiskDetailsModalProps) {
-  const dropdownOptions: DropdownOption[] = React.useMemo(() => {
-    return Object.entries(marketRiskData)
-      .filter(([, data]) => data.healthFactor !== null) // Only include markets with borrow positions
-      .map(([key, data]) => ({
-        key,
-        label: `${data.chainName} - ${data.marketName}`, // Display chain name and market name
-        data,
-      }));
-  }, [marketRiskData]);
+  const dropdownOptions: DropdownOption[] = Object.entries(marketRiskData)
+    .filter(([, data]) => data.healthFactor !== null)
+    .map(([key, data]) => ({
+      key,
+      label: `${data.chainName} - ${data.marketName}`,
+      data,
+    }));
 
   const [selectedMarketKey, setSelectedMarketKey] = useState<string>(
     dropdownOptions[0]?.key || "",

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -100,7 +100,7 @@ export default function RiskDetailsModal({
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="w-[calc(100vw-0.5rem)] max-w-[500px] bg-[#18181B] border-[#27272A] max-h-[95vh] overflow-y-auto sm:w-[calc(100vw-2rem)]">
-        <DialogHeader className="pb-1 sm:pb-2">
+        <DialogHeader className="pb-1 sm:pb-2 text-left">
           <DialogTitle className="text-[#FAFAFA] text-base sm:text-lg font-semibold">
             liquidation risk details
           </DialogTitle>

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import * as React from "react";
+import { useState } from "react";
+import { ChevronDown, ExternalLink } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/StyledDialog";
+import { Slider } from "@/components/ui/Slider";
+import { ChainId } from "@/types/aave";
+import { formatHealthFactor } from "@/utils/formatters";
+
+interface MarketRiskData {
+  healthFactor: string | null;
+  ltv: string | null;
+  currentLiquidationThreshold: string | null;
+  chainId: ChainId;
+}
+
+interface RiskDetailsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  marketRiskData: Record<string, MarketRiskData>;
+}
+
+interface DropdownOption {
+  key: string;
+  label: string;
+  data: MarketRiskData;
+}
+
+export default function RiskDetailsModal({
+  isOpen,
+  onClose,
+  marketRiskData,
+}: RiskDetailsModalProps) {
+  // Create dropdown options from market risk data
+  const dropdownOptions: DropdownOption[] = React.useMemo(() => {
+    return Object.entries(marketRiskData).map(([key, data]) => ({
+      key,
+      label: key, // Using the market key as label for now
+      data,
+    }));
+  }, [marketRiskData]);
+
+  const [selectedMarketKey, setSelectedMarketKey] = useState<string>(
+    dropdownOptions[0]?.key || "",
+  );
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const selectedMarketData = marketRiskData[selectedMarketKey];
+
+  if (!selectedMarketData || dropdownOptions.length === 0) {
+    return null;
+  }
+
+  const healthFactorValue = selectedMarketData.healthFactor
+    ? parseFloat(selectedMarketData.healthFactor)
+    : 0;
+
+  const ltvValue = selectedMarketData.ltv
+    ? parseFloat(selectedMarketData.ltv)
+    : 0;
+
+  const liquidationThreshold = selectedMarketData.currentLiquidationThreshold
+    ? parseFloat(selectedMarketData.currentLiquidationThreshold)
+    : 0;
+
+  // Cap health factor display at 5 for slider
+  const displayHealthFactor = Math.min(healthFactorValue, 5);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="w-[calc(100vw-0.5rem)] max-w-[500px] bg-[#18181B] border-[#27272A] max-h-[95vh] overflow-y-auto mx-1 sm:mx-4 sm:w-[calc(100vw-2rem)]">
+        <DialogHeader className="pb-2 sm:pb-4">
+          <DialogTitle className="text-[#FAFAFA] text-base sm:text-lg font-semibold">
+            liquidation risk details
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 sm:space-y-4">
+          {/* Market Selection Dropdown */}
+          <div className="space-y-1.5">
+            <label className="text-xs sm:text-sm text-[#A1A1AA]">
+              select chain/market
+            </label>
+            <div className="relative">
+              <button
+                onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                className="w-full flex items-center justify-between p-2 sm:p-3 bg-[#1F1F23] border border-[#27272A] rounded-lg text-[#FAFAFA] hover:bg-[#27272A]/50 transition-colors text-sm sm:text-base"
+              >
+                <span className="truncate pr-2">{selectedMarketKey}</span>
+                <ChevronDown
+                  className={`h-3.5 w-3.5 sm:h-4 sm:w-4 text-[#A1A1AA] transition-transform flex-shrink-0 ${
+                    isDropdownOpen ? "rotate-180" : ""
+                  }`}
+                />
+              </button>
+
+              {isDropdownOpen && (
+                <div className="absolute top-full left-0 right-0 z-50 mt-1 bg-[#1F1F23] border border-[#27272A] rounded-lg shadow-lg overflow-hidden">
+                  {dropdownOptions.map((option) => (
+                    <button
+                      key={option.key}
+                      onClick={() => {
+                        setSelectedMarketKey(option.key);
+                        setIsDropdownOpen(false);
+                      }}
+                      className={`w-full text-left p-2 sm:p-3 hover:bg-[#27272A]/50 transition-colors text-sm sm:text-base ${
+                        selectedMarketKey === option.key
+                          ? "bg-[#27272A]/50 text-[#FAFAFA]"
+                          : "text-[#A1A1AA]"
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Information Paragraph */}
+          <div>
+            <p className="text-[#A1A1AA] text-xs sm:text-sm leading-relaxed">
+              your health factor and loan to value determine the assurance of
+              your collateral. to avoid liquidations you can supply more
+              collateral or repay borrow positions.{" "}
+              <a
+                href="https://aave.com/docs"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sky-400 hover:text-sky-300 underline inline-flex items-center gap-1"
+              >
+                learn more
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </p>
+          </div>
+
+          {/* Health Factor Card */}
+          <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-3 sm:p-4 space-y-3 sm:space-y-4">
+            <h3 className="text-[#FAFAFA] font-medium text-sm sm:text-base">
+              health factor
+            </h3>
+            <p className="text-[#A1A1AA] text-xs sm:text-sm">
+              safety of your deposited collateral against the borrowed assets
+              and its underlying value.
+            </p>
+
+            {/* Health Factor Slider */}
+            <div className="space-y-2 sm:space-y-3">
+              <div className="flex items-center space-x-2 sm:space-x-4">
+                <div className="flex-1 min-w-0">
+                  <Slider
+                    value={[displayHealthFactor]}
+                    min={0}
+                    max={5}
+                    step={0.01}
+                    disabled
+                    className="w-full
+                      [&_.bg-primary]:bg-sky-500
+                      [&_.bg-primary\\/20]:bg-[#27272A]
+                      [&_[role=slider]]:border-[#3F3F46]
+                      [&_[role=slider]]:bg-sky-500
+                      [&_[role=slider]]:pointer-events-none
+                    "
+                  />
+                </div>
+                <div className="text-right text-[#FAFAFA] text-xs sm:text-sm font-mono w-12 sm:w-[60px] flex-shrink-0">
+                  {formatHealthFactor(selectedMarketData.healthFactor).value}
+                </div>
+              </div>
+
+              {/* Slider Labels */}
+              <div className="relative text-xs text-[#A1A1AA] px-1 pb-1.5">
+                <div className="absolute left-0">0</div>
+                <div className="absolute" style={{ left: "20%" }}>
+                  1.00
+                </div>
+                <div className="absolute right-0" style={{ right: "18%" }}>
+                  5+
+                </div>
+              </div>
+
+              <p className="text-[#A1A1AA] text-xs sm:text-sm">
+                if the health factor goes below 1.00, the liquidation of your
+                collateral might be triggered.
+              </p>
+            </div>
+          </div>
+
+          {/* Current LTV Card */}
+          <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-2.5 sm:p-4 space-y-2.5 sm:space-y-3">
+            <h3 className="text-[#FAFAFA] font-medium text-xs sm:text-base">
+              current LTV
+            </h3>
+            <p className="text-[#A1A1AA] text-xs">
+              your current loan to value based on your collateral supplied.
+            </p>
+
+            {/* LTV Slider */}
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2 sm:space-x-3">
+                <div className="flex-1 min-w-0">
+                  <Slider
+                    value={[ltvValue]}
+                    min={0}
+                    max={100}
+                    step={0.01}
+                    disabled
+                    className="w-full
+                      [&_.bg-primary]:bg-amber-500
+                      [&_.bg-primary\\/20]:bg-[#27272A]
+                      [&_[role=slider]]:border-[#3F3F46]
+                      [&_[role=slider]]:bg-amber-500
+                      [&_[role=slider]]:pointer-events-none
+                    "
+                  />
+                </div>
+                <div className="text-right text-[#FAFAFA] text-xs font-mono w-10 sm:w-[60px] flex-shrink-0">
+                  {ltvValue.toFixed(2)}%
+                </div>
+              </div>
+
+              {/* Liquidation Threshold Label */}
+              <div className="flex justify-center pb-1.5">
+                <span className="text-xs text-[#A1A1AA]">
+                  liquidation threshold: {liquidationThreshold.toFixed(2)}%
+                </span>
+              </div>
+
+              <p className="text-[#A1A1AA] text-xs">
+                if your loan to value goes above the liquidation threshold your
+                collateral supplied may be liquidated.
+              </p>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/Select";
 import { ChainId } from "@/types/aave";
 import { formatHealthFactor } from "@/utils/formatters";
+import Image from "next/image";
 
 interface MarketRiskData {
   healthFactor: string | null;
@@ -25,6 +26,7 @@ interface MarketRiskData {
   currentLiquidationThreshold: string | null;
   chainId: ChainId;
   chainName: string;
+  chainIcon: string;
   marketName: string;
 }
 
@@ -115,8 +117,28 @@ export default function RiskDetailsModal({
             >
               <SelectTrigger className="w-full p-2 sm:p-3 bg-[#1F1F23] border-[#27272A] text-[#FAFAFA] hover:bg-[#27272A]/50 text-sm sm:text-base focus:ring-1 focus:ring-sky-500 focus:ring-offset-0">
                 <SelectValue>
-                  {dropdownOptions.find((opt) => opt.key === selectedMarketKey)
-                    ?.label || selectedMarketKey}
+                  {(() => {
+                    const selectedOption = dropdownOptions.find(
+                      (opt) => opt.key === selectedMarketKey,
+                    );
+                    return selectedOption ? (
+                      <div className="flex items-center gap-2">
+                        <Image
+                          src={selectedOption.data.chainIcon}
+                          alt={selectedOption.data.chainName}
+                          width={22}
+                          height={22}
+                          className="object-contain"
+                          onError={(e) => {
+                            e.currentTarget.src = "/images/tokens/default.svg";
+                          }}
+                        />
+                        <span>{selectedOption.label}</span>
+                      </div>
+                    ) : (
+                      selectedMarketKey
+                    );
+                  })()}
                 </SelectValue>
               </SelectTrigger>
               <SelectContent className="bg-[#1F1F23] border-[#27272A]">
@@ -126,7 +148,19 @@ export default function RiskDetailsModal({
                     value={option.key}
                     className="text-[#A1A1AA] hover:bg-[#27272A]/50 focus:bg-[#27272A]/50 focus:text-[#FAFAFA] text-sm sm:text-base"
                   >
-                    {option.label}
+                    <div className="flex items-center gap-2">
+                      <Image
+                        src={option.data.chainIcon}
+                        alt={option.data.chainName}
+                        width={22}
+                        height={22}
+                        className="object-contain"
+                        onError={(e) => {
+                          e.currentTarget.src = "/images/tokens/default.svg";
+                        }}
+                      />
+                      <span>{option.label}</span>
+                    </div>
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useState } from "react";
-import { ChevronDown, ExternalLink } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -10,6 +10,13 @@ import {
   DialogTitle,
 } from "@/components/ui/StyledDialog";
 import { Slider } from "@/components/ui/Slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/Select";
 import { ChainId } from "@/types/aave";
 import { formatHealthFactor } from "@/utils/formatters";
 
@@ -62,7 +69,6 @@ export default function RiskDetailsModal({
   const [selectedMarketKey, setSelectedMarketKey] = useState<string>(
     dropdownOptions[0]?.key || "",
   );
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const selectedMarketData = marketRiskData[selectedMarketKey];
 
@@ -94,7 +100,7 @@ export default function RiskDetailsModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="w-[calc(100vw-0.5rem)] max-w-[500px] bg-[#18181B] border-[#27272A] max-h-[95vh] overflow-y-auto mx-1 sm:mx-4 sm:w-[calc(100vw-2rem)]">
+      <DialogContent className="w-[calc(100vw-0.5rem)] max-w-[500px] bg-[#18181B] border-[#27272A] max-h-[95vh] overflow-y-auto sm:w-[calc(100vw-2rem)]">
         <DialogHeader className="pb-2 sm:pb-4">
           <DialogTitle className="text-[#FAFAFA] text-base sm:text-lg font-semibold">
             liquidation risk details
@@ -102,48 +108,33 @@ export default function RiskDetailsModal({
         </DialogHeader>
 
         <div className="space-y-3 sm:space-y-4">
-          {/* Market Selection Dropdown */}
+          {/* Market Selection */}
           <div className="space-y-1.5">
             <label className="text-xs sm:text-sm text-[#A1A1AA]">
-              select chain/market
+              select chain/market:
             </label>
-            <div className="relative">
-              <button
-                onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-                className="w-full flex items-center justify-between p-2 sm:p-3 bg-[#1F1F23] border border-[#27272A] rounded-lg text-[#FAFAFA] hover:bg-[#27272A]/50 transition-colors text-sm sm:text-base"
-              >
-                <span className="truncate pr-2">
+            <Select
+              value={selectedMarketKey}
+              onValueChange={setSelectedMarketKey}
+            >
+              <SelectTrigger className="w-full p-2 sm:p-3 bg-[#1F1F23] border-[#27272A] text-[#FAFAFA] hover:bg-[#27272A]/50 text-sm sm:text-base focus:ring-1 focus:ring-sky-500 focus:ring-offset-0">
+                <SelectValue>
                   {dropdownOptions.find((opt) => opt.key === selectedMarketKey)
                     ?.label || selectedMarketKey}
-                </span>
-                <ChevronDown
-                  className={`h-3.5 w-3.5 sm:h-4 sm:w-4 text-[#A1A1AA] transition-transform flex-shrink-0 ${
-                    isDropdownOpen ? "rotate-180" : ""
-                  }`}
-                />
-              </button>
-
-              {isDropdownOpen && (
-                <div className="absolute top-full left-0 right-0 z-50 mt-1 bg-[#1F1F23] border border-[#27272A] rounded-lg shadow-lg overflow-hidden">
-                  {dropdownOptions.map((option) => (
-                    <button
-                      key={option.key}
-                      onClick={() => {
-                        setSelectedMarketKey(option.key);
-                        setIsDropdownOpen(false);
-                      }}
-                      className={`w-full text-left p-2 sm:p-3 hover:bg-[#27272A]/50 transition-colors text-sm sm:text-base ${
-                        selectedMarketKey === option.key
-                          ? "bg-[#27272A]/50 text-[#FAFAFA]"
-                          : "text-[#A1A1AA]"
-                      }`}
-                    >
-                      {option.label}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent className="bg-[#1F1F23] border-[#27272A]">
+                {dropdownOptions.map((option) => (
+                  <SelectItem
+                    key={option.key}
+                    value={option.key}
+                    className="text-[#A1A1AA] hover:bg-[#27272A]/50 focus:bg-[#27272A]/50 focus:text-[#FAFAFA] text-sm sm:text-base"
+                  >
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           {/* Information Paragraph */}
@@ -199,7 +190,7 @@ export default function RiskDetailsModal({
               </div>
 
               {/* Slider Labels */}
-              <div className="relative text-xs text-[#A1A1AA] px-1 pb-1.5">
+              <div className="relative text-xs sm:text-sm text-[#A1A1AA] px-1 pb-7">
                 <div className="absolute left-0">0</div>
                 <div className="absolute" style={{ left: "20%" }}>
                   1.00
@@ -217,17 +208,17 @@ export default function RiskDetailsModal({
           </div>
 
           {/* Current LTV Card */}
-          <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-2.5 sm:p-4 space-y-2.5 sm:space-y-3">
-            <h3 className="text-[#FAFAFA] font-medium text-xs sm:text-base">
+          <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-3 sm:p-4 space-y-3 sm:space-y-4">
+            <h3 className="text-[#FAFAFA] font-medium text-sm sm:text-base">
               current LTV
             </h3>
-            <p className="text-[#A1A1AA] text-xs">
+            <p className="text-[#A1A1AA] text-xs sm:text-sm">
               your current loan to value based on your collateral supplied.
             </p>
 
             {/* LTV Slider */}
-            <div className="space-y-2">
-              <div className="flex items-center space-x-2 sm:space-x-3">
+            <div className="space-y-2 sm:space-y-3">
+              <div className="flex items-center space-x-2 sm:space-x-4">
                 <div className="flex-1 min-w-0">
                   <Slider
                     value={[currentLtvValue]}
@@ -244,19 +235,19 @@ export default function RiskDetailsModal({
                     "
                   />
                 </div>
-                <div className="text-right text-[#FAFAFA] text-xs font-mono w-10 sm:w-[60px] flex-shrink-0">
+                <div className="text-right text-[#FAFAFA] text-xs sm:text-sm font-mono w-12 sm:w-[60px] flex-shrink-0">
                   {currentLtvValue.toFixed(2)}%
                 </div>
               </div>
 
               {/* Liquidation Threshold Label */}
-              <div className="flex justify-center pb-1.5">
-                <span className="text-xs text-[#A1A1AA]">
+              <div className="flex justify-center pb-2">
+                <span className="text-xs sm:text-sm text-[#A1A1AA]">
                   liquidation threshold: {liquidationThreshold.toFixed(2)}%
                 </span>
               </div>
 
-              <p className="text-[#A1A1AA] text-xs">
+              <p className="text-[#A1A1AA] text-xs sm:text-sm">
                 if your loan to value goes above the liquidation threshold your
                 collateral supplied may be liquidated. you can borrow up to a
                 maximum LTV of{" "}

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -101,7 +101,7 @@ export default function RiskDetailsModal({
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="w-[calc(100vw-0.5rem)] max-w-[500px] bg-[#18181B] border-[#27272A] max-h-[95vh] overflow-y-auto sm:w-[calc(100vw-2rem)]">
-        <DialogHeader className="pb-2 sm:pb-4">
+        <DialogHeader className="pb-1 sm:pb-2">
           <DialogTitle className="text-[#FAFAFA] text-base sm:text-lg font-semibold">
             liquidation risk details
           </DialogTitle>

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -242,7 +242,9 @@ export default function RiskDetailsModal({
 
               <p className="text-[#A1A1AA] text-xs">
                 if your loan to value goes above the liquidation threshold your
-                collateral supplied may be liquidated.
+                collateral supplied may be liquidated. you can borrow up to a
+                maximum LTV of{" "}
+                <span className="text-amber-500">{ltvValue.toFixed(2)}%</span>.
               </p>
             </div>
           </div>

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -41,11 +41,13 @@ export default function RiskDetailsModal({
 }: RiskDetailsModalProps) {
   // Create dropdown options from market risk data
   const dropdownOptions: DropdownOption[] = React.useMemo(() => {
-    return Object.entries(marketRiskData).map(([key, data]) => ({
-      key,
-      label: `${data.chainName} - ${data.marketName}`, // Display chain name and market name
-      data,
-    }));
+    return Object.entries(marketRiskData)
+      .filter(([, data]) => data.healthFactor !== null) // Only include markets with borrow positions
+      .map(([key, data]) => ({
+        key,
+        label: `${data.chainName} - ${data.marketName}`, // Display chain name and market name
+        data,
+      }));
   }, [marketRiskData]);
 
   const [selectedMarketKey, setSelectedMarketKey] = useState<string>(

--- a/src/components/ui/lending/RiskDetailsModal.tsx
+++ b/src/components/ui/lending/RiskDetailsModal.tsx
@@ -55,7 +55,6 @@ export default function RiskDetailsModal({
   marketRiskData,
   borrowMarketData,
 }: RiskDetailsModalProps) {
-  // Create dropdown options from market risk data
   const dropdownOptions: DropdownOption[] = React.useMemo(() => {
     return Object.entries(marketRiskData)
       .filter(([, data]) => data.healthFactor !== null) // Only include markets with borrow positions
@@ -192,10 +191,10 @@ export default function RiskDetailsModal({
               {/* Slider Labels */}
               <div className="relative text-xs sm:text-sm text-[#A1A1AA] px-1 pb-7">
                 <div className="absolute left-0">0</div>
-                <div className="absolute" style={{ left: "20%" }}>
+                <div className="absolute" style={{ left: "15%" }}>
                   1.00
                 </div>
-                <div className="absolute right-0" style={{ right: "18%" }}>
+                <div className="absolute right-0" style={{ right: "17.5%" }}>
                   5+
                 </div>
               </div>


### PR DESCRIPTION
This PR is concerned with implementing the "risk details" modal - which is only an available modal for and on chains where borrow positions are open for the user.  In order to display relevant data, the health factor and LTV and maximum LTV and liquidation threshold, per-market, where borrow positions are open, need to be available. 

The liquidation threshold is available in the market state data.

The maximum LTV is also available in the market state data.

In order to calculate the *current LTV*, the collateral and debt on the relevant market needs to be leveraged - as such `borrowData` has been extended to record it, per-chain and the calculation is done in `AggregatedMarketUserState.tsx`

---

Desktop:

<img width="1308" height="893" alt="image" src="https://github.com/user-attachments/assets/7dffe951-f584-49e3-a019-8ae285905fc5" />

Tablet:

<img width="646" height="905" alt="image" src="https://github.com/user-attachments/assets/f8dd0856-5533-4ee4-ba14-0f3e8e9baacc" />

Mobile:

<img width="454" height="909" alt="image" src="https://github.com/user-attachments/assets/87e1cf59-b8d8-497c-8583-b952f088d7b8" />

---

Proof of parity:

<img width="409" height="661" alt="image" src="https://github.com/user-attachments/assets/e88d16e2-060d-46fc-a283-d95974367c0e" />
