### PR TITLE
feat: collateral toggle modal

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -40,6 +40,7 @@ import { useSupplyOperations } from "@/hooks/lending/useSupplyOperations";
 import { useBorrowOperations } from "@/hooks/lending/useBorrowOperations";
 import { useWithdrawOperations } from "@/hooks/lending/useWithdrawOperations";
 import { useRepayOperations } from "@/hooks/lending/useRepayOperations";
+import { useCollateralToggleOperations } from "@/hooks/lending/useCollateralToggleOperations";
 
 type LendingTabType = "markets" | "dashboard" | "staking" | "history";
 
@@ -188,6 +189,11 @@ export default function LendingPage() {
     sourceToken,
     userWalletAddress: userWalletAddress || null,
     tokenRepayState: { amount: tokenTransferState.amount || "" },
+  });
+
+  const { handleCollateralToggle } = useCollateralToggleOperations({
+    userWalletAddress: userWalletAddress || null,
+    targetChain: sourceChain,
   });
 
   useEffect(() => {
@@ -381,6 +387,7 @@ export default function LendingPage() {
                         onWithdraw={handleWithdraw}
                         refetchMarkets={refetchMarkets}
                         onRepay={handleRepay}
+                        onCollateralToggle={handleCollateralToggle}
                       />
                     )}
                     {activeTab === "history" && (

--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -43,6 +43,7 @@ interface DashboardContentProps {
   onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
   refetchMarkets?: () => void;
   onRepay: (market: UnifiedMarketData, max: boolean) => void;
+  onCollateralToggle: (market: UnifiedMarketData) => void;
 }
 
 export default function DashboardContent({
@@ -57,6 +58,7 @@ export default function DashboardContent({
   onWithdraw,
   refetchMarkets,
   onRepay,
+  onCollateralToggle,
 }: DashboardContentProps) {
   // Calculate aggregated data from markets' internal userState
   const aggregatedUserState = useMemo(() => {
@@ -321,6 +323,7 @@ export default function DashboardContent({
                 onWithdraw={onWithdraw}
                 refetchMarkets={refetchMarkets}
                 onRepay={onRepay}
+                onCollateralToggle={onCollateralToggle}
               />
             );
           }}
@@ -386,6 +389,7 @@ interface DashboardContentInnerProps {
   onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
   refetchMarkets?: () => void;
   onRepay: (market: UnifiedMarketData, max: boolean) => void;
+  onCollateralToggle: (market: UnifiedMarketData) => void;
 }
 
 function DashboardContentInner({
@@ -411,6 +415,7 @@ function DashboardContentInner({
   onWithdraw,
   refetchMarkets,
   onRepay,
+  onCollateralToggle,
 }: DashboardContentInnerProps) {
   const [isSupplyMode, setIsSupplyMode] = useState(true);
   const [showAvailable, setShowAvailable] = useState(true);
@@ -659,6 +664,7 @@ function DashboardContentInner({
             onSupply={onSupply}
             onBorrow={onBorrow}
             onWithdraw={onWithdraw}
+            onCollateralToggle={onCollateralToggle}
           />
         ) : (
           <UserBorrowContent

--- a/src/components/ui/lending/ToggleCollateralModal.tsx
+++ b/src/components/ui/lending/ToggleCollateralModal.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/StyledDialog";
+import { BrandedButton } from "@/components/ui/BrandedButton";
+import { formatCurrency } from "@/utils/formatters";
+import { UserSupplyPosition } from "@/types/aave";
+import { Shield, ShieldOff, TrendingUp } from "lucide-react";
+import Image from "next/image";
+import SubscriptNumber from "@/components/ui/SubscriptNumber";
+
+interface ToggleCollateralModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  position: UserSupplyPosition;
+  onToggleCollateral: () => void;
+  isLoading?: boolean;
+}
+
+const ToggleCollateralModal: React.FC<ToggleCollateralModalProps> = ({
+  isOpen,
+  onClose,
+  position,
+  onToggleCollateral,
+  isLoading = false,
+}) => {
+  const { supply, marketName } = position;
+  const balanceAmount = supply.balance.amount.value;
+  const balanceUsd = parseFloat(supply.balance.usd) || 0;
+  const isCurrentlyCollateral = supply.isCollateral;
+  const canBeCollateral = supply.canBeCollateral;
+
+  const handleToggle = async () => {
+    onToggleCollateral();
+  };
+
+  // Don't render modal if asset can't be used as collateral
+  if (!canBeCollateral) {
+    return null;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-md bg-[#18181B] border border-[#27272A] text-white">
+        <DialogHeader className="border-b border-[#27272A] pb-4">
+          <DialogTitle className="text-lg font-semibold flex items-center gap-2">
+            {isCurrentlyCollateral ? (
+              <>
+                <ShieldOff className="w-5 h-5 text-red-500" />
+                disable collateral
+              </>
+            ) : (
+              <>
+                <Shield className="w-5 h-5 text-green-400" />
+                enable collateral
+              </>
+            )}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Asset Information */}
+          <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
+            <div className="flex items-center gap-3 mb-3">
+              <div className="relative">
+                <Image
+                  src={supply.currency.imageUrl || "/images/tokens/default.svg"}
+                  alt={supply.currency.symbol}
+                  width={32}
+                  height={32}
+                  className="rounded-full"
+                  onError={(e) => {
+                    e.currentTarget.src = "/images/tokens/default.svg";
+                  }}
+                />
+                <div className="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-[#18181B] border border-[#27272A] flex items-center justify-center">
+                  <Image
+                    src={
+                      supply.market.chain.icon || "/images/chains/default.svg"
+                    }
+                    alt={marketName}
+                    width={12}
+                    height={12}
+                    className="rounded-full"
+                    onError={(e) => {
+                      e.currentTarget.src = "/images/chains/default.svg";
+                    }}
+                  />
+                </div>
+              </div>
+              <div>
+                <div className="text-sm font-medium text-white">
+                  {supply.currency.symbol}
+                </div>
+                <div className="text-xs text-[#A1A1AA]">{marketName}</div>
+              </div>
+            </div>
+
+            {/* Supply Balance */}
+            <div className="space-y-2">
+              <div className="text-sm text-[#A1A1AA]">supply balance</div>
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col">
+                  <div className="text-lg font-mono font-semibold text-white">
+                    <SubscriptNumber value={balanceAmount} />{" "}
+                    <span className="text-base">{supply.currency.symbol}</span>
+                  </div>
+                  <div className="text-sm text-[#71717A] font-mono">
+                    {formatCurrency(balanceUsd)}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Health Factor Impact */}
+          <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <TrendingUp className="w-4 h-4 text-[#A1A1AA]" />
+              <span className="text-sm font-medium text-white">
+                health factor impact
+              </span>
+            </div>
+            <div className="text-xs text-[#A1A1AA] bg-amber-500/10 border border-amber-500/20 rounded p-2">
+              {isCurrentlyCollateral
+                ? "Disabling collateral may reduce your borrowing power and affect your health factor."
+                : "Enabling collateral will increase your borrowing power and improve your health factor."}
+            </div>
+          </div>
+
+          {/* Action Explanation */}
+          <div className="text-xs text-[#A1A1AA] text-center px-2">
+            {isCurrentlyCollateral
+              ? "This asset is currently being used as collateral for your borrows."
+              : "This asset is not currently being used as collateral."}
+          </div>
+
+          {/* Toggle Button */}
+          <BrandedButton
+            onClick={handleToggle}
+            disabled={isLoading}
+            className={`w-full py-3 font-medium transition-all duration-200 ${
+              isCurrentlyCollateral
+                ? "bg-red-500/20 hover:bg-red-500/30 text-red-300 hover:text-red-200 border-red-700/50 hover:border-red-600"
+                : "bg-green-500/20 hover:bg-green-500/30 text-green-300 hover:text-green-200 border-green-700/50 hover:border-green-600"
+            }`}
+            buttonText={
+              isLoading
+                ? "processing..."
+                : isCurrentlyCollateral
+                  ? "disable collateral"
+                  : "enable collateral"
+            }
+            iconName="Coins"
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ToggleCollateralModal;

--- a/src/components/ui/lending/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserSupplyCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import {
   Card,
   CardHeader,
@@ -16,6 +16,7 @@ import { formatCurrency, formatPercentage } from "@/utils/formatters";
 import { UserSupplyPosition, UnifiedMarketData } from "@/types/aave";
 import { Shield, ShieldOff } from "lucide-react";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetailsModal";
+import ToggleCollateralModal from "@/components/ui/lending/ToggleCollateralModal";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { TokenTransferState } from "@/types/web3";
 
@@ -25,8 +26,9 @@ interface UserSupplyCardProps {
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
   onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
-  onToggleCollateral?: (position: UserSupplyPosition) => void;
+  onCollateralToggle: (market: UnifiedMarketData) => void;
   tokenTransferState: TokenTransferState;
+  isCollateralLoading?: boolean;
 }
 
 const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
@@ -35,17 +37,25 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
   onSupply,
   onBorrow,
   onWithdraw,
-  onToggleCollateral,
+  onCollateralToggle,
   tokenTransferState,
+  isCollateralLoading = false,
 }) => {
   const { supply, marketName } = position;
   const balanceUsd = parseFloat(supply.balance.usd) || 0;
   const apy = parseFloat(supply.apy.value) || 0;
 
+  // State for collateral toggle modal
+  const [isCollateralModalOpen, setIsCollateralModalOpen] = useState(false);
+
   const handleCollateralToggle = () => {
-    if (onToggleCollateral) {
-      onToggleCollateral(position);
-    }
+    // Open the collateral toggle modal
+    setIsCollateralModalOpen(true);
+  };
+
+  const handleModalCollateralToggle = () => {
+    onCollateralToggle(unifiedMarket);
+    setIsCollateralModalOpen(false);
   };
 
   return (
@@ -144,7 +154,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
               checked={supply.isCollateral}
               onCheckedChange={handleCollateralToggle}
               className="data-[state=checked]:bg-green-600 data-[state=unchecked]:bg-[#3F3F46]"
-              disabled={!onToggleCollateral}
+              disabled={isCollateralLoading}
             />
           </div>
         </div>
@@ -167,6 +177,15 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
           />
         </AssetDetailsModal>
       </CardFooter>
+
+      {/* Collateral Toggle Modal */}
+      <ToggleCollateralModal
+        isOpen={isCollateralModalOpen}
+        onClose={() => setIsCollateralModalOpen(false)}
+        position={position}
+        onToggleCollateral={handleModalCollateralToggle}
+        isLoading={isCollateralLoading}
+      />
     </Card>
   );
 };

--- a/src/components/ui/lending/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserSupplyContent.tsx
@@ -22,6 +22,7 @@ interface UserSupplyContentProps {
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
   onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
+  onCollateralToggle: (market: UnifiedMarketData) => void;
 }
 
 interface EnhancedUserSupplyPosition extends UserSupplyPosition {
@@ -39,6 +40,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
   onSupply,
   onBorrow,
   onWithdraw,
+  onCollateralToggle,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -155,9 +157,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
           onSupply={onSupply}
           onBorrow={onBorrow}
           onWithdraw={onWithdraw}
-          onToggleCollateral={(position: UserSupplyPosition) => {
-            console.log(position); // TODO: update me
-          }}
+          onCollateralToggle={onCollateralToggle}
           tokenTransferState={tokenTransferState}
         />
       )}

--- a/src/hooks/lending/useCollateralToggleOperations.ts
+++ b/src/hooks/lending/useCollateralToggleOperations.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { evmAddress } from "@aave/react";
+import { useAaveCollateral } from "@/hooks/aave/useAaveInteractions";
+import { useChainSwitch } from "@/utils/swap/walletMethods";
+import { truncateAddress } from "@/utils/formatters";
+import { UnifiedMarketData, ChainId } from "@/types/aave";
+import { Chain } from "@/types/web3";
+import { getChainByChainId } from "@/config/chains";
+
+export interface CollateralToggleOperationDependencies {
+  userWalletAddress: string | null;
+  targetChain: Chain | null;
+}
+
+export interface CollateralToggleOperationResult {
+  success: boolean;
+  transactionHash?: string;
+  error?: string;
+}
+
+export interface CollateralToggleOperationHook {
+  handleCollateralToggle: (market: UnifiedMarketData) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const useCollateralToggleOperations = (
+  dependencies: CollateralToggleOperationDependencies,
+): CollateralToggleOperationHook => {
+  const { userWalletAddress, targetChain } = dependencies;
+  const {
+    executeCollateralToggle,
+    loading: collateralLoading,
+    error: collateralError,
+  } = useAaveCollateral();
+
+  let marketChain;
+  if (!targetChain) {
+    marketChain = getChainByChainId(1);
+    console.error("No target chain provided, defaulting to Ethereum mainnet");
+  } else {
+    marketChain = targetChain;
+  }
+
+  const { switchToChain } = useChainSwitch(marketChain);
+
+  const handleCollateralToggle = useCallback(
+    async (market: UnifiedMarketData): Promise<void> => {
+      try {
+        // Validate required dependencies
+        if (!userWalletAddress) {
+          console.error("Missing user wallet address");
+          toast.error("Missing wallet connection", {
+            description: "Please connect your wallet",
+          });
+          return;
+        }
+
+        if (!targetChain) {
+          console.error("Missing target chain");
+          toast.error("Missing target chain", {
+            description: "Please select a target chain",
+          });
+          return;
+        }
+
+        // Switch to correct chain FIRST before any operations
+        try {
+          await switchToChain(targetChain);
+        } catch (chainSwitchError) {
+          console.error("Chain switch failed:", chainSwitchError);
+          toast.error("Chain switch failed", {
+            description: "Please try manually switching chains",
+          });
+          return;
+        }
+
+        const collateralToastId = toast.loading(
+          "Toggling collateral status...",
+          {
+            description: "Please confirm the transaction in your wallet",
+          },
+        );
+
+        // Execute the collateral toggle operation
+        const result = await executeCollateralToggle({
+          market: evmAddress(market.marketInfo.address),
+          underlyingToken: evmAddress(market.underlyingToken.address),
+          user: evmAddress(userWalletAddress),
+          chainId: market.marketInfo.chain.chainId as ChainId,
+        });
+
+        // Handle the result
+        if (result.success) {
+          console.log("Collateral toggle successful:", result.transactionHash);
+          toast.success("Collateral status updated", {
+            id: collateralToastId,
+            description: `Transaction hash: ${truncateAddress(
+              result.transactionHash!,
+            )}`,
+          });
+        } else {
+          console.error("Collateral toggle failed:", result.error);
+          toast.error("Collateral toggle failed", {
+            id: collateralToastId,
+            description: result.error || "An unknown error occurred",
+          });
+        }
+      } catch (error) {
+        console.error("Collateral toggle operation failed:", error);
+        toast.error("Collateral toggle operation failed", {
+          description:
+            error instanceof Error
+              ? error.message
+              : "An unknown error occurred",
+        });
+      }
+    },
+    [userWalletAddress, targetChain, executeCollateralToggle, switchToChain],
+  );
+
+  return {
+    handleCollateralToggle,
+    isLoading: collateralLoading,
+    error: typeof collateralError === "string" ? collateralError : null,
+  };
+};

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -322,3 +322,34 @@ export interface EmodeState {
   loading: boolean;
   error: string | null;
 }
+
+/**
+ * Arguments for collateral toggle operations
+ */
+export interface CollateralArgs {
+  /** The market address */
+  market: EvmAddress;
+  /** The underlying token address to toggle collateral for */
+  underlyingToken: EvmAddress;
+  /** The user address */
+  user: EvmAddress;
+  /** The chain ID */
+  chainId: ChainId;
+}
+
+/**
+ * Result of a collateral toggle operation
+ */
+export interface CollateralResult {
+  success: boolean;
+  transactionHash?: string;
+  error?: string;
+}
+
+/**
+ * Loading state for collateral operations
+ */
+export interface CollateralState {
+  loading: boolean;
+  error: string | null;
+}


### PR DESCRIPTION
branch off #363, please see 0e97d1e0db0dbddf5066b802d91b5b457e05a1e8

---

this PR adds the `ToggleCollateralModal.tsx`. It is a relatively small and simple modal, showing only the current supply position balance, as well as a placeholder for what WILL be the health factor impact.

I have passed down the hook from `lending/page.tsx`, following the same clean pattern we have used for all interactions.

The only issue is that the toggle state is tied to what is received from the SDK call at the `page.tsx` level, so the toggle won't currently update until a refresh is done. 

> [!NOTE]
> the above point about manual refreshes is something we are planning to take care of for all interactions - currently all interactions require a manual refresh to get the latest state. in general, we should close the modal, and call a refresh as soon as a transaction has completed.

## Screenshots
### Desktop
**Enable**
<img width="3120" height="1988" alt="Screenshot 2025-09-13 at 9 19 57 pm" src="https://github.com/user-attachments/assets/f02a4dec-f65f-41fc-bd8e-f909690e337a" />
**Disable**
<img width="2596" height="2118" alt="Screenshot 2025-09-13 at 9 29 07 pm" src="https://github.com/user-attachments/assets/167e0e29-7efe-4627-9f1c-698f01684c90" />


### Tablet
<img width="1028" height="1368" alt="Screenshot 2025-09-13 at 9 21 00 pm" src="https://github.com/user-attachments/assets/adf0822c-9b7d-4440-832c-c1a8944cb153" />

### Mobile
<img width="854" height="1854" alt="Screenshot 2025-09-13 at 9 21 14 pm" src="https://github.com/user-attachments/assets/b5dfa88f-b102-4474-874a-0e1789cc9927" />

