### PR TITLE
feat: swap repay

### DIFF
--- a/src/components/ui/lending/WithdrawAssetModal.tsx
+++ b/src/components/ui/lending/WithdrawAssetModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -50,6 +50,23 @@ const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
   const maxWithdrawableTokensString =
     position?.supply.balance.amount.value || "0";
 
+  // Track if user clicked the max button
+  const [maxButtonClicked, setMaxButtonClicked] = useState(false);
+
+  // Reset max button state if user manually changes amount
+  useEffect(() => {
+    if (
+      maxButtonClicked &&
+      tokenTransferState.amount !== maxWithdrawableTokensString
+    ) {
+      setMaxButtonClicked(false);
+    }
+  }, [
+    tokenTransferState.amount,
+    maxWithdrawableTokensString,
+    maxButtonClicked,
+  ]);
+
   return (
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
@@ -92,7 +109,10 @@ const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
               <div className="mt-2 flex items-center gap-2">
                 <button
                   onClick={() => {
-                    tokenTransferState.setAmount(maxWithdrawableTokensString);
+                    tokenTransferState.setAmount(
+                      position.supply.balance.amount.value,
+                    );
+                    setMaxButtonClicked(true);
                   }}
                   className="px-1 py-0.5 rounded-md bg-green-500 bg-opacity-25 text-green-500 text-xs cursor-pointer"
                 >
@@ -204,11 +224,7 @@ const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
           </div>
           <BrandedButton
             onClick={async () => {
-              // Check if user is doing a max withdraw by comparing with the max withdrawable amount
-              const isMaxWithdraw =
-                parseFloat(tokenTransferState.amount || "0") ===
-                maxWithdrawableTokens;
-              onWithdraw(market, isMaxWithdraw);
+              onWithdraw(market, maxButtonClicked);
             }}
             disabled={
               !tokenTransferState.amount ||

--- a/src/utils/swap/mayanSwapMethods.ts
+++ b/src/utils/swap/mayanSwapMethods.ts
@@ -121,7 +121,7 @@ export async function executeEvmSwap({
   ];
   return TEST_SWAP_IDS[Math.floor(Math.random() * TEST_SWAP_IDS.length)];
   */
-  debugger;
+
   try {
     // Check if the quote is valid
     if (!quote) {

--- a/src/utils/swap/walletMethods.ts
+++ b/src/utils/swap/walletMethods.ts
@@ -1226,7 +1226,7 @@ export function useTokenTransfer(
         // Get Solana signer
         const solanaSigner = await getSolanaSigner();
         const connection = new Connection(
-          `https://solana-rpc.publicnode.com`,
+          `https://solana-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`,
           "confirmed",
         );
         // Execute Solana swap


### PR DESCRIPTION
this PR integrates swapping into repay. I have used the same approach as for swap supply here, nothing new.

Other semi-related changes:
- updated the logic for handling a `max` withdraw or repay - since the balance of the supply/borrow is constantly changing due to the APY, I found that even after clicking `max` it would not actually do the entire amount and you would be left with a fractional position. this has been resolved by explicitly calling the transaction with `max` regardless of the actual balance.
- updated the solana RPC url back to the alchemy one after I was let down once again

## Screenshots
### Desktop
<img width="3068" height="2068" alt="Screenshot 2025-09-13 at 4 27 29 pm" src="https://github.com/user-attachments/assets/274a0a61-74ee-4718-a5c3-24f13d704d01" />

### Tablet
<img width="1018" height="1362" alt="Screenshot 2025-09-13 at 4 39 35 pm" src="https://github.com/user-attachments/assets/d592c3ae-9f4c-49c7-8c4e-e16add7e21f6" />

### Mobile
<img width="854" height="1860" alt="Screenshot 2025-09-13 at 4 40 36 pm" src="https://github.com/user-attachments/assets/4b713e4c-79a6-4286-be7b-c788b3c8a5bb" />
