### PR TITLE
feat: added asset details modal to open position cards

### DIFF
--- a/src/components/ui/lending/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetailsModal.tsx
@@ -10,7 +10,11 @@ import {
 } from "@/components/ui/StyledDialog";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 import Image from "next/image";
-import { UnifiedMarketData } from "@/types/aave";
+import {
+  UnifiedMarketData,
+  UserBorrowPosition,
+  UserSupplyPosition,
+} from "@/types/aave";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import UserInfoTab from "@/components/ui/lending/assetDetails/UserInfoTab";
 import EModeInfoTab from "@/components/ui/lending/assetDetails/EmodeInfoTab";
@@ -23,6 +27,8 @@ interface AssetDetailsModalProps {
   children: React.ReactNode;
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
+  onRepay?: (market: UserBorrowPosition) => void;
+  onWithdraw?: (market: UserSupplyPosition) => void;
 }
 
 type TabType = "user" | "supply" | "borrow" | "emode" | "asset";

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -354,11 +354,15 @@ function DashboardContentInner({
           )
         ) : // Show open positions
         isSupplyMode ? (
-          <UserSupplyContent marketSupplyData={marketSupplyData} />
+          <UserSupplyContent
+            marketSupplyData={marketSupplyData}
+            activeMarkets={activeMarkets}
+          />
         ) : (
           <UserBorrowContent
             marketBorrowData={marketBorrowData}
             showZeroBalance={showZeroBalance}
+            activeMarkets={activeMarkets}
           />
         )}
       </div>

--- a/src/components/ui/lending/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserBorrowCard.tsx
@@ -12,16 +12,21 @@ import {
 import BrandedButton from "@/components/ui/BrandedButton";
 import Image from "next/image";
 import { formatCurrency, formatPercentage } from "@/utils/formatters";
-import { UserBorrowPosition } from "@/types/aave";
+import { UnifiedMarketData, UserBorrowPosition } from "@/types/aave";
+import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
 
 interface UserBorrowCardProps {
   position: UserBorrowPosition;
-  onBorrow?: (position: UserBorrowPosition) => void;
+  unifiedMarket: UnifiedMarketData;
+  onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
   onRepay?: (position: UserBorrowPosition) => void;
 }
 
 const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
   position,
+  unifiedMarket,
+  onSupply,
   onBorrow,
   onRepay,
 }) => {
@@ -87,15 +92,18 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
       </CardContent>
 
       <CardFooter className="flex gap-2 p-4 pt-0">
-        <BrandedButton
-          buttonText="details"
-          onClick={() => {
-            //placeholder, we would be passing in these functions as props to the modal
-            console.log(onBorrow, onRepay);
-          }}
-          className="flex-1 text-xs py-2 h-8"
-          disabled={true}
-        />
+        <AssetDetailsModal
+          market={unifiedMarket}
+          onSupply={onSupply}
+          onBorrow={onBorrow}
+          onRepay={onRepay}
+        >
+          <BrandedButton
+            buttonText="details"
+            className="w-full text-xs py-2 h-8"
+            disabled={false}
+          />
+        </AssetDetailsModal>
       </CardFooter>
     </Card>
   );

--- a/src/components/ui/lending/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserSupplyCard.tsx
@@ -13,20 +13,25 @@ import { Switch } from "@/components/ui/Switch";
 import BrandedButton from "@/components/ui/BrandedButton";
 import Image from "next/image";
 import { formatCurrency, formatPercentage } from "@/utils/formatters";
-import { UserSupplyPosition } from "@/types/aave";
+import { UserSupplyPosition, UnifiedMarketData } from "@/types/aave";
 import { Shield, ShieldOff } from "lucide-react";
+import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
 import * as Tooltip from "@radix-ui/react-tooltip";
 
 interface UserSupplyCardProps {
   position: UserSupplyPosition;
-  onSupply?: (position: UserSupplyPosition) => void;
-  onWithdraw?: (position: UserSupplyPosition) => void;
+  unifiedMarket: UnifiedMarketData;
+  onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
+  onWithdraw: (position: UserSupplyPosition) => void;
   onToggleCollateral?: (position: UserSupplyPosition) => void;
 }
 
 const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
   position,
+  unifiedMarket,
   onSupply,
+  onBorrow,
   onWithdraw,
   onToggleCollateral,
 }) => {
@@ -135,15 +140,18 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
       </CardContent>
 
       <CardFooter className="flex gap-2 p-4 pt-0">
-        <BrandedButton
-          buttonText="details"
-          onClick={() => {
-            //placeholder, we would be passing in these functions as props to the modal
-            console.log(onSupply, onWithdraw, onToggleCollateral);
-          }}
-          className="flex-1 text-xs py-2 h-8"
-          disabled={true}
-        />
+        <AssetDetailsModal
+          market={unifiedMarket}
+          onSupply={onSupply}
+          onBorrow={onBorrow}
+          onWithdraw={onWithdraw}
+        >
+          <BrandedButton
+            buttonText="details"
+            className="w-full text-xs py-2 h-8"
+            disabled={false}
+          />
+        </AssetDetailsModal>
       </CardFooter>
     </Card>
   );


### PR DESCRIPTION
this PR adds the `AssetDetailsModal` to be available from the details button on open supply and borrow cards.

the only struggle with this integration was that the `UserSupplyContent` and `UserBorrowContent` were only passed `UserBorrowPosition` and `UserSupplyPosition` props, not the markets (to create the unified markets, which need to be there to pass the `unifiedMarket` into the `AssetDetailsModal`).

The rest was pretty straightforward.

Please note I have still mocked all the interactions with simple console log statements for now.