### PR TITLE
fix: aggregate market data for lending individually

### DIFF
--- a/src/components/meta/AggregatedMarketData.tsx
+++ b/src/components/meta/AggregatedMarketData.tsx
@@ -1,0 +1,196 @@
+import { useState, useMemo, useCallback, useEffect } from "react";
+import { evmAddress, chainId } from "@aave/react";
+import {
+  useAaveMarketsWithLoading,
+  useAaveSingleMarketDataWithLoading,
+} from "@/hooks/aave/useAaveMarketsData";
+import {
+  ChainId,
+  EvmAddress,
+  Market,
+  MarketReservesRequestOrderBy,
+} from "@/types/aave";
+
+interface MarketData {
+  marketAddress: string;
+  chainId: ChainId;
+  data: Market | null;
+  loading: boolean;
+  error: boolean;
+  hasData: boolean;
+}
+
+interface SingleMarketDataProps {
+  marketAddress: string;
+  chainId: ChainId;
+  user?: EvmAddress;
+  borrowsOrderBy?: MarketReservesRequestOrderBy;
+  suppliesOrderBy?: MarketReservesRequestOrderBy;
+  onDataChange: (marketData: MarketData) => void;
+}
+
+const SingleMarketData: React.FC<SingleMarketDataProps> = ({
+  marketAddress,
+  chainId: marketChainId,
+  user,
+  borrowsOrderBy,
+  suppliesOrderBy,
+  onDataChange,
+}) => {
+  const { market, loading } = useAaveSingleMarketDataWithLoading({
+    address: evmAddress(marketAddress),
+    chainId: chainId(marketChainId),
+    user,
+    borrowsOrderBy,
+    suppliesOrderBy,
+  });
+
+  const error = !loading && !market;
+
+  useEffect(() => {
+    const marketData: MarketData = {
+      marketAddress,
+      chainId: marketChainId,
+      data: market || null,
+      loading,
+      error,
+      hasData: !!market,
+    };
+
+    onDataChange(marketData);
+  }, [market, loading, error, marketAddress, marketChainId, onDataChange]);
+
+  return null;
+};
+
+interface AggregatedMarketDataProps {
+  chainIds: ChainId[];
+  user?: EvmAddress;
+  borrowsOrderBy?: MarketReservesRequestOrderBy;
+  suppliesOrderBy?: MarketReservesRequestOrderBy;
+  children: (props: {
+    markets: Market[] | null;
+    loading: boolean;
+    error: boolean;
+    hasData: boolean;
+  }) => React.ReactNode;
+}
+
+export const AggregatedMarketData: React.FC<AggregatedMarketDataProps> = ({
+  chainIds,
+  user,
+  borrowsOrderBy,
+  suppliesOrderBy,
+  children,
+}) => {
+  const [marketDataMap, setMarketDataMap] = useState<
+    Record<string, MarketData>
+  >({});
+
+  // First, get market addresses from the original useAaveMarketsWithLoading
+  const { markets: marketAddresses, loading: addressesLoading } =
+    useAaveMarketsWithLoading({
+      chainIds,
+      user,
+      borrowsOrderBy,
+      suppliesOrderBy,
+    });
+
+  // Extract market addresses and chainIds for individual calls
+  const marketConfigs = useMemo(() => {
+    if (!marketAddresses) return [];
+
+    return marketAddresses.map((market) => ({
+      address: market.address,
+      chainId: market.chain.chainId as ChainId,
+    }));
+  }, [marketAddresses]);
+
+  // Create a set of current market keys for O(1) lookup
+  const currentMarketKeys = useMemo(() => {
+    return new Set(
+      marketConfigs.map((config) => `${config.chainId}-${config.address}`),
+    );
+  }, [marketConfigs]);
+
+  // Clean up stale market data when marketConfigs change
+  useEffect(() => {
+    setMarketDataMap((prev) => {
+      const filtered: Record<string, MarketData> = {};
+
+      // Only keep data for markets that are currently configured
+      Object.entries(prev).forEach(([key, data]) => {
+        if (currentMarketKeys.has(key)) {
+          filtered[key] = data;
+        }
+      });
+
+      return filtered;
+    });
+  }, [currentMarketKeys]);
+
+  const handleMarketDataChange = useCallback(
+    (marketData: MarketData) => {
+      const key = `${marketData.chainId}-${marketData.marketAddress}`;
+
+      // Only update if this market is currently configured
+      if (currentMarketKeys.has(key)) {
+        setMarketDataMap((prev) => ({
+          ...prev,
+          [key]: marketData,
+        }));
+      }
+    },
+    [currentMarketKeys],
+  );
+
+  const aggregatedData = useMemo(() => {
+    // Filter marketDataMap to only include current markets
+    const currentMarketData = Object.entries(marketDataMap)
+      .filter(([key]) => currentMarketKeys.has(key))
+      .map(([, data]) => data);
+
+    // Calculate overall loading state
+    const isLoading =
+      addressesLoading ||
+      currentMarketData.some((marketData) => marketData.loading);
+
+    // Calculate overall error state
+    const hasError = currentMarketData.some((marketData) => marketData.error);
+
+    // Get valid markets with data
+    const validMarkets = currentMarketData
+      .filter((marketData) => marketData.data && !marketData.error)
+      .map((marketData) => marketData.data!);
+
+    // Check if we have any data
+    const hasData = validMarkets.length > 0;
+
+    return {
+      markets: hasData ? validMarkets : null,
+      loading: isLoading,
+      error: hasError,
+      hasData,
+    };
+  }, [marketDataMap, currentMarketKeys, addressesLoading]);
+
+  return (
+    <>
+      {/* Render individual market components for data fetching */}
+      {marketConfigs.map((config) => (
+        <SingleMarketData
+          key={`${config.chainId}-${config.address}`}
+          marketAddress={config.address}
+          chainId={config.chainId}
+          user={user}
+          borrowsOrderBy={borrowsOrderBy}
+          suppliesOrderBy={suppliesOrderBy}
+          onDataChange={handleMarketDataChange}
+        />
+      ))}
+
+      {/* Render children with aggregated data */}
+      {children(aggregatedData)}
+    </>
+  );
+};

