### PR TITLE
feat: use token transfer init in lending

### DIFF
--- a/src/components/ui/lending/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetailsModal.tsx
@@ -21,6 +21,7 @@ import EModeInfoTab from "@/components/ui/lending/assetDetails/EmodeInfoTab";
 import SupplyInfoTab from "@/components/ui/lending/assetDetails/SupplyInfoTab";
 import BorrowInfoTab from "@/components/ui/lending/assetDetails/BorrowInfoTab";
 import BrandedButton from "@/components/ui/BrandedButton";
+import { TokenTransferState } from "@/types/web3";
 
 interface AssetDetailsModalProps {
   market: UnifiedMarketData;
@@ -29,6 +30,7 @@ interface AssetDetailsModalProps {
   onBorrow: (market: UnifiedMarketData) => void;
   onRepay?: (market: UserBorrowPosition) => void;
   onWithdraw?: (market: UserSupplyPosition) => void;
+  tokenTransferState: TokenTransferState;
 }
 
 type TabType = "user" | "supply" | "borrow" | "emode" | "asset";

--- a/src/components/ui/lending/AvailableBorrowCard.tsx
+++ b/src/components/ui/lending/AvailableBorrowCard.tsx
@@ -22,17 +22,20 @@ import { SquareMinus, SquareEqual, AlertTriangle } from "lucide-react";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
 import * as Tooltip from "@radix-ui/react-tooltip";
+import { TokenTransferState } from "@/types/web3";
 
 interface AvailableBorrowCardProps {
   market: UnifiedMarketData;
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
+  tokenTransferState: TokenTransferState;
 }
 
 const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
   market,
   onSupply,
   onBorrow,
+  tokenTransferState,
 }) => {
   // Extract borrow data
   const baseBorrowAPY = market.borrowData.apy;
@@ -170,6 +173,7 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
           market={market}
           onSupply={onSupply}
           onBorrow={onBorrow}
+          tokenTransferState={tokenTransferState}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/AvailableBorrowContent.tsx
+++ b/src/components/ui/lending/AvailableBorrowContent.tsx
@@ -5,15 +5,18 @@ import AvailableBorrowCard from "@/components/ui/lending/AvailableBorrowCard";
 import CardsList from "@/components/ui/CardsList";
 import { Market, UnifiedMarketData } from "@/types/aave";
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
+import { TokenTransferState } from "@/types/web3";
 
 interface AvailableBorrowContentProps {
   markets: Market[] | null | undefined;
+  tokenTransferState: TokenTransferState;
 }
 
 const ITEMS_PER_PAGE = 10;
 
 const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
   markets,
+  tokenTransferState,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -70,6 +73,7 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
             // TODO: Implement borrow modal/flow
             console.log("Borrow clicked for:", market.underlyingToken.symbol);
           }}
+          tokenTransferState={tokenTransferState}
         />
       )}
       currentPage={currentPage}

--- a/src/components/ui/lending/AvailableSupplyCard.tsx
+++ b/src/components/ui/lending/AvailableSupplyCard.tsx
@@ -21,17 +21,20 @@ import { UnifiedMarketData } from "@/types/aave";
 import { SquarePlus, SquareEqual, AlertTriangle } from "lucide-react";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
+import { TokenTransferState } from "@/types/web3";
 
 interface AvailableSupplyCardProps {
   market: UnifiedMarketData;
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
+  tokenTransferState: TokenTransferState;
 }
 
 const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
   market,
   onSupply,
   onBorrow,
+  tokenTransferState,
 }) => {
   // Extract supply data
   const baseSupplyAPY = market.supplyData.apy;
@@ -149,6 +152,7 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
           market={market}
           onSupply={onSupply}
           onBorrow={onBorrow}
+          tokenTransferState={tokenTransferState}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/AvailableSupplyContent.tsx
+++ b/src/components/ui/lending/AvailableSupplyContent.tsx
@@ -5,10 +5,12 @@ import AvailableSupplyCard from "@/components/ui/lending/AvailableSupplyCard";
 import CardsList from "@/components/ui/CardsList";
 import { Market, UnifiedMarketData } from "@/types/aave";
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
+import { TokenTransferState } from "@/types/web3";
 
 interface AvailableSupplyContentProps {
   markets: Market[] | null | undefined;
   showZeroBalance?: boolean;
+  tokenTransferState: TokenTransferState;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -16,6 +18,7 @@ const ITEMS_PER_PAGE = 10;
 const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
   markets,
   showZeroBalance = false,
+  tokenTransferState,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -78,6 +81,7 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
             // TODO: Implement borrow modal/flow
             console.log("Borrow clicked for:", market.underlyingToken.symbol);
           }}
