### PR TITLE
refactor: moved token transfer interfaces to export from types/web3

### DIFF
--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -1,6 +1,7 @@
 // types/web3.ts
 
 import { Transaction, VersionedTransaction } from "@solana/web3.js";
+import { Quote } from "@mayanfinance/swap-sdk";
 
 export interface WalletInfo {
   type: WalletType; // Static Enum to type/identify the wallet
@@ -495,4 +496,68 @@ export interface WalletFilterProps {
   selectedWallet: WalletFilterType;
   onWalletChange: (wallet: WalletFilterType) => void;
   className?: string;
+}
+
+export interface TokenTransferOptions {
+  type:
+    | "vanilla"
+    | "earn/etherFi"
+    | "earn/aave"
+    | "earn/pendle"
+    | "lending/aave";
+  pauseQuoting?: boolean;
+  enableTracking?: boolean;
+  trackingOptions?: SwapTrackingOptions;
+  onSuccess?: (
+    amount: string,
+    sourceToken: Token,
+    destinationToken?: Token,
+  ) => void;
+  onError?: (error: string) => void;
+  onSwapInitiated?: (swapId: string) => void;
+  onTrackingComplete?: (status: SwapStatus) => void;
+  sourceChain: Chain;
+  destinationChain: Chain;
+  sourceToken?: Token | null;
+  destinationToken?: Token | null;
+  transactionDetails: {
+    slippage: "auto" | string;
+    receiveAddress: string | null;
+    gasDrop: number;
+  };
+}
+
+export interface TokenTransferState {
+  amount: string;
+  setAmount: (amount: string) => void;
+  handleAmountChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+
+  isProcessing: boolean;
+
+  isValid: boolean;
+  isButtonDisabled: boolean;
+
+  isWalletCompatible: boolean;
+  quoteData: Quote[] | null;
+  receiveAmount: string;
+  isLoadingQuote: boolean;
+
+  estimatedTimeSeconds: number | null;
+
+  protocolFeeBps: number | null;
+  protocolFeeUsd: number | null;
+  relayerFeeUsd: number | null;
+  totalFeeUsd: number | null;
+
+  swapId: string | null;
+  swapStatus: SwapStatus | null;
+  isTracking: boolean;
+  trackingError: Error | null;
+
+  swapAmounts: () => Promise<void>;
+  handleTransfer: () => Promise<string | void>;
+}
+
+export interface ExtendedQuote extends Quote {
+  toTokenPrice?: number;
 }

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -1,6 +1,6 @@
 // utils/walletMethods.ts
 
-import { WalletInfo, WalletType, Token, Chain } from "@/types/web3";
+import { WalletInfo, WalletType, Chain } from "@/types/web3";
 import useWeb3Store from "@/store/web3Store";
 import { useState, useEffect, useRef, useCallback } from "react";
 import {
@@ -24,8 +24,11 @@ import { useSwapTracking } from "@/hooks/swap/useSwapTracking";
 import { useReownWalletProviderAndSigner } from "@/hooks/useReownWalletProviderAndSigner";
 import { Connection } from "@solana/web3.js";
 import { useWallet } from "@suiet/wallet-kit"; // Import Suiet hook
-import { SwapStatus } from "@/types/web3";
-import { SwapTrackingOptions } from "@/types/web3";
+import {
+  TokenTransferOptions,
+  TokenTransferState,
+  ExtendedQuote,
+} from "@/types/web3";
 import { recordSwap } from "@/utils/swap/swapRecorder";
 import { SwapMetricsRequest } from "@/utils/swap/swapRecorder";
 import {
@@ -604,74 +607,6 @@ export function ensureCorrectWalletTypeForChain(sourceChain: Chain): boolean {
     `No connected ${neededWalletType} wallet available for ${sourceChain.name}`,
   );
   return false;
-}
-
-interface TokenTransferOptions {
-  type:
-    | "vanilla"
-    | "earn/etherFi"
-    | "earn/aave"
-    | "earn/pendle"
-    | "lending/aave";
-  pauseQuoting?: boolean;
-  enableTracking?: boolean; // New option to enable automatic tracking
-  trackingOptions?: SwapTrackingOptions; // Pass through tracking configuration
-  onSuccess?: (
-    amount: string,
-    sourceToken: Token,
-    destinationToken?: Token,
-  ) => void;
-  onError?: (error: string) => void;
-  onSwapInitiated?: (swapId: string) => void; // New callback when swap starts
-  onTrackingComplete?: (status: SwapStatus) => void; // New callback when tracking completes
-  sourceChain: Chain;
-  destinationChain: Chain;
-  sourceToken?: Token | null;
-  destinationToken?: Token | null;
-  transactionDetails: {
-    slippage: "auto" | string;
-    receiveAddress: string | null;
-    gasDrop: number;
-  };
-}
-
-interface TokenTransferState {
-  // Input state
-  amount: string;
-  setAmount: (amount: string) => void;
-  handleAmountChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-
-  isProcessing: boolean;
-
-  isValid: boolean;
-  isButtonDisabled: boolean;
-
-  isWalletCompatible: boolean;
-  quoteData: Quote[] | null;
-  receiveAmount: string;
-  isLoadingQuote: boolean;
-
-  // Add estimated time in seconds from the quote
-  estimatedTimeSeconds: number | null;
-
-  // Add fee information
-  protocolFeeBps: number | null;
-  protocolFeeUsd: number | null;
-  relayerFeeUsd: number | null;
-  totalFeeUsd: number | null;
-
-  swapId: string | null;
-  swapStatus: SwapStatus | null;
-  isTracking: boolean;
-  trackingError: Error | null;
-
-  swapAmounts: () => Promise<void>;
-  handleTransfer: () => Promise<string | void>;
-}
-
-// I had to include this as it appears the Mayan SDK is outdated
-interface ExtendedQuote extends Quote {
-  toTokenPrice?: number;
 }
 
 /**


### PR DESCRIPTION
this PR moves the definitions for the token transfer interfaces to `types/web3.ts` and exports them such that they can be used by components which use the `useTokenTransfer` hook, without having to individually define all the props.
