### PR TITLE
feat: supply integration all modals

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -344,6 +344,7 @@ export default function LendingPage() {
                   filters={filters}
                   sortConfig={sortConfig}
                   onSubsectionChange={setCurrentSubsection}
+                  onSupply={handleSupply}
                 />
               )}
               {activeTab === "history" && (

--- a/src/components/ui/lending/AvailableBorrowContent.tsx
+++ b/src/components/ui/lending/AvailableBorrowContent.tsx
@@ -13,6 +13,7 @@ interface AvailableBorrowContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
+  onSupply: (market: UnifiedMarketData) => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -22,6 +23,7 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
+  onSupply,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -116,10 +118,7 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
         <AvailableBorrowCard
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
-          onSupply={(market: UnifiedMarketData) => {
-            // TODO: Implement supply modal/flow
-            console.log("Supply clicked for:", market.underlyingToken.symbol);
-          }}
+          onSupply={onSupply}
           onBorrow={(market: UnifiedMarketData) => {
             // TODO: Implement borrow modal/flow
             console.log("Borrow clicked for:", market.underlyingToken.symbol);

--- a/src/components/ui/lending/AvailableSupplyContent.tsx
+++ b/src/components/ui/lending/AvailableSupplyContent.tsx
@@ -14,6 +14,7 @@ interface AvailableSupplyContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
+  onSupply: (market: UnifiedMarketData) => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -24,6 +25,7 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
+  onSupply,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -115,10 +117,7 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
         <AvailableSupplyCard
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
-          onSupply={(market: UnifiedMarketData) => {
-            // TODO: Implement supply modal/flow
-            console.log("Supply clicked for:", market.underlyingToken.symbol);
-          }}
+          onSupply={onSupply}
           onBorrow={(market: UnifiedMarketData) => {
             // TODO: Implement borrow modal/flow
             console.log("Borrow clicked for:", market.underlyingToken.symbol);

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -11,6 +11,7 @@ import {
   EModeStatus,
   UserSupplyData,
   UserBorrowData,
+  UnifiedMarketData,
 } from "@/types/aave";
 import { AggregatedMarketUserState } from "@/components/ui/lending/AggregatedMarketUserState";
 import { AggregatedMarketUserSupplies } from "@/components/ui/lending/AggregatedMarketUserSupplies";
@@ -32,6 +33,7 @@ interface DashboardContentProps {
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
   onSubsectionChange?: (subsection: string) => void;
+  onSupply: (market: UnifiedMarketData) => void;
 }
 
 export default function DashboardContent({
@@ -41,6 +43,7 @@ export default function DashboardContent({
   filters,
   sortConfig,
   onSubsectionChange,
+  onSupply,
 }: DashboardContentProps) {
   if (!userAddress) {
     return (
@@ -102,6 +105,7 @@ export default function DashboardContent({
                     filters={filters}
                     sortConfig={sortConfig}
                     onSubsectionChange={onSubsectionChange}
+                    onSupply={onSupply}
                   />
                 );
               }}
@@ -163,6 +167,7 @@ interface DashboardContentInnerProps {
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
   onSubsectionChange?: (subsection: string) => void;
+  onSupply: (market: UnifiedMarketData) => void;
 }
 
 function DashboardContentInner({
@@ -182,6 +187,7 @@ function DashboardContentInner({
   filters,
   sortConfig,
   onSubsectionChange,
+  onSupply,
 }: DashboardContentInnerProps) {
   const [isSupplyMode, setIsSupplyMode] = useState(true);
   const [showAvailable, setShowAvailable] = useState(true);
@@ -404,6 +410,7 @@ function DashboardContentInner({
               tokenTransferState={tokenTransferState}
               filters={filters}
               sortConfig={sortConfig}
+              onSupply={onSupply}
             />
           ) : (
             <AvailableBorrowContent
@@ -411,6 +418,7 @@ function DashboardContentInner({
               tokenTransferState={tokenTransferState}
               filters={filters}
               sortConfig={sortConfig}
+              onSupply={onSupply}
             />
           )
         ) : // Show open positions
@@ -421,6 +429,7 @@ function DashboardContentInner({
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
+            onSupply={onSupply}
           />
         ) : (
           <UserBorrowContent
@@ -430,6 +439,7 @@ function DashboardContentInner({
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
+            onSupply={onSupply}
           />
         )}
       </div>

--- a/src/components/ui/lending/UserBorrowContent.tsx
+++ b/src/components/ui/lending/UserBorrowContent.tsx
@@ -19,6 +19,7 @@ interface UserBorrowContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
+  onSupply: (market: UnifiedMarketData) => void;
 }
 
 interface EnhancedUserBorrowPosition extends UserBorrowPosition {
@@ -34,6 +35,7 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
+  onSupply,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -152,9 +154,7 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
           key={`${position.marketAddress}-${position.borrow.currency.symbol}`}
           position={position}
           unifiedMarket={position.unifiedMarket}
-          onSupply={(market: UnifiedMarketData) => {
-            console.log(market); // TODO: update me
-          }}
+          onSupply={onSupply}
           onBorrow={(market: UnifiedMarketData) => {
             console.log(market); // TODO: update me
           }}

--- a/src/components/ui/lending/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserSupplyCard.tsx
@@ -66,7 +66,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
-              {unifiedMarket.underlyingToken.name}
+              {supply.currency.name}
             </CardTitle>
             <div className="flex items-center gap-2">
               <Tooltip.Provider>

--- a/src/components/ui/lending/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserSupplyContent.tsx
@@ -19,6 +19,7 @@ interface UserSupplyContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
+  onSupply: (market: UnifiedMarketData) => void;
 }
 
 interface EnhancedUserSupplyPosition extends UserSupplyPosition {
@@ -33,15 +34,16 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
+  onSupply,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
   const unifiedMarkets = unifyMarkets(activeMarkets);
 
-  // lookup map for unified markets by market address and chain
+  // lookup map for unified markets by currency address and chain
   const unifiedMarketMap = new Map<string, UnifiedMarketData>();
   unifiedMarkets.forEach((market) => {
-    const key = `${market.marketInfo.address}-${market.marketInfo.chain.chainId}`;
+    const key = `${market.underlyingToken.address.toLowerCase()}-${market.marketInfo.chain.chainId}`;
     unifiedMarketMap.set(key, market);
   });
 
@@ -50,8 +52,8 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
   Object.values(marketSupplyData).forEach((marketData) => {
     if (marketData.supplies && marketData.supplies.length > 0) {
       marketData.supplies.forEach((supply) => {
-        const marketKey = `${marketData.marketAddress}-${marketData.chainId}`;
-        const unifiedMarket = unifiedMarketMap.get(marketKey);
+        const currencyKey = `${supply.currency.address.toLowerCase()}-${marketData.chainId}`;
+        const unifiedMarket = unifiedMarketMap.get(currencyKey);
 
         if (unifiedMarket) {
           enhancedPositions.push({
@@ -146,9 +148,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
           key={`${position.marketAddress}-${position.supply.currency.symbol}`}
           position={position}
           unifiedMarket={position.unifiedMarket}
-          onSupply={(market: UnifiedMarketData) => {
-            console.log(market); // TODO: update me
-          }}
+          onSupply={onSupply}
           onBorrow={(market: UnifiedMarketData) => {
             console.log(market); // TODO: update me
           }}


### PR DESCRIPTION
this PR passes through the completed `handleSupply` hook as a prop to all children components which implement the `AssetDetailsModal`.

There was also a bug in which open supply/borrow positions were incorrectly showing the same asset name and details for all the open cards. This has been resolved by getting the `currency.address` as opposed to the `market.address` to retrieve the `unifiedMarket`.