### PR TITLE
feat: initial commit for horizontal progress bar

### DIFF
--- a/src/components/ui/HorizontalProgressBar.tsx
+++ b/src/components/ui/HorizontalProgressBar.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { formatPercentage } from "@/utils/formatters";
+interface HorizontalProgressBarProps {
+  current: number;
+  max: number;
+  label: string;
+  primaryValue: string;
+  secondaryValue: string;
+  showPercentage?: boolean;
+  color?: "green" | "sky" | "amber" | "red";
+}
+
+const HorizontalProgressBar: React.FC<HorizontalProgressBarProps> = ({
+  current,
+  max,
+  label,
+  primaryValue,
+  secondaryValue,
+  showPercentage = true,
+  color = "green",
+}) => {
+  const percentage = max > 0 ? Math.min((current / max) * 100, 100) : 0;
+
+  const colorClass = {
+    bg: `bg-${color}-500/10`,
+    fill: `bg-${color}-500`,
+    border: `border-${color}-500/30`,
+    text: `text-${color}-400`,
+    percentage: `text-${color}-400`,
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Header with label and percentage */}
+      <div className="flex justify-between items-center">
+        <span className="text-sm font-medium text-zinc-300">{label}</span>
+        {showPercentage && (
+          <span
+            className={`text-sm font-semibold font-mono ${colorClass.percentage}`}
+          >
+            {formatPercentage(percentage)}
+          </span>
+        )}
+      </div>
+
+      {/* Progress Bar */}
+      <div
+        className={`relative h-4 rounded-lg border ${colorClass.border} ${colorClass.bg} overflow-hidden`}
+      >
+        {/* Background track */}
+        <div className="absolute inset-0 bg-zinc-800/50 rounded-lg" />
+
+        {/* Progress fill */}
+        <div
+          className={`h-full ${colorClass.fill} rounded-lg transition-all duration-700 ease-out relative`}
+          style={{ width: `${percentage}%` }}
+        >
+          {/* Subtle shine effect */}
+          <div className="absolute inset-0 bg-white/10 rounded-lg animate-pulse" />
+        </div>
+      </div>
+
+      {/* Values display */}
+      <div className="flex justify-between items-center text-xs">
+        <div className="flex flex-col space-y-1">
+          <span className={`font-medium font-mono ${colorClass.text}`}>
+            {primaryValue}
+          </span>
+          <span className="text-zinc-500 font-mono">{secondaryValue}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HorizontalProgressBar;

--- a/src/components/ui/lending/assetDetails/SupplyInfoTab.tsx
+++ b/src/components/ui/lending/assetDetails/SupplyInfoTab.tsx
@@ -1,5 +1,6 @@
 import { UnifiedMarketData } from "@/types/aave";
 import { InfoRow } from "@/components/ui/lending/assetDetails/InfoRow";
+import HorizontalProgressBar from "@/components/ui/HorizontalProgressBar";
 import {
   formatBalance,
   formatCurrency,
@@ -11,6 +12,7 @@ import {
   SquarePlus,
   SquareEqual,
   AlertTriangle,
+  Infinity,
 } from "lucide-react";
 
 const SupplyInfoTab: React.FC<{
@@ -24,32 +26,72 @@ const SupplyInfoTab: React.FC<{
   // Calculate supply utilization
   const hasSupplyCap = supplyInfo.supplyCap.amount.value !== "0";
   const supplyCapTokens = hasSupplyCap
-    ? supplyInfo.supplyCap.amount.value
-    : "0";
+    ? parseFloat(supplyInfo.supplyCap.amount.value)
+    : 0;
   const supplyCapUsd = hasSupplyCap ? supplyInfo.supplyCap.usd : 0;
+  const currentSuppliedTokens = parseFloat(market.supplyData.totalSupplied);
+  const currentSuppliedUsd = market.supplyData.totalSuppliedUsd;
 
-  const totalSuppliedAmount = hasSupplyCap
-    ? `${formatBalance(market.supplyData.totalSupplied)} out of ${formatBalance(supplyCapTokens)} ${market.underlyingToken.symbol}`
-    : `${formatBalance(market.supplyData.totalSupplied)} ${market.underlyingToken.symbol}`;
-
-  const totalSuppliedUsd = hasSupplyCap
-    ? `${formatCurrency(market.supplyData.totalSuppliedUsd)} out of ${formatCurrency(supplyCapUsd)}`
-    : formatCurrency(market.supplyData.totalSuppliedUsd);
+  // Format values for display
+  const primaryValue = `${formatBalance(market.supplyData.totalSupplied)} ${market.underlyingToken.symbol}`;
+  const secondaryValue = formatCurrency(currentSuppliedUsd);
+  const maxPrimaryValue = hasSupplyCap
+    ? `${formatBalance(supplyInfo.supplyCap.amount.value)} ${market.underlyingToken.symbol}`
+    : "Unlimited";
+  const maxSecondaryValue = hasSupplyCap
+    ? formatCurrency(supplyCapUsd)
+    : "No cap";
 
   return (
     <div className="space-y-4">
-      {/* Total Supplied Amount */}
+      {/* Total Supplied Amount with Progress Bar */}
       <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
-        <h3 className="text-sm font-medium text-white mb-3 flex items-center gap-2">
+        <h3 className="text-sm font-medium text-white mb-4 flex items-center gap-2">
           <TrendingUp className="w-4 h-4 text-green-400" />
           supply liquidity
         </h3>
-        <InfoRow label="total supplied amount" value={totalSuppliedAmount} />
-        <InfoRow label="total supplied amount (USD)" value={totalSuppliedUsd} />
+
+        {hasSupplyCap ? (
+          <HorizontalProgressBar
+            current={currentSuppliedTokens}
+            max={supplyCapTokens}
+            label="total amount supplied"
+            primaryValue={`${primaryValue} of ${maxPrimaryValue}`}
+            secondaryValue={`${secondaryValue} of ${maxSecondaryValue}`}
+            color="green"
+          />
+        ) : (
+          // Fallback for unlimited supply cap
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Infinity className="w-4 h-4 text-blue-400" />
+                <span className="text-sm text-zinc-300">
+                  unlimited Supply Cap
+                </span>
+              </div>
+            </div>
+            <div className="grid grid-cols-1 gap-2 p-3 bg-zinc-800/30 rounded-lg border border-zinc-700/50">
+              <div className="flex justify-between">
+                <span className="text-sm text-zinc-400">Total Supplied:</span>
+                <span className="text-sm font-medium text-green-400">
+                  {primaryValue}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-zinc-400">USD Value:</span>
+                <span className="text-sm font-medium text-blue-400">
+                  {secondaryValue}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+
         {supplyInfo.supplyCapReached && (
-          <div className="flex items-center gap-2 text-orange-400 text-xs mt-2">
-            <AlertTriangle className="w-3 h-3" />
-            supply cap reached
+          <div className="flex items-center gap-2 text-orange-400 text-xs mt-3 p-3 bg-orange-500/10 border border-orange-500/20 rounded-lg">
+            <AlertTriangle className="w-4 h-4" />
+            <span>supply cap has been reached</span>
           </div>
         )}
       </div>


### PR DESCRIPTION
this PR adds a new reusable `HorizontalProgressBar` which can be used to show the percentage proportion of borrow/supply caps.

The bar is green for supply and red for borrow, and I have also included an option for amber/sky should we require a more generic bar down the line.

## Screenshots
### Desktop
<img width="2054" height="1864" alt="Screenshot 2025-09-02 at 7 44 18 pm" src="https://github.com/user-attachments/assets/c9ed4f25-4562-4619-af7a-a54f5fe177b5" />
<img width="1874" height="1808" alt="Screenshot 2025-09-02 at 7 44 25 pm" src="https://github.com/user-attachments/assets/0566b035-4df5-4f52-9770-8cb1e04b1eb3" />

### Tablet
<img width="1468" height="1960" alt="Screenshot 2025-09-02 at 7 44 54 pm" src="https://github.com/user-attachments/assets/71cf0a73-5abf-44d1-8d17-e614b3d09512" />
<img width="1468" height="1960" alt="Screenshot 2025-09-02 at 7 45 00 pm" src="https://github.com/user-attachments/assets/fb149d02-9192-43cd-9068-03efdf45ff4e" />

### Mobile
<img width="926" height="1910" alt="Screenshot 2025-09-02 at 7 45 15 pm" src="https://github.com/user-attachments/assets/7c812649-7f44-49bd-a511-8f6d2af372d7" />
<img width="902" height="1910" alt="Screenshot 2025-09-02 at 7 45 21 pm" src="https://github.com/user-attachments/assets/1cef2ad7-b090-4624-ab92-ddc844be298f" />
