### PR TITLE
feat: lending withdraw hooks and modal

### DIFF
--- a/src/components/ui/lending/WithdrawAssetModal.tsx
+++ b/src/components/ui/lending/WithdrawAssetModal.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTrigger,
+} from "@/components/ui/StyledDialog";
+import { UnifiedMarketData, UserSupplyPosition } from "@/types/aave";
+import { TokenTransferState } from "@/types/web3";
+import TokenInputGroup from "@/components/ui/TokenInputGroup";
+import { calculateApyWithIncentives } from "@/utils/lending/incentives";
+import {
+  formatCurrency,
+  formatPercentage,
+  formatBalance,
+} from "@/utils/formatters";
+import { TrendingUp, AlertTriangle, Percent } from "lucide-react";
+import { useSourceToken, useSourceChain } from "@/store/web3Store";
+import { ensureCorrectWalletTypeForChain } from "@/utils/swap/walletMethods";
+import { TokenImage } from "@/components/ui/TokenImage";
+import { BrandedButton } from "@/components/ui/BrandedButton";
+import { calculateTokenPrice } from "@/utils/common";
+import WalletConnectButton from "@/components/ui/WalletConnectButton";
+
+interface WithdrawAssetModalProps {
+  market: UnifiedMarketData;
+  position?: UserSupplyPosition;
+  children: React.ReactNode;
+  onWithdraw: (market: UnifiedMarketData) => void;
+  tokenTransferState: TokenTransferState;
+}
+
+const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
+  market,
+  position,
+  children,
+  tokenTransferState,
+  onWithdraw,
+}) => {
+  const sourceToken = useSourceToken();
+  const sourceChain = useSourceChain();
+
+  const sourceWalletConnected = ensureCorrectWalletTypeForChain(sourceChain);
+
+  const maxWithdrawableTokens = position
+    ? parseFloat(position.supply.balance.amount.value) || 0
+    : 0;
+  const maxWithdrawableUsd = position
+    ? parseFloat(position.supply.balance.usd) || 0
+    : 0;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="max-w-m max-h-[80vh] overflow-hidden bg-[#18181B] border border-[#27272A] text-white flex flex-col">
+        <DialogHeader className="border-b border-[#27272A] pb-4 flex-shrink-0 text-left">
+          <h2 className="text-lg font-semibold">
+            withdraw {market.underlyingToken.symbol}
+          </h2>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto">
+          <TokenInputGroup
+            variant="source"
+            amount={tokenTransferState.amount}
+            onChange={tokenTransferState.handleAmountChange}
+            showSelectToken={true}
+            isEnabled={true}
+            dollarValue={0}
+            featuredTokens={[sourceToken!]}
+            featuredTokensDescription="directly withdraw"
+            disableTokenSelect={true}
+            disableWalletBalance={true}
+          />
+
+          {/* Max Withdrawable Amount */}
+          {position && (
+            <div className="mt-3 p-3 bg-green-500/5 border border-green-500/20 rounded-lg">
+              <div className="flex items-start justify-between">
+                <div className="text-sm text-[#A1A1AA]">max withdrawable</div>
+                <div className="flex flex-col items-end">
+                  <div className="text-sm font-mono font-semibold text-green-300">
+                    {formatBalance(position.supply.balance.amount.value)}{" "}
+                    {market.underlyingToken.symbol}
+                  </div>
+                  <div className="text-xs font-mono text-[#71717A]">
+                    {formatCurrency(maxWithdrawableUsd)}
+                  </div>
+                </div>
+              </div>
+              <div className="mt-2 flex items-center gap-2">
+                <button
+                  onClick={() => {
+                    tokenTransferState.setAmount(
+                      position.supply.balance.amount.value,
+                    );
+                  }}
+                  className="text-xs px-2 py-1 bg-green-500/20 hover:bg-green-500/30 text-green-300 hover:text-green-200 border border-green-500/30 hover:border-green-500/50 rounded transition-all duration-200"
+                >
+                  max
+                </button>
+                <span className="text-xs text-[#A1A1AA]">
+                  from your supply position
+                </span>
+              </div>
+            </div>
+          )}
+
+          {!sourceWalletConnected && (
+            <div className="mt-4 flex justify-end">
+              <WalletConnectButton
+                walletType={sourceChain.walletType}
+                className="w-auto"
+              />
+            </div>
+          )}
+
+          {/* Transaction Summary */}
+          <div className="mt-4 bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
+            <div className="flex items-center justify-between mb-3">
+              <div className="text-sm text-white">transaction preview</div>
+            </div>
+
+            {!sourceToken ? (
+              <div className="text-center py-4">
+                <div className="text-sm text-[#A1A1AA]">
+                  please select a token to withdraw
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="text-sm text-[#A1A1AA]">you will withdraw</div>
+                <div className="flex items-start gap-3">
+                  <TokenImage
+                    token={sourceToken}
+                    chain={sourceChain}
+                    size="sm"
+                  />
+                  <div className="flex flex-col">
+                    <div className="flex items-center gap-2">
+                      <span className="text-lg font-mono text-white-400 font-semibold">
+                        {tokenTransferState.amount || "0"}
+                      </span>
+                      <span className="text-white">{sourceToken.ticker}</span>
+                    </div>
+                    {(() => {
+                      const usdAmount = calculateTokenPrice(
+                        tokenTransferState.amount || "0",
+                        market.usdExchangeRate.toString(),
+                      );
+                      return (
+                        usdAmount > 0 && (
+                          <span className="text-sm text-[#71717A] font-mono">
+                            {formatCurrency(usdAmount)}
+                          </span>
+                        )
+                      );
+                    })()}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Asset Supply Details */}
+          <div className="mt-4 bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
+            <h3 className="text-sm font-medium text-white mb-3 flex items-center gap-2">
+              <TrendingUp className="w-4 h-4 text-green-400" />
+              withdraw details
+            </h3>
+
+            <div className="space-y-3">
+              {/* Supply APY being earned */}
+              <div className="flex justify-between items-center py-2">
+                <div className="flex items-center gap-2">
+                  <Percent className="w-3 h-3 text-[#A1A1AA]" />
+                  <span className="text-sm text-[#A1A1AA]">current APY</span>
+                </div>
+                <div className="text-sm font-mono font-semibold text-green-400">
+                  {formatPercentage(
+                    calculateApyWithIncentives(
+                      market.supplyData.apy,
+                      0,
+                      market.incentives,
+                    ).finalSupplyAPY,
+                  )}
+                </div>
+              </div>
+
+              {/* Health Factor Warning (if applicable) */}
+              {position?.supply.isCollateral && (
+                <div className="flex justify-between items-center py-2">
+                  <div className="flex items-center gap-2">
+                    <AlertTriangle className="w-3 h-3 text-yellow-400" />
+                    <span className="text-sm text-[#A1A1AA]">
+                      monitor health factor
+                    </span>
+                  </div>
+                  <div className="text-sm font-mono font-semibold text-yellow-400">
+                    affects collateral
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+          <BrandedButton
+            onClick={async () => {
+              onWithdraw(market);
+            }}
+            disabled={
+              !tokenTransferState.amount ||
+              parseFloat(tokenTransferState.amount) <= 0 ||
+              !sourceWalletConnected ||
+              parseFloat(tokenTransferState.amount) > maxWithdrawableTokens
+            }
+            className="mt-3 flex-1 justify-center bg-green-500/20 hover:bg-green-500/30 hover:text-green-200 text-green-300 border-green-700/50 hover:border-green-600 transition-all duration-200 py-3 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            buttonText={
+              parseFloat(tokenTransferState.amount || "0") >
+                maxWithdrawableTokens &&
+              parseFloat(tokenTransferState.amount || "0") > 0
+                ? "exceeds balance"
+                : "withdraw"
+            }
+            iconName="TrendingUp"
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default WithdrawAssetModal;

--- a/src/hooks/lending/useWithdrawOperations.ts
+++ b/src/hooks/lending/useWithdrawOperations.ts
@@ -1,0 +1,145 @@
+"use client";
+
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { evmAddress, bigDecimal } from "@aave/react";
+import { useAaveWithdraw } from "@/hooks/aave/useAaveInteractions";
+import { useChainSwitch } from "@/utils/swap/walletMethods";
+import { truncateAddress } from "@/utils/formatters";
+import { UnifiedMarketData, ChainId } from "@/types/aave";
+import { Chain, Token } from "@/types/web3";
+import { getChainByChainId } from "@/config/chains";
+
+export interface TokenWithdrawState {
+  amount: string;
+}
+
+export interface WithdrawOperationDependencies {
+  sourceChain: Chain | null;
+  sourceToken: Token | null;
+  userWalletAddress: string | null;
+  tokenWithdrawState: TokenWithdrawState;
+}
+
+export interface WithdrawOperationResult {
+  success: boolean;
+  transactionHash?: string;
+  error?: string;
+}
+
+export interface WithdrawOperationHook {
+  handleWithdraw: (market: UnifiedMarketData) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const useWithdrawOperations = (
+  dependencies: WithdrawOperationDependencies,
+): WithdrawOperationHook => {
+  const { sourceChain, sourceToken, userWalletAddress, tokenWithdrawState } =
+    dependencies;
+  const {
+    executeWithdraw,
+    loading: withdrawLoading,
+    error: withdrawError,
+  } = useAaveWithdraw();
+
+  let marketChain;
+  if (!sourceChain) {
+    marketChain = getChainByChainId(1);
+    console.error("No source chain provided, defaulting to Ethereum mainnet");
+  } else {
+    marketChain = sourceChain;
+  }
+
+  const { switchToChain } = useChainSwitch(marketChain);
+
+  const handleWithdraw = useCallback(
+    async (market: UnifiedMarketData): Promise<void> => {
+      try {
+        // Validate required dependencies
+        if (!sourceToken || !tokenWithdrawState.amount || !userWalletAddress) {
+          console.error("Missing required withdraw data");
+          toast.error("Missing required data", {
+            description: "Please select a source token and enter an amount",
+          });
+          return;
+        }
+
+        if (!sourceChain) {
+          console.error("Missing source chain");
+          toast.error("Missing source chain", {
+            description: "Please select a source chain",
+          });
+          return;
+        }
+
+        // Switch to correct chain FIRST before any operations
+        try {
+          await switchToChain(sourceChain);
+        } catch {
+          toast.error(
+            "Chain switch failed, please try manually switching chains.",
+          );
+          return;
+        }
+
+        const withdrawToastId = toast.loading("Executing withdraw...", {
+          description: "Please confirm the transaction in your wallet",
+        });
+
+        // Determine if we should use native token
+        const useNative =
+          sourceToken.ticker === market.marketInfo.chain.nativeWrappedToken;
+
+        // Execute the withdraw operation
+        const result = await executeWithdraw({
+          market: evmAddress(market.marketInfo.address),
+          amount: bigDecimal(tokenWithdrawState.amount),
+          currency: evmAddress(sourceToken.address),
+          chainId: market.marketInfo.chain.chainId as ChainId,
+          useNative,
+        });
+
+        // Handle the result
+        if (result.success) {
+          console.log("Withdraw successful:", result.transactionHash);
+          toast.success("Withdraw successful", {
+            id: withdrawToastId,
+            description: `Transaction hash: ${truncateAddress(
+              result.transactionHash!,
+            )}`,
+          });
+        } else {
+          console.error("Withdraw failed:", result.error);
+          toast.error("Withdraw failed", {
+            id: withdrawToastId,
+            description: result.error || "An unknown error occurred",
+          });
+        }
+      } catch (error) {
+        console.error("Withdraw operation failed:", error);
+        toast.error("Withdraw operation failed", {
+          description:
+            error instanceof Error
+              ? error.message
+              : "An unknown error occurred",
+        });
+      }
+    },
+    [
+      sourceToken,
+      tokenWithdrawState,
+      userWalletAddress,
+      sourceChain,
+      executeWithdraw,
+      switchToChain,
+    ],
+  );
+
+  return {
+    handleWithdraw,
+    isLoading: withdrawLoading,
+    error: typeof withdrawError === "string" ? withdrawError : null,
+  };
+};


### PR DESCRIPTION
branch off #351, please see c408b7d8f2aa30f313ded810386cbbae8065f820

this PR adds the `useWithdrawOperations.ts` hook to handle all the extra logic and conditionals to support the `useAaveWithdraw` hook which is already defined (following the same pattern we have taken already for supplying and borrowing.

additionally, I have included the `WithdrawAssetModal.tsx`. This follows a similar layout to our `BorrowAssetModal`.

We haven't really decided or discussed on colours for the "Withdraw" and "Repay" actions (i.e. Supply is green, Borrow is red). I'm not too fussed about that yet since it's easily configurable when we do our big clean up.

## Screenshots

### Desktop
<img width="2796" height="2178" alt="Screenshot 2025-09-10 at 9 19 57 pm" src="https://github.com/user-attachments/assets/34d02615-b60f-48fd-a971-aa9321a60782" />

### Tablet
<img width="1920" height="2562" alt="Screenshot 2025-09-10 at 9 20 09 pm" src="https://github.com/user-attachments/assets/a744e827-bdb5-4cc5-a12d-561342205a08" />

### Mobile
<img width="854" height="1862" alt="Screenshot 2025-09-10 at 9 20 19 pm" src="https://github.com/user-attachments/assets/2f6496a7-7db6-409c-9b4a-2c481fe2b221" />



