### PR TITLE
feat: disable token select

### DIFF
--- a/src/components/ui/SelectTokenButton.tsx
+++ b/src/components/ui/SelectTokenButton.tsx
@@ -394,12 +394,14 @@ interface SelectTokenButtonProps {
   selectedToken?: Token;
   featuredTokens?: Token[];
   featuredTokensDescription?: string;
+  disableTokenSelect?: boolean;
 }
 
 export const SelectTokenButton: React.FC<SelectTokenButtonProps> = ({
   variant,
   featuredTokens,
   featuredTokensDescription,
+  disableTokenSelect = false,
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery] = useDebounce(searchQuery, 150);
@@ -602,6 +604,10 @@ export const SelectTokenButton: React.FC<SelectTokenButtonProps> = ({
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
+      if (disableTokenSelect) {
+        setIsOpen(false);
+        return;
+      }
       setIsOpen(open);
       if (open) {
         setSearchQuery("");
@@ -609,7 +615,7 @@ export const SelectTokenButton: React.FC<SelectTokenButtonProps> = ({
         lookedUpAddresses.current.clear();
       }
     },
-    [getTokensForChain, chainToShow.chainId, setIsOpen],
+    [getTokensForChain, chainToShow.chainId, setIsOpen, disableTokenSelect],
   );
 
   const handleMouseEnter = useCallback(() => {
@@ -668,22 +674,24 @@ export const SelectTokenButton: React.FC<SelectTokenButtonProps> = ({
           }}
         >
           {buttonContent}
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 20 20"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-4 w-4 flex-shrink-0"
-          >
-            <path
-              d="M5 7.5L10 12.5L15 7.5"
-              stroke={selectedToken ? "#A1A1A1" : "currentColor"}
-              strokeWidth="1.66667"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          {!disableTokenSelect && (
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4 flex-shrink-0"
+            >
+              <path
+                d="M5 7.5L10 12.5L15 7.5"
+                stroke={selectedToken ? "#A1A1A1" : "currentColor"}
+                strokeWidth="1.66667"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
         </Button>
       </DialogTrigger>
       <DialogContent

--- a/src/components/ui/TokenAmountInput.tsx
+++ b/src/components/ui/TokenAmountInput.tsx
@@ -13,6 +13,7 @@ interface TokenAmountInputProps {
   isLoadingQuote?: boolean;
   variant?: "source" | "destination";
   onContainerClick: () => void; // Add this prop
+  disableWalletBalance?: boolean;
 }
 
 export function TokenAmountInput({
@@ -24,6 +25,7 @@ export function TokenAmountInput({
   isLoadingQuote = false,
   variant = "source",
   onContainerClick, // Add this parameter
+  disableWalletBalance = false,
 }: TokenAmountInputProps) {
   const isLoading = isLoadingQuote && readOnly;
   const sourceToken = useSourceToken();
@@ -100,7 +102,7 @@ export function TokenAmountInput({
             {displayedAmountUsd}
           </span>
         )}
-        {variant === "source" && requiredWallet && (
+        {variant === "source" && requiredWallet && !disableWalletBalance && (
           <div className="flex justify-end w-full mt-2 gap-2">
             {/* Balance display */}
             <div className="flex items-center px-1 py-0.5 rounded-md bg-amber-500 bg-opacity-25">

--- a/src/components/ui/TokenInputGroup.tsx
+++ b/src/components/ui/TokenInputGroup.tsx
@@ -16,6 +16,8 @@ interface TokenInputGroupProps {
   isEnabled?: boolean; // New prop to control if input is enabled
   featuredTokens?: Token[];
   featuredTokensDescription?: string;
+  disableTokenSelect?: boolean;
+  disableWalletBalance?: boolean;
 }
 
 export function TokenInputGroup({
@@ -29,6 +31,8 @@ export function TokenInputGroup({
   isEnabled = true, // Default to true
   featuredTokens = [],
   featuredTokensDescription = "",
+  disableTokenSelect = false,
+  disableWalletBalance = false,
 }: TokenInputGroupProps) {
   const setSourceTokenSelectOpen = useUIStore(
     (state) => state.setSourceTokenSelectOpen,
@@ -52,6 +56,7 @@ export function TokenInputGroup({
           variant={variant}
           featuredTokens={featuredTokens}
           featuredTokensDescription={featuredTokensDescription}
+          disableTokenSelect={disableTokenSelect}
         />
       )}
       <TokenAmountInput
@@ -59,6 +64,7 @@ export function TokenInputGroup({
         onChange={onChange}
         dollarValue={dollarValue}
         readOnly={!isEnabled || readOnly}
+        disableWalletBalance={disableWalletBalance}
         isLoadingQuote={isLoadingQuote && variant === "destination"}
         variant={variant}
         onContainerClick={() => {


### PR DESCRIPTION
this PR adds a new prop to the `SelectTokenButton`, `TokenAmountInput` and `TokenInputGroup` to disable token selection and simply just display the selected source token. This is useful in cases where we want to be able to consistently show the selected asset with the same UI, without the user being able to pick another token (such as the case required for borrowing).