### PR TITLE
chore: added max withdraw handling

### DIFF
--- a/src/components/ui/lending/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetailsModal.tsx
@@ -36,7 +36,7 @@ interface AssetDetailsModalProps {
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
   onRepay?: (market: UnifiedMarketData, max: boolean) => void;
-  onWithdraw?: (market: UnifiedMarketData) => void;
+  onWithdraw?: (market: UnifiedMarketData, max: boolean) => void;
   tokenTransferState: TokenTransferState;
   supplyPosition?: UserSupplyPosition;
   borrowPosition?: UserBorrowPosition;

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -36,7 +36,7 @@ interface DashboardContentProps {
   onSubsectionChange?: (subsection: string) => void;
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
-  onWithdraw: (market: UnifiedMarketData) => void;
+  onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
   refetchMarkets?: () => void;
   onRepay: (market: UnifiedMarketData, max: boolean) => void;
 }
@@ -184,7 +184,7 @@ interface DashboardContentInnerProps {
   onSubsectionChange?: (subsection: string) => void;
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
-  onWithdraw: (market: UnifiedMarketData) => void;
+  onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
   refetchMarkets?: () => void;
   onRepay: (market: UnifiedMarketData, max: boolean) => void;
 }

--- a/src/components/ui/lending/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserSupplyCard.tsx
@@ -24,7 +24,7 @@ interface UserSupplyCardProps {
   unifiedMarket: UnifiedMarketData;
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
-  onWithdraw: (market: UnifiedMarketData) => void;
+  onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
   onToggleCollateral?: (position: UserSupplyPosition) => void;
   tokenTransferState: TokenTransferState;
 }

--- a/src/components/ui/lending/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserSupplyContent.tsx
@@ -21,7 +21,7 @@ interface UserSupplyContentProps {
   sortConfig?: LendingSortConfig | null;
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
-  onWithdraw: (market: UnifiedMarketData) => void;
+  onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
 }
 
 interface EnhancedUserSupplyPosition extends UserSupplyPosition {

--- a/src/hooks/aave/useAaveInteractions.ts
+++ b/src/hooks/aave/useAaveInteractions.ts
@@ -626,13 +626,17 @@ export const useAaveWithdraw = () => {
           amount: args.useNative
             ? {
                 native: {
-                  value: { exact: args.amount },
+                  value: args.max
+                    ? ({ max: true } as const)
+                    : ({ exact: args.amount } as const),
                 },
               }
             : {
                 erc20: {
                   currency: args.currency,
-                  value: { exact: args.amount },
+                  value: args.max
+                    ? ({ max: true } as const)
+                    : ({ exact: args.amount } as const),
                 },
               },
           sender: evmAddress(userAddress),

--- a/src/hooks/lending/useWithdrawOperations.ts
+++ b/src/hooks/lending/useWithdrawOperations.ts
@@ -28,7 +28,7 @@ export interface WithdrawOperationResult {
 }
 
 export interface WithdrawOperationHook {
-  handleWithdraw: (market: UnifiedMarketData) => Promise<void>;
+  handleWithdraw: (market: UnifiedMarketData, max: boolean) => Promise<void>;
   isLoading: boolean;
   error: string | null;
 }
@@ -55,7 +55,7 @@ export const useWithdrawOperations = (
   const { switchToChain } = useChainSwitch(marketChain);
 
   const handleWithdraw = useCallback(
-    async (market: UnifiedMarketData): Promise<void> => {
+    async (market: UnifiedMarketData, max: boolean): Promise<void> => {
       try {
         // Validate required dependencies
         if (!sourceToken || !tokenWithdrawState.amount || !userWalletAddress) {
@@ -99,6 +99,7 @@ export const useWithdrawOperations = (
           currency: evmAddress(sourceToken.address),
           chainId: market.marketInfo.chain.chainId as ChainId,
           useNative,
+          max: max,
         });
 
         // Handle the result

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -271,6 +271,8 @@ export interface WithdrawArgs {
   useNative?: boolean;
   /** Address to send withdrawn tokens to (if different from sender) */
   to?: EvmAddress;
+  /** Whether this is a max withdrawal */
+  max: boolean;
 }
 
 /**


### PR DESCRIPTION
this PR adds max withdrawal handling (like we have done with max repay transactions) as per [the docs](https://aave.com/docs/developers/aave-v3/markets/operations#withdraw-assets-prepare-the-execution-plan)