--- a/src/hooks/aave/useAaveMarketsData.ts
+++ b/src/hooks/aave/useAaveMarketsData.ts
@@ -71,6 +71,22 @@ export const useAaveSingleMarketData = (args: UseAaveMarketArgs) => {
 };
 
 /**
+ * Hook to fetch data for a single Aave market with loading states.
+ * This hook returns loading states instead of suspending.
+ */
+export const useAaveSingleMarketDataWithLoading = (args: UseAaveMarketArgs) => {
+  const { data, loading } = useAaveMarket({
+    address: args.address,
+    chainId: args.chainId,
+    user: args.user,
+    borrowsOrderBy: args.borrowsOrderBy,
+    suppliesOrderBy: args.suppliesOrderBy,
+  });
+
+  return { market: data ?? undefined, loading };
+};
+
+/**
  * Hook to fetch historical borrow APY using Suspense pattern.
  * This hook will suspend the component until data is loaded.
  */


### PR DESCRIPTION
#### Context

This PR is concerned with no longer relying on `useAaveMarketsWithLoading` to retrieve multiple markets... this is a consequence of the `markets: Market[]` returned from `useAaveMarkets` being populated with incorrect data. This has been triple-checked

For example - observe how the avalanche emode categories are returned as part of the polygon data... 

<img width="912" height="219" alt="image" src="https://github.com/user-attachments/assets/a6502448-85aa-41c8-a542-ef4dfce927de" />

This is not the sole error and was the reason we could not rely on just `markets` before and had to use other hooks were we fetched data individually market by market, where similar problems were also observed in addition to just markets being wrong. It is worth investigating which ones we can remove as a consequence of this fix, however, as it's possible we no longer need the other ones such as user state, borrows, and supplies if we can directly compute them now with just markets. This is, however, not a priority at present.

#### So what is the fix?

We still use `useAaveMarketsWithLoading` but only to retrieve market addresses and chain IDs. Those are then used in a meta-component and aggregated component like we do for our other hooks where we rely on the newly added `useAaveSingleMarketDataWithLoading` which leverages `useAaveMarket` to fetch market data individually. We then combine everything into the `markets` returned.

#### Verification that things still work:

<img width="1137" height="869" alt="image" src="https://github.com/user-attachments/assets/b61b7333-73fc-4568-85f4-36d651365780" />
