### PR TITLE
feat: added supply and borrow CTA buttons

### DIFF
--- a/src/components/ui/BrandedButton.tsx
+++ b/src/components/ui/BrandedButton.tsx
@@ -1,6 +1,13 @@
 import { ButtonHTMLAttributes } from "react";
 import { Button } from "@/components/ui/Button";
-import { Coins, Cable, Wallet, ArrowLeftRight } from "lucide-react";
+import {
+  Coins,
+  Cable,
+  Wallet,
+  ArrowLeftRight,
+  TrendingUp,
+  TrendingDown,
+} from "lucide-react";
 import { AvailableIconName } from "@/types/ui";
 
 interface BrandedButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -23,6 +30,8 @@ export function BrandedButton({
         Cable,
         Wallet,
         ArrowLeftRight,
+        TrendingUp,
+        TrendingDown,
       }[iconName]
     : null;
 

--- a/src/components/ui/lending/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetailsModal.tsx
@@ -16,6 +16,7 @@ import UserInfoTab from "@/components/ui/lending/assetDetails/UserInfoTab";
 import EModeInfoTab from "@/components/ui/lending/assetDetails/EmodeInfoTab";
 import SupplyInfoTab from "@/components/ui/lending/assetDetails/SupplyInfoTab";
 import BorrowInfoTab from "@/components/ui/lending/assetDetails/BorrowInfoTab";
+import BrandedButton from "@/components/ui/BrandedButton";
 
 interface AssetDetailsModalProps {
   market: UnifiedMarketData;
@@ -34,9 +35,6 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
 }) => {
   const [activeTab, setActiveTab] = useState<TabType>("user");
 
-  // we will eventually do something with the onSupply and onBorrow functions
-  console.log(onSupply, onBorrow); // just log them for now to silence linting warnings
-
   // Calculate APYs with incentives
   const {
     finalSupplyAPY,
@@ -54,106 +52,155 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
     if (value) setActiveTab(value);
   };
 
+  const handleSupply = () => {
+    onSupply(market);
+  };
+
+  const handleBorrow = () => {
+    onBorrow(market);
+  };
+
   return (
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto bg-[#18181B] border border-[#27272A] text-white">
-        <DialogHeader className="border-b border-[#27272A] pb-4">
-          <div className="flex items-start gap-3">
-            <div className="w-12 h-12 rounded-full overflow-hidden flex items-center justify-center flex-shrink-0">
-              <Image
-                src={market.underlyingToken.imageUrl}
-                alt={market.underlyingToken.symbol}
-                width={48}
-                height={48}
-                className="object-contain"
-                onError={(e) => {
-                  e.currentTarget.src = "/images/tokens/default.svg";
-                }}
-              />
-            </div>
-            <div className="flex-1 min-w-0">
-              <DialogTitle className="text-lg font-semibold text-[#FAFAFA] flex items-center gap-2">
-                {market.underlyingToken.name}
-                <span className="text-[#A1A1AA] text-sm font-normal">
-                  ({market.underlyingToken.symbol})
-                </span>
-              </DialogTitle>
-              <div className="text-[#A1A1AA] text-sm flex items-center gap-2 mt-1">
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-hidden bg-[#18181B] border border-[#27272A] text-white flex flex-col">
+        <DialogHeader className="border-b border-[#27272A] pb-4 flex-shrink-0">
+          <div className="flex items-start gap-4">
+            {/* Asset info - buttons removed from header */}
+            <div className="flex items-start gap-3 flex-1 min-w-0">
+              <div className="w-12 h-12 rounded-full overflow-hidden flex items-center justify-center flex-shrink-0">
                 <Image
-                  src={market.marketInfo.icon}
-                  alt={market.marketName}
-                  width={16}
-                  height={16}
-                  className="object-contain rounded-full"
+                  src={market.underlyingToken.imageUrl}
+                  alt={market.underlyingToken.symbol}
+                  width={48}
+                  height={48}
+                  className="object-contain"
                   onError={(e) => {
-                    e.currentTarget.src = "/images/markets/default.svg";
+                    e.currentTarget.src = "/images/tokens/default.svg";
                   }}
                 />
-                {market.marketName}
+              </div>
+              <div className="flex-1 min-w-0">
+                <DialogTitle className="text-lg font-semibold text-[#FAFAFA] flex items-center gap-2">
+                  {market.underlyingToken.name}
+                  <span className="text-[#A1A1AA] text-sm font-normal">
+                    ({market.underlyingToken.symbol})
+                  </span>
+                </DialogTitle>
+                <div className="text-[#A1A1AA] text-sm flex items-center gap-2 mt-1">
+                  <Image
+                    src={market.marketInfo.icon}
+                    alt={market.marketName}
+                    width={16}
+                    height={16}
+                    className="object-contain rounded-full"
+                    onError={(e) => {
+                      e.currentTarget.src = "/images/markets/default.svg";
+                    }}
+                  />
+                  {market.marketName}
+                </div>
               </div>
             </div>
           </div>
         </DialogHeader>
 
-        <div className="space-y-4">
-          {/* Tab Navigation */}
-          <ToggleGroup
-            type="single"
-            value={activeTab}
-            onValueChange={handleTabChange}
-            className="justify-start"
-          >
-            <ToggleGroupItem
-              value="user"
-              className="data-[state=on]:bg-amber-500/25 data-[state=on]:text-amber-300 data-[state=on]:border-[#61410B]"
+        {/* Main content area with flex-1 to fill space */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="space-y-4 p-1">
+            {/* Tab Navigation */}
+            <ToggleGroup
+              type="single"
+              value={activeTab}
+              onValueChange={handleTabChange}
+              className="justify-start"
             >
-              your info
-            </ToggleGroupItem>
+              <ToggleGroupItem
+                value="user"
+                className="data-[state=on]:bg-amber-500/25 data-[state=on]:text-amber-300 data-[state=on]:border-[#61410B]"
+              >
+                your info
+              </ToggleGroupItem>
 
-            {/* Mobile: Single asset info tab (hidden on desktop) */}
-            <ToggleGroupItem
-              value="asset"
-              className="md:hidden data-[state=on]:bg-sky-500/25 data-[state=on]:text-sky-300 data-[state=on]:border-sky-800"
-            >
-              asset info
-            </ToggleGroupItem>
+              {/* Mobile: Single asset info tab (hidden on desktop) */}
+              <ToggleGroupItem
+                value="asset"
+                className="md:hidden data-[state=on]:bg-sky-500/25 data-[state=on]:text-sky-300 data-[state=on]:border-sky-800"
+              >
+                asset info
+              </ToggleGroupItem>
 
-            {/* Desktop: Individual tabs (hidden on mobile) */}
-            <ToggleGroupItem
-              value="supply"
-              className="hidden md:flex data-[state=on]:bg-green-500/25 data-[state=on]:text-green-300 data-[state=on]:border-green-800"
-            >
-              supply info
-            </ToggleGroupItem>
-            <ToggleGroupItem
-              value="borrow"
-              className="hidden md:flex data-[state=on]:bg-red-500/25 data-[state=on]:text-red-300 data-[state=on]:border-red-800"
-            >
-              borrow info
-            </ToggleGroupItem>
-            <ToggleGroupItem
-              value="emode"
-              className="hidden md:flex data-[state=on]:bg-purple-500/25 data-[state=on]:text-purple-300 data-[state=on]:border-purple-800"
-            >
-              e-mode info
-            </ToggleGroupItem>
-          </ToggleGroup>
+              {/* Desktop: Individual tabs (hidden on mobile) */}
+              <ToggleGroupItem
+                value="supply"
+                className="hidden md:flex data-[state=on]:bg-green-500/25 data-[state=on]:text-green-300 data-[state=on]:border-green-800"
+              >
+                supply info
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                value="borrow"
+                className="hidden md:flex data-[state=on]:bg-red-500/25 data-[state=on]:text-red-300 data-[state=on]:border-red-800"
+              >
+                borrow info
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                value="emode"
+                className="hidden md:flex data-[state=on]:bg-purple-500/25 data-[state=on]:text-purple-300 data-[state=on]:border-purple-800"
+              >
+                e-mode info
+              </ToggleGroupItem>
+            </ToggleGroup>
 
-          {/* Tab Content */}
-          <div className="min-h-[400px]">
-            {/* User Info - Always available */}
-            {activeTab === "user" && <UserInfoTab market={market} />}
+            {/* Tab Content */}
+            <div className="min-h-[300px]">
+              {/* User Info - Always available */}
+              {activeTab === "user" && <UserInfoTab market={market} />}
 
-            {/* Mobile: Combined asset info (only shows on mobile screens) */}
-            {activeTab === "asset" && (
-              <div className="md:hidden space-y-6 max-h-[500px] overflow-y-auto pr-2">
-                {/* Supply Info Section */}
-                <div className="bg-[#1F1F23] rounded-lg p-4 border border-[#27272A]">
-                  <h3 className="text-green-300 font-medium mb-4 flex items-center gap-2">
-                    <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-                    supply Information
-                  </h3>
+              {/* Mobile: Combined asset info (only shows on mobile screens) */}
+              {activeTab === "asset" && (
+                <div className="md:hidden space-y-6 max-h-[400px] overflow-y-auto pr-2">
+                  {/* Supply Info Section */}
+                  <div className="bg-[#1F1F23] rounded-lg p-4 border border-[#27272A]">
+                    <h3 className="text-green-300 font-medium mb-4 flex items-center gap-2">
+                      <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                      supply Information
+                    </h3>
+                    <SupplyInfoTab
+                      market={market}
+                      finalAPY={finalSupplyAPY}
+                      hasSupplyBonuses={hasSupplyBonuses}
+                      hasMixedIncentives={supplyMixed}
+                    />
+                  </div>
+
+                  {/* Borrow Info Section */}
+                  <div className="bg-[#1F1F23] rounded-lg p-4 border border-[#27272A]">
+                    <h3 className="text-red-300 font-medium mb-4 flex items-center gap-2">
+                      <div className="w-2 h-2 bg-red-500 rounded-full"></div>
+                      borrow information
+                    </h3>
+                    <BorrowInfoTab
+                      market={market}
+                      finalAPY={finalBorrowAPY}
+                      hasBorrowBonuses={hasBorrowBonuses}
+                      hasMixedIncentives={borrowMixed}
+                    />
+                  </div>
+
+                  {/* E-Mode Info Section */}
+                  <div className="bg-[#1F1F23] rounded-lg p-4 border border-[#27272A]">
+                    <h3 className="text-purple-300 font-medium mb-4 flex items-center gap-2">
+                      <div className="w-2 h-2 bg-purple-500 rounded-full"></div>
+                      e-mode information
+                    </h3>
+                    <EModeInfoTab market={market} />
+                  </div>
+                </div>
+              )}
+
+              {/* Desktop: Individual tabs (only show on desktop) */}
+              {activeTab === "supply" && (
+                <div className="hidden md:block">
                   <SupplyInfoTab
                     market={market}
                     finalAPY={finalSupplyAPY}
@@ -161,13 +208,9 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                     hasMixedIncentives={supplyMixed}
                   />
                 </div>
-
-                {/* Borrow Info Section */}
-                <div className="bg-[#1F1F23] rounded-lg p-4 border border-[#27272A]">
-                  <h3 className="text-red-300 font-medium mb-4 flex items-center gap-2">
-                    <div className="w-2 h-2 bg-red-500 rounded-full"></div>
-                    borrow information
-                  </h3>
+              )}
+              {activeTab === "borrow" && (
+                <div className="hidden md:block">
                   <BorrowInfoTab
                     market={market}
                     finalAPY={finalBorrowAPY}
@@ -175,44 +218,33 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                     hasMixedIncentives={borrowMixed}
                   />
                 </div>
-
-                {/* E-Mode Info Section */}
-                <div className="bg-[#1F1F23] rounded-lg p-4 border border-[#27272A]">
-                  <h3 className="text-purple-300 font-medium mb-4 flex items-center gap-2">
-                    <div className="w-2 h-2 bg-purple-500 rounded-full"></div>
-                    e-mode information
-                  </h3>
+              )}
+              {activeTab === "emode" && (
+                <div className="hidden md:block">
                   <EModeInfoTab market={market} />
                 </div>
-              </div>
-            )}
+              )}
+            </div>
+          </div>
+        </div>
 
-            {/* Desktop: Individual tabs (only show on desktop) */}
-            {activeTab === "supply" && (
-              <div className="hidden md:block">
-                <SupplyInfoTab
-                  market={market}
-                  finalAPY={finalSupplyAPY}
-                  hasSupplyBonuses={hasSupplyBonuses}
-                  hasMixedIncentives={supplyMixed}
-                />
-              </div>
-            )}
-            {activeTab === "borrow" && (
-              <div className="hidden md:block">
-                <BorrowInfoTab
-                  market={market}
-                  finalAPY={finalBorrowAPY}
-                  hasBorrowBonuses={hasBorrowBonuses}
-                  hasMixedIncentives={borrowMixed}
-                />
-              </div>
-            )}
-            {activeTab === "emode" && (
-              <div className="hidden md:block">
-                <EModeInfoTab market={market} />
-              </div>
-            )}
+        {/* Footer with CTA buttons */}
+        <div className="bg-[#18181B] flex-shrink-0 px-1">
+          <div className="flex gap-3 w-full">
+            <BrandedButton
+              iconName="TrendingUp"
+              buttonText="supply"
+              onClick={handleSupply}
+              className="flex-1 justify-center bg-green-500/20 hover:bg-green-500/30 hover:text-green-200 text-green-300 border-green-700/50 hover:border-green-600 transition-all duration-200 py-3 font-medium"
+              iconClassName="h-4 w-4"
+            />
+            <BrandedButton
+              iconName="TrendingDown"
+              buttonText="borrow"
+              onClick={handleBorrow}
+              className="flex-1 justify-center bg-red-500/20 hover:bg-red-500/30 hover:text-red-400 text-red-400 border-red-500/50 hover:border-red-500 transition-all duration-200 font-medium"
+              iconClassName="h-4 w-4"
+            />
           </div>
         </div>
       </DialogContent>

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,6 +1,12 @@
 export type Tab = "swap" | "earn" | "lending" | "dashboard";
 export type Theme = "light" | "dark";
-export type AvailableIconName = "Coins" | "Cable" | "Wallet" | "ArrowLeftRight";
+export type AvailableIconName =
+  | "Coins"
+  | "Cable"
+  | "Wallet"
+  | "ArrowLeftRight"
+  | "TrendingUp"
+  | "TrendingDown";
 export interface FormattedNumberParts {
   hasSubscript: boolean;
   subscriptCount: number;


### PR DESCRIPTION
this PR adds the supply and borrow CTA buttons in the `AssetDetailsModal`. The buttons will live in a footer at the bottom of the modal which is standard for a CTA.

Currently the buttons are just normal branded buttons, however they should open another modal for the swap/deposit interaction once fully integrated.

## Screenshots
### Desktop
<img width="3114" height="2036" alt="Screenshot 2025-09-02 at 8 41 15 pm" src="https://github.com/user-attachments/assets/17ee0fd7-4855-47f7-b3ba-07103ae8893d" />

### Tablet
<img width="1468" height="1962" alt="Screenshot 2025-09-02 at 8 41 28 pm" src="https://github.com/user-attachments/assets/7edde966-a885-4d6e-a3e2-9065d1ad6c38" />

### Mobile
<img width="858" height="1866" alt="Screenshot 2025-09-02 at 8 41 38 pm" src="https://github.com/user-attachments/assets/0483fad7-5349-4292-8102-986970bfda19" />
