### PR TITLE
refactor: now include both onSupply and onBorrow everywhere

### DIFF
--- a/src/components/ui/lending/AvailableBorrowCard.tsx
+++ b/src/components/ui/lending/AvailableBorrowCard.tsx
@@ -24,11 +24,13 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 
 interface AvailableBorrowCardProps {
   market: UnifiedMarketData;
-  onBorrow?: (market: UnifiedMarketData) => void;
+  onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
 }
 
 const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
   market,
+  onSupply,
   onBorrow,
 }) => {
   // Extract borrow data
@@ -165,7 +167,10 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
       <CardFooter className="flex justify-center p-4 pt-0">
         <BrandedButton
           buttonText="details"
-          onClick={() => onBorrow?.(market)}
+          onClick={() => {
+            onBorrow?.(market);
+            onSupply?.(market);
+          }}
           className="w-full text-xs py-2 h-8"
           disabled={!isAvailable || !hasLiquidity}
         />

--- a/src/components/ui/lending/AvailableBorrowContent.tsx
+++ b/src/components/ui/lending/AvailableBorrowContent.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import AvailableBorrowCard from "@/components/ui/lending/AvailableBorrowCard";
 import CardsList from "@/components/ui/CardsList";
-import { Market } from "@/types/aave";
+import { Market, UnifiedMarketData } from "@/types/aave";
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
 
 interface AvailableBorrowContentProps {
@@ -62,7 +62,11 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
         <AvailableBorrowCard
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
-          onBorrow={() => {
+          onSupply={(market: UnifiedMarketData) => {
+            // TODO: Implement supply modal/flow
+            console.log("Supply clicked for:", market.underlyingToken.symbol);
+          }}
+          onBorrow={(market: UnifiedMarketData) => {
             // TODO: Implement borrow modal/flow
             console.log("Borrow clicked for:", market.underlyingToken.symbol);
           }}

--- a/src/components/ui/lending/AvailableSupplyCard.tsx
+++ b/src/components/ui/lending/AvailableSupplyCard.tsx
@@ -23,12 +23,14 @@ import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 
 interface AvailableSupplyCardProps {
   market: UnifiedMarketData;
-  onSupply?: (market: UnifiedMarketData) => void;
+  onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
 }
 
 const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
   market,
   onSupply,
+  onBorrow,
 }) => {
   // Extract supply data
   const baseSupplyAPY = market.supplyData.apy;
@@ -144,7 +146,10 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
       <CardFooter className="flex justify-center p-4 pt-0">
         <BrandedButton
           buttonText="details"
-          onClick={() => onSupply?.(market)}
+          onClick={() => {
+            onSupply?.(market);
+            onBorrow?.(market);
+          }}
           className="w-full text-xs py-2 h-8"
           disabled={!isAvailable}
         />

--- a/src/components/ui/lending/AvailableSupplyContent.tsx
+++ b/src/components/ui/lending/AvailableSupplyContent.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import AvailableSupplyCard from "@/components/ui/lending/AvailableSupplyCard";
 import CardsList from "@/components/ui/CardsList";
-import { Market } from "@/types/aave";
+import { Market, UnifiedMarketData } from "@/types/aave";
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
 
 interface AvailableSupplyContentProps {
@@ -70,9 +70,13 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
         <AvailableSupplyCard
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
-          onSupply={() => {
+          onSupply={(market: UnifiedMarketData) => {
             // TODO: Implement supply modal/flow
             console.log("Supply clicked for:", market.underlyingToken.symbol);
+          }}
+          onBorrow={(market: UnifiedMarketData) => {
+            // TODO: Implement borrow modal/flow
+            console.log("Borrow clicked for:", market.underlyingToken.symbol);
           }}
         />
       )}


### PR DESCRIPTION
this PR adds both `onSupply` and `onBorrow` to both the `AvailableSupplyCard` and `AvailableBorrowCard`. The reason for this is because both the available supply card and the available borrow card will lead to the same asset details modal, which gives users the option to either supply OR borrow (assuming both options are available on the particular asset).

Since the interactions have not yet been implemented, we do a simple console log of the functions to silence unused prop linting warnings.