### PR TITLE
bugfix: removed quote error

### DIFF
--- a/src/components/ui/lending/SupplyAssetModal.tsx
+++ b/src/components/ui/lending/SupplyAssetModal.tsx
@@ -360,18 +360,6 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
               </div>
             ) : (
               <>
-                {/* Quote Error Display */}
-                {!isDirectSupply &&
-                  tokenTransferState.quoteError &&
-                  (!tokenTransferState.receiveAmount ||
-                    tokenTransferState.receiveAmount === "0") && (
-                    <div className="mb-3 p-3 bg-red-500/10 border border-red-500/20 rounded-lg">
-                      <div className="text-sm text-red-400">
-                        {tokenTransferState.quoteError}
-                      </div>
-                    </div>
-                  )}
-
                 <div className="space-y-3">
                   {isDirectSupply ? (
                     // Direct supply

--- a/src/types/web3.ts
+++ b/src/types/web3.ts
@@ -541,7 +541,6 @@ export interface TokenTransferState {
   quoteData: Quote[] | null;
   receiveAmount: string;
   isLoadingQuote: boolean;
-  quoteError: string | null;
 
   estimatedTimeSeconds: number | null;
 


### PR DESCRIPTION
this PR removes the `quoteError` entirely from the `useTokenTransfer` hook - I realise now that it isn't really necessary and the errors are already displayed by toast notifications - doubling up on these errors is just confusing.

Additionally, the `quoteError` handling was not done properly and was causing multiple quotes to run, delaying the time until a quote was actually received. with this change, I have noticed that quotes load around 3x faster.