+          tokenTransferState={tokenTransferState}
         />
       )}
       currentPage={currentPage}

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -21,16 +21,19 @@ import UserBorrowContent from "@/components/ui/lending/UserBorrowContent";
 import AvailableSupplyContent from "@/components/ui/lending/AvailableSupplyContent";
 import AvailableBorrowContent from "@/components/ui/lending/AvailableBorrowContent";
 import RiskDetailsModal from "@/components/ui/lending/RiskDetailsModal";
+import { TokenTransferState } from "@/types/web3";
 
 interface DashboardContentProps {
   userAddress?: string;
   selectedChains: Chain[];
   activeMarkets: Market[];
+  tokenTransferState: TokenTransferState;
 }
 
 export default function DashboardContent({
   userAddress,
   activeMarkets,
+  tokenTransferState,
 }: DashboardContentProps) {
   if (!userAddress) {
     return (
@@ -88,6 +91,7 @@ export default function DashboardContent({
                     marketRiskData={marketRiskData}
                     loading={loading || supplyLoading || borrowLoading}
                     error={error || supplyError || borrowError}
+                    tokenTransferState={tokenTransferState}
                   />
                 );
               }}
@@ -145,6 +149,7 @@ interface DashboardContentInnerProps {
   activeMarkets: Market[];
   loading: boolean;
   error: boolean;
+  tokenTransferState: TokenTransferState;
 }
 
 function DashboardContentInner({
@@ -160,6 +165,7 @@ function DashboardContentInner({
   activeMarkets,
   loading,
   error,
+  tokenTransferState,
 }: DashboardContentInnerProps) {
   const [isSupplyMode, setIsSupplyMode] = useState(true);
   const [showAvailable, setShowAvailable] = useState(true);
@@ -365,21 +371,27 @@ function DashboardContentInner({
             <AvailableSupplyContent
               markets={activeMarkets}
               showZeroBalance={showZeroBalance}
+              tokenTransferState={tokenTransferState}
             />
           ) : (
-            <AvailableBorrowContent markets={activeMarkets} />
+            <AvailableBorrowContent
+              markets={activeMarkets}
+              tokenTransferState={tokenTransferState}
+            />
           )
         ) : // Show open positions
         isSupplyMode ? (
           <UserSupplyContent
             marketSupplyData={marketSupplyData}
             activeMarkets={activeMarkets}
+            tokenTransferState={tokenTransferState}
           />
         ) : (
           <UserBorrowContent
             marketBorrowData={marketBorrowData}
             showZeroBalance={showZeroBalance}
             activeMarkets={activeMarkets}
+            tokenTransferState={tokenTransferState}
           />
         )}
       </div>

--- a/src/components/ui/lending/MarketCard.tsx
+++ b/src/components/ui/lending/MarketCard.tsx
@@ -25,6 +25,7 @@ import {
 import { SquarePlus, SquareMinus, SquareEqual } from "lucide-react";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
+import { TokenTransferState } from "@/types/web3";
 
 interface MarketCardProps {
   market: UnifiedMarketData;
@@ -33,12 +34,14 @@ interface MarketCardProps {
   onRepay?: (market: UserBorrowPosition) => void;
   onWithdraw?: (market: UserSupplyPosition) => void;
   onDetails?: (market: UnifiedMarketData) => void;
+  tokenTransferState: TokenTransferState;
 }
 
 const MarketCard: React.FC<MarketCardProps> = ({
   market,
   onSupply,
   onBorrow,
+  tokenTransferState,
 }) => {
   // Extract data from unified structure
   const baseSupplyAPY = market.supplyData.apy;
@@ -180,6 +183,7 @@ const MarketCard: React.FC<MarketCardProps> = ({
           market={market}
           onSupply={onSupply}
           onBorrow={onBorrow}
+          tokenTransferState={tokenTransferState}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/MarketContent.tsx
+++ b/src/components/ui/lending/MarketContent.tsx
@@ -10,14 +10,19 @@ import {
   UserSupplyPosition,
 } from "@/types/aave";
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
+import { TokenTransferState } from "@/types/web3";
 
 const ITEMS_PER_PAGE = 10;
 
 interface MarketContentProps {
   markets: Market[] | null | undefined;
+  tokenTransferState: TokenTransferState;
 }
 
-const MarketContent: React.FC<MarketContentProps> = ({ markets }) => {
+const MarketContent: React.FC<MarketContentProps> = ({
+  markets,
+  tokenTransferState,
+}) => {
   const [currentPage, setCurrentPage] = useState(1);
 
   if (!markets || markets.length === 0) {
@@ -60,6 +65,7 @@ const MarketContent: React.FC<MarketContentProps> = ({ markets }) => {
           onWithdraw={(market: UserSupplyPosition) => {
             console.log(market); // TODO: update me
           }}
+          tokenTransferState={tokenTransferState}
         />
       )}
       currentPage={currentPage}

--- a/src/components/ui/lending/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserBorrowCard.tsx
@@ -14,6 +14,7 @@ import Image from "next/image";
 import { formatCurrency, formatPercentage } from "@/utils/formatters";
 import { UnifiedMarketData, UserBorrowPosition } from "@/types/aave";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
+import { TokenTransferState } from "@/types/web3";
 
 interface UserBorrowCardProps {
   position: UserBorrowPosition;
@@ -21,6 +22,7 @@ interface UserBorrowCardProps {
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
   onRepay?: (position: UserBorrowPosition) => void;
+  tokenTransferState: TokenTransferState;
 }
 
 const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
@@ -29,6 +31,7 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
   onSupply,
   onBorrow,
   onRepay,
+  tokenTransferState,
 }) => {
   const { borrow, marketName } = position;
   const balanceUsd = parseFloat(borrow.debt.usd) || 0;
@@ -97,6 +100,7 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
           onSupply={onSupply}
           onBorrow={onBorrow}
           onRepay={onRepay}
+          tokenTransferState={tokenTransferState}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/UserBorrowContent.tsx
+++ b/src/components/ui/lending/UserBorrowContent.tsx
@@ -9,11 +9,13 @@ import {
   UnifiedMarketData,
 } from "@/types/aave";
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
+import { TokenTransferState } from "@/types/web3";
 
 interface UserBorrowContentProps {
   marketBorrowData: Record<string, UserBorrowData>;
-  activeMarkets: Market[]; // Add this prop
+  activeMarkets: Market[];
   showZeroBalance?: boolean;
+  tokenTransferState: TokenTransferState;
 }
 
 interface EnhancedUserBorrowPosition extends UserBorrowPosition {
@@ -26,6 +28,7 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
   marketBorrowData,
   activeMarkets,
   showZeroBalance = false,
+  tokenTransferState,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -108,6 +111,7 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
           onRepay={(position: UserBorrowPosition) => {
             console.log(position); // TODO: update me
           }}
+          tokenTransferState={tokenTransferState}
         />
       )}
       currentPage={currentPage}

--- a/src/components/ui/lending/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserSupplyCard.tsx
@@ -17,6 +17,7 @@ import { UserSupplyPosition, UnifiedMarketData } from "@/types/aave";
 import { Shield, ShieldOff } from "lucide-react";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
 import * as Tooltip from "@radix-ui/react-tooltip";
+import { TokenTransferState } from "@/types/web3";
 
 interface UserSupplyCardProps {
   position: UserSupplyPosition;
@@ -25,6 +26,7 @@ interface UserSupplyCardProps {
   onBorrow: (market: UnifiedMarketData) => void;
   onWithdraw: (position: UserSupplyPosition) => void;
   onToggleCollateral?: (position: UserSupplyPosition) => void;
+  tokenTransferState: TokenTransferState;
 }
 
 const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
@@ -34,6 +36,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
   onBorrow,
   onWithdraw,
   onToggleCollateral,
+  tokenTransferState,
 }) => {
   const { supply, marketName } = position;
   const balanceUsd = parseFloat(supply.balance.usd) || 0;
@@ -145,6 +148,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
           onSupply={onSupply}
           onBorrow={onBorrow}
           onWithdraw={onWithdraw}
+          tokenTransferState={tokenTransferState}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserSupplyContent.tsx
@@ -10,10 +10,12 @@ import {
   UnifiedMarketData,
 } from "@/types/aave";
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
+import { TokenTransferState } from "@/types/web3";
 
 interface UserSupplyContentProps {
   marketSupplyData: Record<string, UserSupplyData>;
   activeMarkets: Market[];
+  tokenTransferState: TokenTransferState;
 }
 
 interface EnhancedUserSupplyPosition extends UserSupplyPosition {
@@ -25,6 +27,7 @@ const ITEMS_PER_PAGE = 10;
 const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
   marketSupplyData,
   activeMarkets,
+  tokenTransferState,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -105,6 +108,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
           onToggleCollateral={(position: UserSupplyPosition) => {
             console.log(position); // TODO: update me
           }}
+          tokenTransferState={tokenTransferState}
         />
       )}
       currentPage={currentPage}


### PR DESCRIPTION
this PR integrates the `useTokenTransfer` hook into the lending `page.tsx` to begin managing the state of swaps and quotes. 

the hook is only defined once at the `page.tsx` level, and the entire `TokenTransferState` is then passed down as a prop until it reaches the `AssetDetailsModal`, where it will eventually be used to show the `TokenInputGroup` component in the asset interact modal (which will be coming in a subsequent PR).