### PR TITLE
feat: borrow full integration into all modals

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -37,6 +37,7 @@ import { useTokenTransfer } from "@/utils/swap/walletMethods";
 import { Button } from "@/components/ui/Button";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
 import { useSupplyOperations } from "@/hooks/lending/useSupplyOperations";
+import { useBorrowOperations } from "@/hooks/lending/useBorrowOperations";
 
 type LendingTabType = "markets" | "dashboard" | "staking" | "history";
 
@@ -164,6 +165,13 @@ export default function LendingPage() {
     tokenTransferState: {
       amount: tokenTransferState.amount || "",
     },
+  });
+
+  const { handleBorrow } = useBorrowOperations({
+    sourceChain,
+    sourceToken,
+    userWalletAddress: userWalletAddress || null,
+    tokenBorrowState: { amount: tokenTransferState.amount || "" },
   });
 
   useEffect(() => {
@@ -340,6 +348,7 @@ export default function LendingPage() {
                         unifiedMarkets={filteredAndSortedUnifiedMarkets}
                         tokenTransferState={tokenTransferState}
                         onSupply={handleSupply}
+                        onBorrow={handleBorrow}
                       />
                     )}
                     {activeTab === "dashboard" && (
@@ -352,6 +361,7 @@ export default function LendingPage() {
                         sortConfig={sortConfig}
                         onSubsectionChange={setCurrentSubsection}
                         onSupply={handleSupply}
+                        onBorrow={handleBorrow}
                       />
                     )}
                     {activeTab === "history" && (

--- a/src/components/ui/lending/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetailsModal.tsx
@@ -26,6 +26,7 @@ import SupplyAssetModal from "@/components/ui/lending/SupplyAssetModal";
 import { getChainByChainId } from "@/config/chains";
 import useWeb3Store from "@/store/web3Store";
 import { getLendingToken } from "@/utils/lending/tokens";
+import BorrowAssetModal from "./BorrowAssetModal";
 
 interface AssetDetailsModalProps {
   market: UnifiedMarketData;
@@ -65,13 +66,6 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
     if (value) setActiveTab(value);
   };
 
-  const handleSupply = () => {
-    onSupply(market);
-  };
-
-  const handleBorrow = () => {
-    onBorrow(market);
-  };
   const tokensByCompositeKey = useWeb3Store(
     (state) => state.tokensByCompositeKey,
   );
@@ -272,20 +266,29 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                   setDestinationChain(lendingChain);
                   setSourceToken(lendingToken);
                   setDestinationToken(lendingToken);
-                  console.log(handleSupply); // just to silence linting warnings
                 }}
                 className="flex-1 justify-center bg-green-500/20 hover:bg-green-500/30 hover:text-green-200 text-green-300 border-green-700/50 hover:border-green-600 transition-all duration-200 py-3 font-medium"
                 iconClassName="h-4 w-4"
               />
             </SupplyAssetModal>
-
-            <BrandedButton
-              iconName="TrendingDown"
-              buttonText="borrow"
-              onClick={handleBorrow}
-              className="flex-1 justify-center bg-red-500/20 hover:bg-red-500/30 hover:text-red-400 text-red-400 border-red-500/50 hover:border-red-500 transition-all duration-200 font-medium"
-              iconClassName="h-4 w-4"
-            />
+            <BorrowAssetModal
+              market={market}
+              onBorrow={onBorrow}
+              tokenTransferState={tokenTransferState}
+            >
+              <BrandedButton
+                iconName="TrendingDown"
+                buttonText="borrow"
+                onClick={() => {
+                  setSourceChain(lendingChain);
+                  setDestinationChain(lendingChain);
+                  setSourceToken(lendingToken);
+                  setDestinationToken(lendingToken);
+                }}
+                className="flex-1 justify-center bg-red-500/20 hover:bg-red-500/30 hover:text-red-400 text-red-400 border-red-500/50 hover:border-red-500 transition-all duration-200 font-medium"
+                iconClassName="h-4 w-4"
+              />
+            </BorrowAssetModal>
           </div>
         </div>
       </DialogContent>

--- a/src/components/ui/lending/AvailableBorrowContent.tsx
+++ b/src/components/ui/lending/AvailableBorrowContent.tsx
@@ -14,6 +14,7 @@ interface AvailableBorrowContentProps {
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
   onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -24,6 +25,7 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
   filters,
   sortConfig,
   onSupply,
+  onBorrow,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -119,10 +121,7 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
           onSupply={onSupply}
-          onBorrow={(market: UnifiedMarketData) => {
-            // TODO: Implement borrow modal/flow
-            console.log("Borrow clicked for:", market.underlyingToken.symbol);
-          }}
+          onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         />
       )}

--- a/src/components/ui/lending/AvailableSupplyContent.tsx
+++ b/src/components/ui/lending/AvailableSupplyContent.tsx
@@ -15,6 +15,7 @@ interface AvailableSupplyContentProps {
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
   onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -26,6 +27,7 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
   filters,
   sortConfig,
   onSupply,
+  onBorrow,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -118,10 +120,7 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
           onSupply={onSupply}
-          onBorrow={(market: UnifiedMarketData) => {
-            // TODO: Implement borrow modal/flow
-            console.log("Borrow clicked for:", market.underlyingToken.symbol);
-          }}
+          onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         />
       )}

