### PR TITLE
feat: added error message display for lending

### DIFF
--- a/src/components/ui/lending/SupplyAssetModal.tsx
+++ b/src/components/ui/lending/SupplyAssetModal.tsx
@@ -81,6 +81,18 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
               <div className="text-sm text-white">transaction preview</div>
             </div>
 
+            {/* Quote Error Display */}
+            {!isDirectSupply &&
+              tokenTransferState.quoteError &&
+              (!tokenTransferState.receiveAmount ||
+                tokenTransferState.receiveAmount === "0") && (
+                <div className="mb-3 p-3 bg-red-500/10 border border-red-500/20 rounded-lg">
+                  <div className="text-sm text-red-400">
+                    {tokenTransferState.quoteError}
+                  </div>
+                </div>
+              )}
+
             <div className="space-y-3">
               {isDirectSupply ? (
                 // Direct supply
@@ -252,7 +264,7 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
                   <Percent className="w-3 h-3 text-[#A1A1AA]" />
                   <span className="text-sm text-[#A1A1AA]">supply APY</span>
                 </div>
-                <div className="text-sm font-semibold text-green-400">
+                <div className="text-sm font-mono font-semibold text-green-400">
                   {formatPercentage(
                     calculateApyWithIncentives(
                       market.supplyData.apy,
@@ -272,7 +284,7 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
                   </span>
                 </div>
                 <div
-                  className={`text-sm font-semibold ${
+                  className={`text-sm font-mono font-semibold ${
                     market.supplyInfo.canBeCollateral
                       ? "text-green-400"
                       : "text-red-400"


### PR DESCRIPTION
this PR adds an error message detail to the supply asset modal when an error occurs during quote fetching.

I have also improved the coverage of error catching, particularly when setting `quoteError` as there were some cases that were previously being missed.

I have also changed the font of the supply details to be consistent with other modals (mono and semibold).

## Screenshots
<img width="1154" height="1696" alt="Screenshot 2025-09-06 at 3 47 42 pm" src="https://github.com/user-attachments/assets/aef46e53-3423-42bf-9435-ce4cc2d591a1" />
<img width="1186" height="1702" alt="Screenshot 2025-09-06 at 3 48 00 pm" src="https://github.com/user-attachments/assets/21efaaad-20f5-4b51-9713-478e1f9076b6" />
