### PR TITLE
feat: repay integration

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -39,6 +39,7 @@ import { LendingFilters, LendingSortConfig } from "@/types/lending";
 import { useSupplyOperations } from "@/hooks/lending/useSupplyOperations";
 import { useBorrowOperations } from "@/hooks/lending/useBorrowOperations";
 import { useWithdrawOperations } from "@/hooks/lending/useWithdrawOperations";
+import { useRepayOperations } from "@/hooks/lending/useRepayOperations";
 
 type LendingTabType = "markets" | "dashboard" | "staking" | "history";
 
@@ -180,6 +181,13 @@ export default function LendingPage() {
     sourceToken,
     userWalletAddress: userWalletAddress || null,
     tokenWithdrawState: { amount: tokenTransferState.amount || "" },
+  });
+
+  const { handleRepay } = useRepayOperations({
+    sourceChain,
+    sourceToken,
+    userWalletAddress: userWalletAddress || null,
+    tokenRepayState: { amount: tokenTransferState.amount || "" },
   });
 
   useEffect(() => {
@@ -372,6 +380,7 @@ export default function LendingPage() {
                         onBorrow={handleBorrow}
                         onWithdraw={handleWithdraw}
                         refetchMarkets={refetchMarkets}
+                        onRepay={handleRepay}
                       />
                     )}
                     {activeTab === "history" && (

--- a/src/components/ui/lending/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetailsModal.tsx
@@ -28,16 +28,18 @@ import useWeb3Store from "@/store/web3Store";
 import { getLendingToken } from "@/utils/lending/tokens";
 import BorrowAssetModal from "@/components/ui/lending/BorrowAssetModal";
 import WithdrawAssetModal from "@/components/ui/lending/WithdrawAssetModal";
+import RepayAssetModal from "@/components/ui/lending/RepayAssetModal";
 
 interface AssetDetailsModalProps {
   market: UnifiedMarketData;
   children: React.ReactNode;
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
-  onRepay?: (market: UserBorrowPosition) => void;
+  onRepay?: (market: UnifiedMarketData, max: boolean) => void;
   onWithdraw?: (market: UnifiedMarketData) => void;
   tokenTransferState: TokenTransferState;
   supplyPosition?: UserSupplyPosition;
+  borrowPosition?: UserBorrowPosition;
   buttonsToShow: ctaButtons[];
 }
 
@@ -50,8 +52,10 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
   onSupply,
   onBorrow,
   onWithdraw,
+  onRepay,
   tokenTransferState,
   supplyPosition,
+  borrowPosition,
   buttonsToShow,
 }) => {
   const [activeTab, setActiveTab] = useState<TabType>("user");
@@ -320,6 +324,27 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                   iconClassName="h-4 w-4"
                 />
               </WithdrawAssetModal>
+            )}
+            {onRepay && buttonsToShow.includes("repay") && (
+              <RepayAssetModal
+                market={market}
+                position={borrowPosition}
+                onRepay={onRepay}
+                tokenTransferState={tokenTransferState}
+              >
+                <BrandedButton
+                  iconName="Coins"
+                  buttonText="repay"
+                  onClick={() => {
+                    setSourceChain(lendingChain);
+                    setDestinationChain(lendingChain);
+                    setSourceToken(lendingToken);
+                    setDestinationToken(lendingToken);
+                  }}
+                  className="flex-1 justify-center bg-sky-500/20 hover:bg-sky-500/30 hover:text-sky-300 text-sky-300 border-sky-500/50 hover:border-sky-500 transition-all duration-200 py-3 font-medium"
+                  iconClassName="h-4 w-4"
+                />
+              </RepayAssetModal>
             )}
           </div>
         </div>

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -38,6 +38,7 @@ interface DashboardContentProps {
   onBorrow: (market: UnifiedMarketData) => void;
   onWithdraw: (market: UnifiedMarketData) => void;
   refetchMarkets?: () => void;
+  onRepay: (market: UnifiedMarketData, max: boolean) => void;
 }
 
 export default function DashboardContent({
@@ -51,6 +52,7 @@ export default function DashboardContent({
   onBorrow,
   onWithdraw,
   refetchMarkets,
+  onRepay,
 }: DashboardContentProps) {
   if (!userAddress) {
     return (
@@ -117,6 +119,7 @@ export default function DashboardContent({
                     onBorrow={onBorrow}
                     onWithdraw={onWithdraw}
                     refetchMarkets={refetchMarkets}
+                    onRepay={onRepay}
                   />
                 );
               }}
@@ -183,6 +186,7 @@ interface DashboardContentInnerProps {
   onBorrow: (market: UnifiedMarketData) => void;
   onWithdraw: (market: UnifiedMarketData) => void;
   refetchMarkets?: () => void;
+  onRepay: (market: UnifiedMarketData, max: boolean) => void;
 }
 
 function DashboardContentInner({
@@ -207,6 +211,7 @@ function DashboardContentInner({
   onBorrow,
   onWithdraw,
   refetchMarkets,
+  onRepay,
 }: DashboardContentInnerProps) {
   const [isSupplyMode, setIsSupplyMode] = useState(true);
   const [showAvailable, setShowAvailable] = useState(true);
@@ -466,6 +471,7 @@ function DashboardContentInner({
             sortConfig={sortConfig}
             onSupply={onSupply}
             onBorrow={onBorrow}
+            onRepay={onRepay}
           />
         )}
       </div>

--- a/src/components/ui/lending/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserBorrowCard.tsx
@@ -21,7 +21,7 @@ interface UserBorrowCardProps {
   unifiedMarket: UnifiedMarketData;
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
-  onRepay?: (position: UserBorrowPosition) => void;
+  onRepay: (market: UnifiedMarketData, max: boolean) => void;
   tokenTransferState: TokenTransferState;
 }
 
@@ -105,6 +105,7 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
       <CardFooter className="flex gap-2 p-4 pt-0">
         <AssetDetailsModal
           market={unifiedMarket}
+          borrowPosition={position}
           onSupply={onSupply}
           onBorrow={onBorrow}
           onRepay={onRepay}

--- a/src/components/ui/lending/UserBorrowContent.tsx
+++ b/src/components/ui/lending/UserBorrowContent.tsx
@@ -21,6 +21,7 @@ interface UserBorrowContentProps {
   sortConfig?: LendingSortConfig | null;
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
+  onRepay: (market: UnifiedMarketData, max: boolean) => void;
 }
 
 interface EnhancedUserBorrowPosition extends UserBorrowPosition {
@@ -38,6 +39,7 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
   sortConfig,
   onSupply,
   onBorrow,
+  onRepay,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -158,9 +160,7 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
           unifiedMarket={position.unifiedMarket}
           onSupply={onSupply}
           onBorrow={onBorrow}
-          onRepay={(position: UserBorrowPosition) => {
-            console.log(position); // TODO: update me
-          }}
+          onRepay={onRepay}
           tokenTransferState={tokenTransferState}
         />
       )}


### PR DESCRIPTION
branch off #355, #356, please see ada0a15b488c2d70389c3f74a4da35e0b9af42b1

---

this PR adds integrates the `useRepayOperations` hook into the lending `page.tsx`, as well as integrating the `RepayAssetModal` into the `AssetDetailsModal` (conditionally - only shown on open user borrow positions).