--- a/src/components/ui/lending/BorrowAssetModal.tsx
+++ b/src/components/ui/lending/BorrowAssetModal.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTrigger,
+} from "@/components/ui/StyledDialog";
+import { UnifiedMarketData } from "@/types/aave";
+import { TokenTransferState } from "@/types/web3";
+import TokenInputGroup from "@/components/ui/TokenInputGroup";
+import { calculateApyWithIncentives } from "@/utils/lending/incentives";
+import { formatCurrency, formatPercentage } from "@/utils/formatters";
+import { TrendingDown, AlertTriangle, Percent } from "lucide-react";
+import { useSourceToken, useSourceChain } from "@/store/web3Store";
+import { ensureCorrectWalletTypeForChain } from "@/utils/swap/walletMethods";
+import { TokenImage } from "@/components/ui/TokenImage";
+import { BrandedButton } from "@/components/ui/BrandedButton";
+import { calculateTokenPrice } from "@/utils/common";
+import WalletConnectButton from "@/components/ui/WalletConnectButton";
+
+interface BorrowAssetModalProps {
+  market: UnifiedMarketData;
+  children: React.ReactNode;
+  onBorrow: (market: UnifiedMarketData) => void;
+  tokenTransferState: TokenTransferState;
+}
+
+const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
+  market,
+  children,
+  tokenTransferState,
+  onBorrow,
+}) => {
+  const sourceToken = useSourceToken();
+  const sourceChain = useSourceChain();
+
+  const sourceWalletConnected = ensureCorrectWalletTypeForChain(sourceChain);
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="max-w-m max-h-[80vh] overflow-hidden bg-[#18181B] border border-[#27272A] text-white flex flex-col">
+        <DialogHeader className="border-b border-[#27272A] pb-4 flex-shrink-0 text-left">
+          <h2 className="text-lg font-semibold">
+            borrow {market.underlyingToken.symbol}
+          </h2>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto">
+          <TokenInputGroup
+            variant="source"
+            amount={tokenTransferState.amount}
+            onChange={tokenTransferState.handleAmountChange}
+            showSelectToken={true}
+            isEnabled={true}
+            dollarValue={0}
+            featuredTokens={[sourceToken!]}
+            featuredTokensDescription="directly borrow"
+            disableTokenSelect={true}
+            disableWalletBalance={true}
+          />
+
+          {/* Max Borrowable Amount */}
+          <div className="mt-3 p-3 bg-amber-500/5 border border-amber-500/20 rounded-lg">
+            <div className="flex items-start justify-between">
+              <div className="text-sm text-[#A1A1AA]">max borrowable</div>
+              <div className="flex flex-col items-end">
+                <div className="text-sm font-mono font-semibold text-amber-300">
+                  {market.userState?.borrowable?.amount?.value || "0"}{" "}
+                  {market.underlyingToken.symbol}
+                </div>
+                <div className="text-xs font-mono text-[#71717A]">
+                  {formatCurrency(
+                    parseFloat(market.userState?.borrowable?.usd || "0"),
+                  )}
+                </div>
+              </div>
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+              <button
+                onClick={() => {
+                  const maxAmount =
+                    market.userState?.borrowable?.amount?.value || "0";
+                  tokenTransferState.setAmount(maxAmount);
+                }}
+                className="text-xs px-2 py-1 bg-amber-500/20 hover:bg-amber-500/30 text-amber-300 hover:text-amber-200 border border-amber-500/30 hover:border-amber-500/50 rounded transition-all duration-200"
+              >
+                max
+              </button>
+              <span className="text-xs text-[#A1A1AA]">
+                based on your collateral and health factor
+              </span>
+            </div>
+          </div>
+
+          {!sourceWalletConnected && (
+            <div className="mt-4 flex justify-end">
+              <WalletConnectButton
+                walletType={sourceChain.walletType}
+                className="w-auto"
+              />
+            </div>
+          )}
+
+          {/* Transaction Summary */}
+          <div className="mt-4 bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
+            <div className="flex items-center justify-between mb-3">
+              <div className="text-sm text-white">transaction preview</div>
+            </div>
+
+            {!sourceToken ? (
+              <div className="text-center py-4">
+                <div className="text-sm text-[#A1A1AA]">
+                  please select a token to borrow
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="text-sm text-[#A1A1AA]">you will borrow</div>
+                <div className="flex items-start gap-3">
+                  <TokenImage
+                    token={sourceToken}
+                    chain={sourceChain}
+                    size="sm"
+                  />
+                  <div className="flex flex-col">
+                    <div className="flex items-center gap-2">
+                      <span className="text-lg font-mono text-white-400 font-semibold">
+                        {tokenTransferState.amount || "0"}
+                      </span>
+                      <span className="text-white">{sourceToken.ticker}</span>
+                    </div>
+                    {(() => {
+                      const usdAmount = calculateTokenPrice(
+                        tokenTransferState.amount || "0",
+                        market.usdExchangeRate.toString(),
+                      );
+                      return (
+                        usdAmount > 0 && (
+                          <span className="text-sm text-[#71717A] font-mono">
+                            {formatCurrency(usdAmount)}
+                          </span>
+                        )
+                      );
+                    })()}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Asset Borrow Details */}
+          <div className="mt-4 bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
+            <h3 className="text-sm font-medium text-white mb-3 flex items-center gap-2">
+              <TrendingDown className="w-4 h-4 text-red-400" />
+              borrow details
+            </h3>
+
+            <div className="space-y-3">
+              {/* Borrow APY */}
+              <div className="flex justify-between items-center py-2">
+                <div className="flex items-center gap-2">
+                  <Percent className="w-3 h-3 text-[#A1A1AA]" />
+                  <span className="text-sm text-[#A1A1AA]">variable APY</span>
+                </div>
+                <div className="text-sm font-mono font-semibold text-red-400">
+                  {formatPercentage(
+                    calculateApyWithIncentives(
+                      0,
+                      market.borrowData.apy,
+                      market.incentives,
+                    ).finalBorrowAPY,
+                  )}
+                </div>
+              </div>
+
+              {/* Health Factor Warning */}
+              <div className="flex justify-between items-center py-2">
+                <div className="flex items-center gap-2">
+                  <AlertTriangle className="w-3 h-3 text-yellow-400" />
+                  <span className="text-sm text-[#A1A1AA]">
+                    requires collateral
+                  </span>
+                </div>
+                <div className="text-sm font-mono font-semibold text-yellow-400">
+                  check health factor
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <BrandedButton
+            onClick={async () => {
+              console.log(
+                "BorrowAssetModal: Button clicked - executing borrow",
+              );
+              onBorrow(market);
+            }}
+            disabled={
+              !tokenTransferState.amount ||
+              parseFloat(tokenTransferState.amount) <= 0 ||
+              !sourceWalletConnected ||
+              parseFloat(tokenTransferState.amount) >
+                parseFloat(market.userState?.borrowable?.amount?.value || "0")
+            }
+            className="mt-3 flex-1 justify-center bg-red-500/20 hover:bg-red-500/30 hover:text-red-200 text-red-300 border-red-700/50 hover:border-red-600 transition-all duration-200 py-3 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            buttonText={
+              parseFloat(tokenTransferState.amount || "0") >
+                parseFloat(
+                  market.userState?.borrowable?.amount?.value || "0",
+                ) && parseFloat(tokenTransferState.amount || "0") > 0
+                ? "exceeds max borrowable"
+                : "borrow"
+            }
+            iconName="TrendingDown"
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default BorrowAssetModal;

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -34,6 +34,7 @@ interface DashboardContentProps {
   sortConfig?: LendingSortConfig | null;
   onSubsectionChange?: (subsection: string) => void;
   onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
 }
 
 export default function DashboardContent({
@@ -44,6 +45,7 @@ export default function DashboardContent({
   sortConfig,
   onSubsectionChange,
   onSupply,
+  onBorrow,
 }: DashboardContentProps) {
   if (!userAddress) {
     return (
@@ -106,6 +108,7 @@ export default function DashboardContent({
                     sortConfig={sortConfig}
                     onSubsectionChange={onSubsectionChange}
                     onSupply={onSupply}
+                    onBorrow={onBorrow}
                   />
                 );
               }}
@@ -168,6 +171,7 @@ interface DashboardContentInnerProps {
   sortConfig?: LendingSortConfig | null;
   onSubsectionChange?: (subsection: string) => void;
   onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
 }
 
 function DashboardContentInner({
@@ -188,6 +192,7 @@ function DashboardContentInner({
   sortConfig,
   onSubsectionChange,
   onSupply,
+  onBorrow,
 }: DashboardContentInnerProps) {
   const [isSupplyMode, setIsSupplyMode] = useState(true);
   const [showAvailable, setShowAvailable] = useState(true);
@@ -411,6 +416,7 @@ function DashboardContentInner({
               filters={filters}
               sortConfig={sortConfig}
               onSupply={onSupply}
+              onBorrow={onBorrow}
             />
           ) : (
             <AvailableBorrowContent
@@ -419,6 +425,7 @@ function DashboardContentInner({
               filters={filters}
               sortConfig={sortConfig}
               onSupply={onSupply}
+              onBorrow={onBorrow}
             />
           )
         ) : // Show open positions
@@ -430,6 +437,7 @@ function DashboardContentInner({
             filters={filters}
             sortConfig={sortConfig}
             onSupply={onSupply}
+            onBorrow={onBorrow}
           />
         ) : (
           <UserBorrowContent
@@ -440,6 +448,7 @@ function DashboardContentInner({
             filters={filters}
             sortConfig={sortConfig}
             onSupply={onSupply}
+            onBorrow={onBorrow}
           />
         )}
       </div>

--- a/src/components/ui/lending/MarketContent.tsx
+++ b/src/components/ui/lending/MarketContent.tsx
@@ -16,12 +16,14 @@ interface MarketContentProps {
   unifiedMarkets: UnifiedMarketData[] | null | undefined;
   tokenTransferState: TokenTransferState;
   onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
 }
 
 const MarketContent: React.FC<MarketContentProps> = ({
   unifiedMarkets,
   tokenTransferState,
   onSupply,
+  onBorrow,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -52,9 +54,7 @@ const MarketContent: React.FC<MarketContentProps> = ({
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
           onSupply={onSupply}
-          onBorrow={(market: UnifiedMarketData) => {
-            console.log(market); // TODO: update me
-          }}
+          onBorrow={onBorrow}
           onRepay={(market: UserBorrowPosition) => {
             console.log(market); // TODO: update me
           }}

--- a/src/components/ui/lending/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserBorrowCard.tsx
@@ -55,7 +55,7 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
-              {unifiedMarket.underlyingToken.name}
+              {borrow.currency.name}
             </CardTitle>
           </div>
           <CardDescription className="text-[#A1A1AA] text-xs mt-1 flex items-center gap-1">

--- a/src/components/ui/lending/UserBorrowContent.tsx
+++ b/src/components/ui/lending/UserBorrowContent.tsx
@@ -20,6 +20,7 @@ interface UserBorrowContentProps {
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
   onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
 }
 
 interface EnhancedUserBorrowPosition extends UserBorrowPosition {
@@ -36,15 +37,16 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
   filters,
   sortConfig,
   onSupply,
+  onBorrow,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
   const unifiedMarkets = unifyMarkets(activeMarkets);
 
-  // lookup map for unified markets by market address and chain
+  // lookup map for unified markets by currency address and chain
   const unifiedMarketMap = new Map<string, UnifiedMarketData>();
   unifiedMarkets.forEach((market) => {
-    const key = `${market.marketInfo.address}-${market.marketInfo.chain.chainId}`;
+    const key = `${market.underlyingToken.address.toLowerCase()}-${market.marketInfo.chain.chainId}`;
     unifiedMarketMap.set(key, market);
   });
 
@@ -53,8 +55,8 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
   Object.values(marketBorrowData).forEach((marketData) => {
     if (marketData.borrows && marketData.borrows.length > 0) {
       marketData.borrows.forEach((borrow) => {
-        const marketKey = `${marketData.marketAddress}-${marketData.chainId}`;
-        const unifiedMarket = unifiedMarketMap.get(marketKey);
+        const currencyKey = `${borrow.currency.address.toLowerCase()}-${marketData.chainId}`;
+        const unifiedMarket = unifiedMarketMap.get(currencyKey);
 
         if (unifiedMarket) {
           const debtAmount = parseFloat(borrow.debt.usd) || 0;
@@ -155,9 +157,7 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
           position={position}
           unifiedMarket={position.unifiedMarket}
           onSupply={onSupply}
-          onBorrow={(market: UnifiedMarketData) => {
-            console.log(market); // TODO: update me
-          }}
+          onBorrow={onBorrow}
           onRepay={(position: UserBorrowPosition) => {
             console.log(position); // TODO: update me
           }}

--- a/src/components/ui/lending/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserSupplyContent.tsx
@@ -20,6 +20,7 @@ interface UserSupplyContentProps {
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
   onSupply: (market: UnifiedMarketData) => void;
+  onBorrow: (market: UnifiedMarketData) => void;
 }
 
 interface EnhancedUserSupplyPosition extends UserSupplyPosition {
@@ -35,6 +36,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
   filters,
   sortConfig,
   onSupply,
+  onBorrow,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -149,9 +151,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
           position={position}
           unifiedMarket={position.unifiedMarket}
           onSupply={onSupply}
-          onBorrow={(market: UnifiedMarketData) => {
-            console.log(market); // TODO: update me
-          }}
+          onBorrow={onBorrow}
           onWithdraw={(position: UserSupplyPosition) => {
             console.log(position); // TODO: update me
           }}

--- a/src/hooks/lending/useBorrowOperations.ts
+++ b/src/hooks/lending/useBorrowOperations.ts
@@ -1,0 +1,143 @@
+"use client";
+
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { evmAddress, bigDecimal } from "@aave/react";
+import { useAaveBorrow } from "@/hooks/aave/useAaveInteractions";
+import { useChainSwitch } from "@/utils/swap/walletMethods";
+import { truncateAddress } from "@/utils/formatters";
+import { UnifiedMarketData, ChainId } from "@/types/aave";
+import { Chain, Token } from "@/types/web3";
+import { getChainByChainId } from "@/config/chains";
+
+export interface TokenBorrowState {
+  amount: string;
+}
+
+export interface BorrowOperationDependencies {
+  sourceChain: Chain | null;
+  sourceToken: Token | null;
+  userWalletAddress: string | null;
+  tokenBorrowState: TokenBorrowState;
+}
+
+export interface BorrowOperationResult {
+  success: boolean;
+  transactionHash?: string;
+  error?: string;
+}
+
+export interface BorrowOperationHook {
+  handleBorrow: (market: UnifiedMarketData) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const useBorrowOperations = (
+  dependencies: BorrowOperationDependencies,
+): BorrowOperationHook => {
+  const { sourceChain, sourceToken, userWalletAddress, tokenBorrowState } =
+    dependencies;
+  const {
+    executeBorrow,
+    loading: borrowLoading,
+    error: borrowError,
+  } = useAaveBorrow();
+
+  let marketChain;
+  if (!sourceChain) {
+    marketChain = getChainByChainId(1);
+    console.error("No source chain provided, defaulting to Ethereum mainnet");
+  } else {
+    marketChain = sourceChain;
+  }
+
+  const { switchToChain } = useChainSwitch(marketChain);
+
+  const handleBorrow = useCallback(
+    async (market: UnifiedMarketData): Promise<void> => {
+      try {
+        // Validate required dependencies
+        if (!sourceToken || !tokenBorrowState.amount || !userWalletAddress) {
+          console.error("Missing required borrow data");
+          toast.error("Missing required data", {
+            description: "Please select a source token and enter an amount",
+          });
+          return;
+        }
+
+        if (!sourceChain) {
+          console.error("Missing source chain");
+          toast.error("Missing source chain", {
+            description: "Please select a source chain",
+          });
+          return;
+        }
+
+        // Switch to correct chain FIRST before any operations
+        try {
+          await switchToChain(sourceChain);
+        } catch (chainSwitchError) {
+          console.error("Chain switch failed:", chainSwitchError);
+          return;
+        }
+
+        const borrowToastId = toast.loading("Executing borrow...", {
+          description: "Please confirm the transaction in your wallet",
+        });
+
+        // Determine if we should use native token
+        const useNative =
+          sourceToken.ticker === market.marketInfo.chain.nativeWrappedToken;
+
+        // Execute the borrow operation
+        const result = await executeBorrow({
+          market: evmAddress(market.marketInfo.address),
+          amount: bigDecimal(tokenBorrowState.amount),
+          currency: evmAddress(sourceToken.address),
+          chainId: market.marketInfo.chain.chainId as ChainId,
+          useNative,
+        });
+
+        // Handle the result
+        if (result.success) {
+          console.log("Borrow successful:", result.transactionHash);
+          toast.success("Borrow successful", {
+            id: borrowToastId,
+            description: `Transaction hash: ${truncateAddress(
+              result.transactionHash!,
+            )}`,
+          });
+        } else {
+          console.error("Borrow failed:", result.error);
+          toast.error("Borrow failed", {
+            id: borrowToastId,
+            description: result.error || "An unknown error occurred",
+          });
+        }
+      } catch (error) {
+        console.error("Borrow operation failed:", error);
+        toast.error("Borrow operation failed", {
+          description:
+            error instanceof Error
+              ? error.message
+              : "An unknown error occurred",
+        });
+      }
+    },
+    [
+      sourceToken,
+      tokenBorrowState,
+      userWalletAddress,
+      sourceChain,
+      executeBorrow,
+      switchToChain,
+    ],
+  );
+
+  return {
+    handleBorrow,
+    isLoading: borrowLoading,
+    error: typeof borrowError === "string" ? borrowError : null,
+  };
+};

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -178,3 +178,115 @@ export interface SupplyState {
   loading: boolean;
   error: string | null;
 }
+
+/**
+ * Arguments for borrow operations
+ */
+export interface BorrowArgs {
+  /** The market address to borrow from */
+  market: EvmAddress;
+  /** The amount to borrow */
+  amount: BigDecimal;
+  /** The currency address to borrow */
+  currency: EvmAddress;
+  /** The chain ID */
+  chainId: ChainId;
+  /** Whether to use native token (e.g., ETH instead of WETH) */
+  useNative?: boolean;
+  /** Address to send borrowed tokens to (if different from sender) */
+  onBehalfOf?: EvmAddress;
+}
+
+/**
+ * Result of a borrow operation
+ */
+export interface BorrowResult {
+  success: boolean;
+  transactionHash?: string;
+  error?: string;
+}
+
+/**
+ * Loading state for borrow operations
+ */
+export interface BorrowState {
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Arguments for repay operations
+ */
+export interface RepayArgs {
+  /** The market address to repay to */
+  market: EvmAddress;
+  /** The amount to repay (use max uint256 for full repayment) */
+  amount: BigDecimal;
+  /** The currency address to repay */
+  currency: EvmAddress;
+  /** The chain ID */
+  chainId: ChainId;
+  /** Interest rate mode: 1 for stable, 2 for variable */
+  interestRateMode: 1 | 2;
+  /** Whether to use native token (e.g., ETH instead of WETH) */
+  useNative?: boolean;
+  /** Address to repay on behalf of (if different from sender) */
+  onBehalfOf?: EvmAddress;
+  /** Optional permit signature for gasless approval */
+  permitSig?: {
+    deadline: bigint;
+    signature: Signature;
+  };
+}
+
+/**
+ * Result of a repay operation
+ */
+export interface RepayResult {
+  success: boolean;
+  transactionHash?: string;
+  error?: string;
+}
+
+/**
+ * Loading state for repay operations
+ */
+export interface RepayState {
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Arguments for withdraw operations
+ */
+export interface WithdrawArgs {
+  /** The market address to withdraw from */
+  market: EvmAddress;
+  /** The amount to withdraw (use max uint256 for full withdrawal) */
+  amount: BigDecimal;
+  /** The currency address to withdraw */
+  currency: EvmAddress;
+  /** The chain ID */
+  chainId: ChainId;
+  /** Whether to use native token (e.g., ETH instead of WETH) */
+  useNative?: boolean;
+  /** Address to send withdrawn tokens to (if different from sender) */
+  to?: EvmAddress;
+}
+
+/**
+ * Result of a withdraw operation
+ */
+export interface WithdrawResult {
+  success: boolean;
+  transactionHash?: string;
+  error?: string;
+}
+
+/**
+ * Loading state for withdraw operations
+ */
+export interface WithdrawState {
+  loading: boolean;
+  error: string | null;
+}


### PR DESCRIPTION
branch off #350, please see 1d7d06d696fa965dfb1b639877e7d3ed90d2e112 for relevant changes

apologies for the large number of file changes - kind of unavoidable when we pass everything through long prop changes, but worth it for the easy of changes in the future

---

this PR adds the required hooks for executing aave borrows, as well as integrating the operations hook into all modals with borrow accessibility.

the borrow flow is much simpler than supply - no swap required, simply have to allow the user to enter an amount, ensure it doesn't exceed their max borrowable (which is already returned to us in decimal point precision by the sdk), then execute the transaction. 

I have successfully opened multiple borrow positions from a number of different modals with no issues.

## Screenshots
### Desktop
<img width="3140" height="2112" alt="Screenshot 2025-09-09 at 8 10 35 pm" src="https://github.com/user-attachments/assets/3c76734d-74a6-46d7-a430-6cac80b94602" />


### Tablet
<img width="1310" height="1880" alt="Screenshot 2025-09-09 at 8 12 37 pm" src="https://github.com/user-attachments/assets/00a65c3b-880b-41f1-9df6-b01639ade61f" />

### Mobile
<img width="858" height="1862" alt="Screenshot 2025-09-09 at 8 12 57 pm" src="https://github.com/user-attachments/assets/865a2eb6-08b6-4028-a0a0-7a69c13b69c8" />

