### PR TITLE
feat: added asset details to market-cards

### DIFF
--- a/src/components/ui/lending/MarketCard.tsx
+++ b/src/components/ui/lending/MarketCard.tsx
@@ -17,16 +17,29 @@ import {
   formatPercentage,
   formatBalance,
 } from "@/utils/formatters";
-import { UnifiedMarketData } from "@/types/aave";
+import {
+  UnifiedMarketData,
+  UserBorrowPosition,
+  UserSupplyPosition,
+} from "@/types/aave";
 import { SquarePlus, SquareMinus, SquareEqual } from "lucide-react";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
+import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
 
 interface MarketCardProps {
   market: UnifiedMarketData;
+  onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
+  onRepay?: (market: UserBorrowPosition) => void;
+  onWithdraw?: (market: UserSupplyPosition) => void;
   onDetails?: (market: UnifiedMarketData) => void;
 }
 
-const MarketCard: React.FC<MarketCardProps> = ({ market, onDetails }) => {
+const MarketCard: React.FC<MarketCardProps> = ({
+  market,
+  onSupply,
+  onBorrow,
+}) => {
   // Extract data from unified structure
   const baseSupplyAPY = market.supplyData.apy;
   const baseBorrowAPY = market.borrowData.apy;
@@ -163,12 +176,16 @@ const MarketCard: React.FC<MarketCardProps> = ({ market, onDetails }) => {
       </CardContent>
 
       <CardFooter className="flex justify-center p-4 pt-0">
-        <BrandedButton
-          buttonText="details"
-          onClick={() => onDetails?.(market)}
-          className="w-full text-xs py-2 h-8"
-          disabled={true}
-        />
+        <AssetDetailsModal
+          market={market}
+          onSupply={onSupply}
+          onBorrow={onBorrow}
+        >
+          <BrandedButton
+            buttonText="details"
+            className="w-full text-xs py-2 h-8"
+          />
+        </AssetDetailsModal>
       </CardFooter>
     </Card>
   );

--- a/src/components/ui/lending/MarketContent.tsx
+++ b/src/components/ui/lending/MarketContent.tsx
@@ -3,7 +3,12 @@
 import React, { useState } from "react";
 import MarketCard from "@/components/ui/lending/MarketCard";
 import CardsList from "@/components/ui/CardsList";
-import { Market } from "@/types/aave";
+import {
+  Market,
+  UnifiedMarketData,
+  UserBorrowPosition,
+  UserSupplyPosition,
+} from "@/types/aave";
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
 
 const ITEMS_PER_PAGE = 10;
@@ -43,7 +48,18 @@ const MarketContent: React.FC<MarketContentProps> = ({ markets }) => {
         <MarketCard
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
-          onDetails={() => {}}
+          onSupply={(market: UnifiedMarketData) => {
+            console.log(market); // TODO: update me
+          }}
+          onBorrow={(market: UnifiedMarketData) => {
+            console.log(market); // TODO: update me
+          }}
+          onRepay={(market: UserBorrowPosition) => {
+            console.log(market); // TODO: update me
+          }}
+          onWithdraw={(market: UserSupplyPosition) => {
+            console.log(market); // TODO: update me
+          }}
         />
       )}
       currentPage={currentPage}


### PR DESCRIPTION
this PR adds the `AssetDetailsModal` to the `MarketCard` components. Since these already use the `UnifiedMarketData` type, no mapping was required.