### PR TITLE
fix: lending section informational & checkbox

### DIFF
--- a/src/components/ui/lending/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent.tsx
@@ -605,7 +605,7 @@ function DashboardContentInner({
 
           {/* Conditional Content */}
           <div className="flex items-center">
-            {(isSupplyMode && showAvailable) || !isSupplyMode ? (
+            {isSupplyMode && showAvailable ? (
               <label className="flex items-center space-x-2 cursor-pointer">
                 <input
                   type="checkbox"
@@ -617,14 +617,14 @@ function DashboardContentInner({
                   show assets with 0 balance
                 </span>
               </label>
-            ) : (
+            ) : !isSupplyMode && showAvailable ? (
               <div className="flex items-center space-x-1 text-sky-500">
                 <Info className="w-5 h-5" />
                 <span className="text-xs pl-1 sm:pl-0">
                   to borrow you need to supply assets to be used as collateral
                 </span>
               </div>
-            )}
+            ) : null}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Oddly enough there was a bug as to when the checkbox for `show assets with 0 balance` and the informational for `to borrow you need to supply assets to be used as collateral` was displayed...

This fix enforces the following:
- show the checkbox `show assets with 0 balance` for supply available
- show the informational `to borrow you need to supply assets to be used as collateral` for borrow available
- show nothing for supply open and borrow open

---

<img width="454" height="55" alt="image" src="https://github.com/user-attachments/assets/bc43d784-6db1-4375-900e-d8c7ebd3edbb" />
<img width="333" height="44" alt="image" src="https://github.com/user-attachments/assets/8d82854e-eaf5-403a-89a3-d0c5b055ed81" />
<img width="600" height="39" alt="image" src="https://github.com/user-attachments/assets/82965e9c-b0c1-4e53-89a5-b5c0de21c3e7" />
<img width="290" height="39" alt="image" src="https://github.com/user-attachments/assets/1324fbb2-b4fe-41de-841b-87943b57b0ef" />

---

checkbox functionality verified