### PR TITLE
chore: added quoteError and increased quote refresh delay

### DIFF
--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -541,6 +541,7 @@ export interface TokenTransferState {
   quoteData: Quote[] | null;
   receiveAmount: string;
   isLoadingQuote: boolean;
+  quoteError: string | null;
 
   estimatedTimeSeconds: number | null;
 

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -632,6 +632,7 @@ export function useTokenTransfer(
   const [protocolFeeUsd, setProtocolFeeUsd] = useState<number | null>(null);
   const [relayerFeeUsd, setRelayerFeeUsd] = useState<number | null>(null);
   const [totalFeeUsd, setTotalFeeUsd] = useState<number | null>(null);
+  const [quoteError, setQuoteError] = useState<string | null>(null);
   const [swapId, setSwapId] = useState<string | null>(null);
   const isTrackingEnabled = options.enableTracking ?? false;
   const [progressToastId, setProgressToastId] = useState<
@@ -1012,6 +1013,7 @@ export function useTokenTransfer(
         }
 
         toast.error(`Error: ${errorMessage}`);
+        setQuoteError(errorMessage);
         failQuote();
       } finally {
         // Only update loading state if this is the latest request
@@ -1058,7 +1060,7 @@ export function useTokenTransfer(
       if (isLoadingQuote || isProcessing) return;
 
       setRefreshTrigger((prev) => prev + 1);
-    }, 5000);
+    }, 10000);
 
     return () => {
       clearInterval(intervalId);
@@ -1353,6 +1355,7 @@ export function useTokenTransfer(
     quoteData,
     receiveAmount,
     isLoadingQuote,
+    quoteError,
 
     // Store state
     estimatedTimeSeconds,


### PR DESCRIPTION
this PR adds `quoteError` to the `TokenTransferState` (the returned by used by `useTokenTransfer`) such that we are able to show quote errors in swap integrations - as well as manage state when there is a quote error.

I have also increased the quote refresh delay to 10s - I find that the quote is not volatile enough to actually change every 5 seconds, and can be a bit visually jarring when a user has their swap amount input pulsing and loading every 5 seconds.