### PR TITLE
feat: lending filter headers

### DIFF
--- a/src/app/(dapp)/earn/page.tsx
+++ b/src/app/(dapp)/earn/page.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useEffect } from "react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 import ProtocolFilter from "@/components/ui/earn/ProtocolFilter";
 import SortDropdown from "@/components/ui/earn/SortDropdown";
-import { Input } from "@/components/ui/Input";
+import AssetFilter from "@/components/ui/AssetFilter";
 import EarnTable from "@/components/ui/earn/EarnTable";
 import CardsList from "@/components/ui/CardsList";
 import EarnCard from "@/components/ui/earn/EarnCard";
@@ -340,11 +340,11 @@ export default function EarnPage() {
                 </div>
               </div>
 
-              <Input
-                placeholder="filter by asset (e.g., ETH, BTC)"
+              <AssetFilter
                 value={filters.assetFilter}
-                onChange={(e) => handleAssetFilterChange(e.target.value)}
-                className="h-8 w-full sm:w-60 border-[#27272A] bg-[#18181B] text-[#FAFAFA] placeholder:text-[#A1A1AA] focus:border-amber-500/80 focus:ring-amber-500/80 focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                onChange={handleAssetFilterChange}
+                placeholder="filter by asset (e.g., ETH, BTC)"
+                className="w-full sm:w-60"
               />
             </div>
           </div>

--- a/src/components/ui/AssetFilter.tsx
+++ b/src/components/ui/AssetFilter.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React from "react";
+import { Input } from "@/components/ui/Input";
+import { cn } from "@/lib/utils";
+
+interface AssetFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+  placeholder?: string;
+  mobilePlaceholder?: string;
+}
+
+const AssetFilter: React.FC<AssetFilterProps> = ({
+  value,
+  onChange,
+  className,
+  placeholder = "filter by asset",
+  mobilePlaceholder,
+}) => {
+  return (
+    <>
+      <Input
+        placeholder={mobilePlaceholder || placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={cn(
+          "h-8 border-[#27272A] bg-[#18181B] text-[#FAFAFA] placeholder:text-[#A1A1AA] focus:border-amber-500/80 focus:ring-amber-500/80 focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:hidden",
+          className,
+        )}
+      />
+      <Input
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={cn(
+          "h-8 border-[#27272A] bg-[#18181B] text-[#FAFAFA] placeholder:text-[#A1A1AA] focus:border-amber-500/80 focus:ring-amber-500/80 focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 hidden sm:block",
+          className,
+        )}
+      />
+    </>
+  );
+};
+
+export default AssetFilter;

--- a/src/components/ui/earn/SortDropdown.tsx
+++ b/src/components/ui/earn/SortDropdown.tsx
@@ -80,7 +80,7 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
-        className="w-32 bg-[#18181B] border-[#27272A]"
+        className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-32 bg-[#18181B] border-[#27272A]"
       >
         {sortOptions.map((option) => (
           <DropdownMenuItem

--- a/src/components/ui/lending/AvailableBorrowContent.tsx
+++ b/src/components/ui/lending/AvailableBorrowContent.tsx
@@ -6,10 +6,13 @@ import CardsList from "@/components/ui/CardsList";
 import { Market, UnifiedMarketData } from "@/types/aave";
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
 import { TokenTransferState } from "@/types/web3";
+import { LendingFilters, LendingSortConfig } from "@/types/lending";
 
 interface AvailableBorrowContentProps {
   markets: Market[] | null | undefined;
   tokenTransferState: TokenTransferState;
+  filters?: LendingFilters;
+  sortConfig?: LendingSortConfig | null;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -17,11 +20,13 @@ const ITEMS_PER_PAGE = 10;
 const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
   markets,
   tokenTransferState,
+  filters,
+  sortConfig,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
   const unifiedMarkets = unifyMarkets(markets!);
-  const availableBorrowMarkets = unifiedMarkets.filter((market) => {
+  let availableBorrowMarkets = unifiedMarkets.filter((market) => {
     // Filter out disabled markets
     return (
       !market.isFrozen &&
@@ -29,6 +34,52 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
       market.borrowInfo?.borrowingState === "ENABLED"
     );
   });
+
+  // Apply asset filter
+  if (filters?.assetFilter) {
+    const filterLower = filters.assetFilter.toLowerCase();
+    availableBorrowMarkets = availableBorrowMarkets.filter((market) => {
+      return (
+        market.underlyingToken.symbol.toLowerCase().includes(filterLower) ||
+        market.underlyingToken.name.toLowerCase().includes(filterLower) ||
+        market.marketName.toLowerCase().includes(filterLower)
+      );
+    });
+  }
+
+  // Apply sorting
+  if (sortConfig) {
+    availableBorrowMarkets = [...availableBorrowMarkets].sort((a, b) => {
+      let aValue: number;
+      let bValue: number;
+
+      switch (sortConfig.column) {
+        case "borrowApy":
+          aValue = a.borrowData.apy;
+          bValue = b.borrowData.apy;
+          break;
+        case "borrowAvailable":
+          // Use available liquidity for borrow available
+          aValue = a.borrowInfo?.availableLiquidity?.usd || 0;
+          bValue = b.borrowInfo?.availableLiquidity?.usd || 0;
+          break;
+        default:
+          // Default sort by borrow APY (ascending - lower is better for borrowing)
+          aValue = a.borrowData.apy;
+          bValue = b.borrowData.apy;
+          break;
+      }
+
+      return sortConfig.direction === "asc" ? aValue - bValue : bValue - aValue;
+    });
+  } else {
+    // Default sort by borrow APY (ascending - lower is better for borrowing)
+    availableBorrowMarkets = [...availableBorrowMarkets].sort((a, b) => {
+      const aBorrowAPY = a.borrowData.apy || 0;
+      const bBorrowAPY = b.borrowData.apy || 0;
+      return aBorrowAPY - bBorrowAPY;
+    });
+  }
 
   if (!markets || markets.length === 0) {
     return (

--- a/src/components/ui/lending/AvailableSupplyContent.tsx
+++ b/src/components/ui/lending/AvailableSupplyContent.tsx
@@ -6,11 +6,14 @@ import CardsList from "@/components/ui/CardsList";
 import { Market, UnifiedMarketData } from "@/types/aave";
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
 import { TokenTransferState } from "@/types/web3";
+import { LendingFilters, LendingSortConfig } from "@/types/lending";
 
 interface AvailableSupplyContentProps {
   markets: Market[] | null | undefined;
   showZeroBalance?: boolean;
   tokenTransferState: TokenTransferState;
+  filters?: LendingFilters;
+  sortConfig?: LendingSortConfig | null;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -19,24 +22,63 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
   markets,
   showZeroBalance = false,
   tokenTransferState,
+  filters,
+  sortConfig,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
   const unifiedMarkets = unifyMarkets(markets!);
-  const availableSupplyMarkets = unifiedMarkets
-    .filter((market) => {
-      if (showZeroBalance) return true;
-      if (!market.userState) return false;
-      const userBalance =
-        parseFloat(market.userState.balance.amount.value) || 0;
-      return userBalance > 0;
-    })
-    .sort((a, b) => {
-      //TODO: change this to custom sorting based on header
+  let availableSupplyMarkets = unifiedMarkets.filter((market) => {
+    if (showZeroBalance) return true;
+    if (!market.userState) return false;
+    const userBalance = parseFloat(market.userState.balance.amount.value) || 0;
+    return userBalance > 0;
+  });
+
+  // Apply asset filter
+  if (filters?.assetFilter) {
+    const filterLower = filters.assetFilter.toLowerCase();
+    availableSupplyMarkets = availableSupplyMarkets.filter((market) => {
+      return (
+        market.underlyingToken.symbol.toLowerCase().includes(filterLower) ||
+        market.underlyingToken.name.toLowerCase().includes(filterLower) ||
+        market.marketName.toLowerCase().includes(filterLower)
+      );
+    });
+  }
+
+  // Apply sorting
+  if (sortConfig) {
+    availableSupplyMarkets = [...availableSupplyMarkets].sort((a, b) => {
+      let aValue: number;
+      let bValue: number;
+
+      switch (sortConfig.column) {
+        case "supplyApy":
+          aValue = a.supplyData.apy;
+          bValue = b.supplyData.apy;
+          break;
+        case "suppliedMarketCap":
+          aValue = a.supplyData.totalSuppliedUsd;
+          bValue = b.supplyData.totalSuppliedUsd;
+          break;
+        default:
+          // Default sort by supply APY (descending)
+          aValue = a.supplyData.apy;
+          bValue = b.supplyData.apy;
+          break;
+      }
+
+      return sortConfig.direction === "asc" ? aValue - bValue : bValue - aValue;
+    });
+  } else {
+    // Default sort by supply APY (descending)
+    availableSupplyMarkets = [...availableSupplyMarkets].sort((a, b) => {
       const aSupplyAPY = a.supplyData.apy || 0;
       const bSupplyAPY = b.supplyData.apy || 0;
       return bSupplyAPY - aSupplyAPY;
     });
+  }
 
   if (!markets || markets.length === 0) {
     return (

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 import { Info } from "lucide-react";
 import { evmAddress } from "@aave/react";
@@ -22,18 +22,25 @@ import AvailableSupplyContent from "@/components/ui/lending/AvailableSupplyConte
 import AvailableBorrowContent from "@/components/ui/lending/AvailableBorrowContent";
 import RiskDetailsModal from "@/components/ui/lending/RiskDetailsModal";
 import { TokenTransferState } from "@/types/web3";
+import { LendingFilters, LendingSortConfig } from "@/types/lending";
 
 interface DashboardContentProps {
   userAddress?: string;
   selectedChains: Chain[];
   activeMarkets: Market[];
   tokenTransferState: TokenTransferState;
+  filters?: LendingFilters;
+  sortConfig?: LendingSortConfig | null;
+  onSubsectionChange?: (subsection: string) => void;
 }
 
 export default function DashboardContent({
   userAddress,
   activeMarkets,
   tokenTransferState,
+  filters,
+  sortConfig,
+  onSubsectionChange,
 }: DashboardContentProps) {
   if (!userAddress) {
     return (
@@ -92,6 +99,9 @@ export default function DashboardContent({
                     loading={loading || supplyLoading || borrowLoading}
                     error={error || supplyError || borrowError}
                     tokenTransferState={tokenTransferState}
+                    filters={filters}
+                    sortConfig={sortConfig}
+                    onSubsectionChange={onSubsectionChange}
                   />
                 );
               }}
@@ -150,6 +160,9 @@ interface DashboardContentInnerProps {
   loading: boolean;
   error: boolean;
   tokenTransferState: TokenTransferState;
+  filters?: LendingFilters;
+  sortConfig?: LendingSortConfig | null;
+  onSubsectionChange?: (subsection: string) => void;
 }
 
 function DashboardContentInner({
@@ -166,11 +179,28 @@ function DashboardContentInner({
   loading,
   error,
   tokenTransferState,
+  filters,
+  sortConfig,
+  onSubsectionChange,
 }: DashboardContentInnerProps) {
   const [isSupplyMode, setIsSupplyMode] = useState(true);
   const [showAvailable, setShowAvailable] = useState(true);
   const [showZeroBalance, setShowZeroBalance] = useState(false);
   const [isRiskDetailsModalOpen, setIsRiskDetailsModalOpen] = useState(false);
+
+  // Notify parent of subsection changes
+  useEffect(() => {
+    if (onSubsectionChange) {
+      const currentSubsection = showAvailable
+        ? isSupplyMode
+          ? "supply-available"
+          : "borrow-available"
+        : isSupplyMode
+          ? "supply-open"
+          : "borrow-open";
+      onSubsectionChange(currentSubsection);
+    }
+  }, [isSupplyMode, showAvailable, onSubsectionChange]);
 
   // Show loading state if any market is still loading
   if (loading) {
@@ -372,11 +402,15 @@ function DashboardContentInner({
               markets={activeMarkets}
               showZeroBalance={showZeroBalance}
               tokenTransferState={tokenTransferState}
+              filters={filters}
+              sortConfig={sortConfig}
             />
           ) : (
             <AvailableBorrowContent
               markets={activeMarkets}
               tokenTransferState={tokenTransferState}
+              filters={filters}
+              sortConfig={sortConfig}
             />
           )
         ) : // Show open positions
@@ -385,6 +419,8 @@ function DashboardContentInner({
             marketSupplyData={marketSupplyData}
             activeMarkets={activeMarkets}
             tokenTransferState={tokenTransferState}
+            filters={filters}
+            sortConfig={sortConfig}
           />
         ) : (
           <UserBorrowContent
@@ -392,6 +428,8 @@ function DashboardContentInner({
             showZeroBalance={showZeroBalance}
             activeMarkets={activeMarkets}
             tokenTransferState={tokenTransferState}
+            filters={filters}
+            sortConfig={sortConfig}
           />
         )}
       </div>

--- a/src/components/ui/lending/MarketContent.tsx
+++ b/src/components/ui/lending/MarketContent.tsx
@@ -4,36 +4,32 @@ import React, { useState } from "react";
 import MarketCard from "@/components/ui/lending/MarketCard";
 import CardsList from "@/components/ui/CardsList";
 import {
-  Market,
   UnifiedMarketData,
   UserBorrowPosition,
   UserSupplyPosition,
 } from "@/types/aave";
-import { unifyMarkets } from "@/utils/lending/unifyMarkets";
 import { TokenTransferState } from "@/types/web3";
 
 const ITEMS_PER_PAGE = 10;
 
 interface MarketContentProps {
-  markets: Market[] | null | undefined;
+  unifiedMarkets: UnifiedMarketData[] | null | undefined;
   tokenTransferState: TokenTransferState;
 }
 
 const MarketContent: React.FC<MarketContentProps> = ({
-  markets,
+  unifiedMarkets,
   tokenTransferState,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
-  if (!markets || markets.length === 0) {
+  if (!unifiedMarkets || unifiedMarkets.length === 0) {
     return (
       <div className="text-center py-16">
         <div className="text-[#A1A1AA]">no markets found</div>
       </div>
     );
   }
-
-  const unifiedMarkets = unifyMarkets(markets);
 
   const totalPages = Math.ceil(unifiedMarkets.length / ITEMS_PER_PAGE);
   const paginatedMarkets = unifiedMarkets.slice(

--- a/src/components/ui/lending/SortDropdown.tsx
+++ b/src/components/ui/lending/SortDropdown.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import React from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
+import { Button } from "@/components/ui/Button";
+import { ChevronDownIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface LendingSortOption {
+  label: string;
+  value: string;
+  column: string;
+  direction: "asc" | "desc";
+  applicableTo: string[]; // markets, supply-available, supply-open, borrow-available, borrow-open
+}
+
+interface LendingSortDropdownProps {
+  value?: string;
+  onSortChange: (column: string, direction: "asc" | "desc") => void;
+  activeSection: string; // markets, dashboard etc
+  activeSubSection?: string; // supply-available, supply-open, borrow-available, borrow-open
+  className?: string;
+}
+
+const lendingSortOptions: LendingSortOption[] = [
+  // Supply APY (decreasing) - applies to markets, supply available, supply open
+  {
+    label: "supply APY",
+    value: "supply-apy-desc",
+    column: "supplyApy",
+    direction: "desc",
+    applicableTo: ["markets", "supply-available", "supply-open", "dashboard"],
+  },
+  // Borrow APY (increasing) - applies to markets, borrow available
+  {
+    label: "borrow APY",
+    value: "borrow-apy-asc",
+    column: "borrowApy",
+    direction: "asc",
+    applicableTo: ["markets", "borrow-available", "borrow-open", "dashboard"],
+  },
+  // Supplied Market Cap (USD value)
+  {
+    label: "supplied $",
+    value: "supplied-mc-desc",
+    column: "suppliedMarketCap",
+    direction: "desc",
+    applicableTo: ["markets", "supply-available", "dashboard"],
+  },
+  // Borrowed Market Cap (USD value)
+  {
+    label: "borrowed $",
+    value: "borrowed-mc-desc",
+    column: "borrowedMarketCap",
+    direction: "desc",
+    applicableTo: ["markets", "dashboard"],
+  },
+  // Borrow Available (decreasing)
+  {
+    label: "borr. $ avail.",
+    value: "borrow-available-desc",
+    column: "borrowAvailable",
+    direction: "desc",
+    applicableTo: ["borrow-available", "dashboard"],
+  },
+  // Value Supplied (user's supplied value)
+  {
+    label: "value suppl.",
+    value: "value-supplied-desc",
+    column: "userSuppliedValue",
+    direction: "desc",
+    applicableTo: ["supply-open", "dashboard"],
+  },
+  // Value Borrowed (user's borrowed value)
+  {
+    label: "value borr.",
+    value: "value-borrowed-desc",
+    column: "userBorrowedValue",
+    direction: "desc",
+    applicableTo: ["borrow-open", "dashboard"],
+  },
+];
+
+const LendingSortDropdown: React.FC<LendingSortDropdownProps> = ({
+  value,
+  onSortChange,
+  activeSection,
+  activeSubSection,
+  className,
+}) => {
+  // Filter options based on active section/subsection
+  const availableOptions = lendingSortOptions.filter((option) => {
+    if (activeSubSection) {
+      return option.applicableTo.includes(activeSubSection);
+    }
+    return option.applicableTo.includes(activeSection);
+  });
+
+  const currentSort = value
+    ? availableOptions.find((option) => option.value === value)
+    : null;
+
+  const handleSortSelect = (option: LendingSortOption) => {
+    onSortChange(option.column, option.direction);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            "h-8 border-[#27272A] bg-[#18181B] text-[#FAFAFA] hover:bg-[#27272A] focus:border-amber-500/80 focus:ring-amber-500/80 justify-between",
+            className,
+          )}
+        >
+          <span className="text-sm text-left">
+            {currentSort ? currentSort.label : "sort by"}
+          </span>
+          <ChevronDownIcon className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-32 bg-[#18181B] border-[#27272A]"
+      >
+        {availableOptions.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            onClick={() => handleSortSelect(option)}
+            className="text-[#FAFAFA] hover:bg-[#27272A] cursor-pointer"
+          >
+            <span className="text-sm">{option.label}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default LendingSortDropdown;

--- a/src/components/ui/lending/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserBorrowCard.tsx
@@ -55,7 +55,7 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
-              {borrow.currency.symbol}
+              {unifiedMarket.underlyingToken.name}
             </CardTitle>
           </div>
           <CardDescription className="text-[#A1A1AA] text-xs mt-1 flex items-center gap-1">
@@ -90,6 +90,14 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
           <div className="text-[#A1A1AA] text-sm">APY</div>
           <div className="text-red-500 text-sm font-semibold font-mono">
             {formatPercentage(apy * 100)}
+          </div>
+        </div>
+
+        {/* Ticker */}
+        <div className="flex justify-between items-center">
+          <div className="text-[#A1A1AA] text-sm">ticker</div>
+          <div className="text-[#FAFAFA] text-sm font-semibold font-mono">
+            {borrow.currency.symbol}
           </div>
         </div>
       </CardContent>

--- a/src/components/ui/lending/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserSupplyCard.tsx
@@ -66,7 +66,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
-              {supply.currency.symbol}
+              {unifiedMarket.underlyingToken.name}
             </CardTitle>
             <div className="flex items-center gap-2">
               <Tooltip.Provider>
@@ -125,6 +125,14 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
           <div className="text-[#A1A1AA] text-sm">APY</div>
           <div className="text-green-500 text-sm font-semibold font-mono">
             {formatPercentage(apy * 100)}
+          </div>
+        </div>
+
+        {/* Ticker */}
+        <div className="flex justify-between items-center">
+          <div className="text-[#A1A1AA] text-sm">ticker</div>
+          <div className="text-[#FAFAFA] text-sm font-semibold font-mono">
+            {supply.currency.symbol}
           </div>
         </div>
 

--- a/src/types/lending.ts
+++ b/src/types/lending.ts
@@ -1,0 +1,10 @@
+export interface LendingFilters {
+  sortColumn?: string;
+  sortDirection?: "asc" | "desc";
+  assetFilter: string;
+}
+
+export interface LendingSortConfig {
+  column: string;
+  direction: "asc" | "desc";
+}


### PR DESCRIPTION
This PR is concerned with implementing the filter headers for lending. This includes:

- The dropdown to filter by total supplied capital, supply APY, total borrowed capital, borrow APY, user supplied capital, user borrowed capital, borrow capital available, each available in their appropriate lending section (markets vs. dashboard subsection) as relevant and in ascending/descending order where it logically makes sense (supply APY would be asc. borrow APY would be desc., etc.). 
- The input filter filters cards by asset ticker OR by the underlying token's name.

This feature is completely implemented but the code needs to be cleaned up.

---

Desktop:

<img width="1195" height="816" alt="image" src="https://github.com/user-attachments/assets/a57133c8-fee5-458a-bdf3-48b5753766ab" />
<img width="1193" height="754" alt="image" src="https://github.com/user-attachments/assets/35b556e9-e444-4bcc-851d-291334a35aab" />

Tablet:

<img width="643" height="901" alt="image" src="https://github.com/user-attachments/assets/8590a542-9517-49ab-a205-50c82476455d" />
<img width="638" height="903" alt="image" src="https://github.com/user-attachments/assets/a408d53a-72ff-4c32-8de5-27bffa7a18ed" />

Mobile:

<img width="405" height="688" alt="image" src="https://github.com/user-attachments/assets/a27e7ab9-a592-4066-b317-881567679626" />

---

TODO:

- [x] extract generalized types: e.g. `LendingFilters`, etc. into a single place
- [x] fix the input filter text on mobile (drop the "(e.g. BTC, ETH)")
- [x] apply `AssetFilter` to the "earn" section as well
- [x] [cancelled - there is a reason they are both separate for earn and lending] use `SortDropdown` as a generalized component in lieu of `@/components/ui/lending/LendingSortDropdown`
- [x] patch responsiveness on mobile displayed options relative to dropdown component taking up half the screen, do the same on earn
- [x] supply screenshots for PR