### PR TITLE
feat: added health factor preview hooks

### DIFF
--- a/src/hooks/aave/useAaveInteractions.ts
+++ b/src/hooks/aave/useAaveInteractions.ts
@@ -7,6 +7,7 @@ import {
   useWithdraw,
   useUserEMode,
   useCollateralToggle,
+  useAaveHealthFactorPreview,
   evmAddress,
   signatureFrom,
 } from "@aave/react";
@@ -32,6 +33,8 @@ import {
   EvmAddress,
   BigDecimal,
   ChainId,
+  HealthFactorPreviewRequest,
+  HealthFactorPreviewResponse,
 } from "@/types/aave";
 import { useReownWalletProviderAndSigner } from "@/hooks/useReownWalletProviderAndSigner";
 import { useCallback, useState } from "react";
@@ -935,5 +938,40 @@ export const useAaveCollateral = () => {
     executeCollateralToggle,
     loading: state.loading || togglingCollateral.loading,
     error: state.error || togglingCollateral.error,
+  };
+};
+
+/**
+ * Hook for health factor preview operations
+ * Handles previewing health factor for different operations (borrow, supply, repay, withdraw)
+ */
+export const useHealthFactorPreview = () => {
+  const [preview, { loading, error }] = useAaveHealthFactorPreview();
+
+  const executePreview = useCallback(
+    async (
+      request: HealthFactorPreviewRequest,
+    ): Promise<HealthFactorPreviewResponse | null> => {
+      try {
+        const result = await preview(request);
+
+        if (result.isErr()) {
+          console.error("Health factor preview failed:", result.error);
+          throw result.error;
+        }
+
+        return result.value;
+      } catch (error) {
+        console.error("Health factor preview operation failed:", error);
+        throw error;
+      }
+    },
+    [preview],
+  );
+
+  return {
+    executePreview,
+    loading,
+    error,
   };
 };

--- a/src/hooks/lending/useHealthFactorPreviewOperations.ts
+++ b/src/hooks/lending/useHealthFactorPreviewOperations.ts
@@ -1,0 +1,245 @@
+"use client";
+
+import { useCallback } from "react";
+import { evmAddress, bigDecimal } from "@aave/react";
+import { useHealthFactorPreview } from "@/hooks/aave/useAaveInteractions";
+import {
+  UnifiedMarketData,
+  ChainId,
+  EvmAddress,
+  HealthFactorPreviewRequest,
+  HealthFactorPreviewOperation,
+  HealthFactorRiskLevel,
+} from "@/types/aave";
+import { Chain, Token } from "@/types/web3";
+
+export interface HealthFactorPreviewArgs {
+  operation: HealthFactorPreviewOperation;
+  market: UnifiedMarketData;
+  amount: string;
+  currency: EvmAddress;
+  chainId: ChainId;
+  userAddress: EvmAddress;
+  useNative?: boolean;
+  max?: boolean; // For repay/withdraw operations
+}
+
+export interface HealthFactorPreviewResult {
+  success: boolean;
+  healthFactorBefore?: string;
+  healthFactorAfter?: string;
+  liquidationRisk?: HealthFactorRiskLevel;
+  error?: string;
+}
+
+export interface HealthFactorPreviewOperationDependencies {
+  sourceChain: Chain | null;
+  sourceToken: Token | null;
+  userWalletAddress: string | null;
+}
+
+export interface HealthFactorPreviewOperationHook {
+  previewHealthFactor: (
+    args: Omit<HealthFactorPreviewArgs, "userAddress" | "chainId">,
+  ) => Promise<HealthFactorPreviewResult>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const useHealthFactorPreviewOperations = (
+  dependencies: HealthFactorPreviewOperationDependencies,
+): HealthFactorPreviewOperationHook => {
+  const { sourceChain, userWalletAddress } = dependencies;
+  const { executePreview, loading, error } = useHealthFactorPreview();
+
+  const previewHealthFactor = useCallback(
+    async (
+      args: Omit<HealthFactorPreviewArgs, "userAddress" | "chainId">,
+    ): Promise<HealthFactorPreviewResult> => {
+      try {
+        // Validate required dependencies
+        if (!userWalletAddress) {
+          return {
+            success: false,
+            error: "User wallet address is required",
+          };
+        }
+
+        if (!sourceChain) {
+          return {
+            success: false,
+            error: "Source chain is required",
+          };
+        }
+
+        const {
+          operation,
+          market,
+          amount,
+          currency,
+          useNative = false,
+          max = false,
+        } = args;
+
+        // Build the health factor preview request based on operation type
+        let previewRequest: HealthFactorPreviewRequest;
+
+        const userAddress = evmAddress(userWalletAddress);
+        const marketAddress = evmAddress(market.marketInfo.address);
+        const chainId = market.marketInfo.chain.chainId as ChainId;
+
+        switch (operation) {
+          case "borrow":
+            previewRequest = {
+              action: {
+                borrow: {
+                  market: marketAddress,
+                  amount: useNative
+                    ? {
+                        native: bigDecimal(amount),
+                      }
+                    : {
+                        erc20: {
+                          currency,
+                          value: bigDecimal(amount),
+                        },
+                      },
+                  sender: userAddress,
+                  chainId,
+                },
+              },
+            };
+            break;
+
+          case "supply":
+            previewRequest = {
+              action: {
+                supply: {
+                  market: marketAddress,
+                  amount: useNative
+                    ? {
+                        native: bigDecimal(amount),
+                      }
+                    : {
+                        erc20: {
+                          currency,
+                          value: bigDecimal(amount),
+                        },
+                      },
+                  sender: userAddress,
+                  chainId,
+                },
+              },
+            };
+            break;
+
+          case "repay":
+            previewRequest = {
+              action: {
+                repay: {
+                  market: marketAddress,
+                  amount: useNative
+                    ? {
+                        native: bigDecimal(amount), // For native repay, max logic should be handled at higher level
+                      }
+                    : {
+                        erc20: {
+                          currency,
+                          value: max
+                            ? ({ max: true } as const)
+                            : ({ exact: bigDecimal(amount) } as const),
+                        },
+                      },
+                  sender: userAddress,
+                  chainId,
+                },
+              },
+            };
+            break;
+
+          case "withdraw":
+            previewRequest = {
+              action: {
+                withdraw: {
+                  market: marketAddress,
+                  amount: useNative
+                    ? {
+                        native: {
+                          value: max
+                            ? ({ max: true } as const)
+                            : ({ exact: bigDecimal(amount) } as const),
+                        },
+                      }
+                    : {
+                        erc20: {
+                          currency,
+                          value: max
+                            ? ({ max: true } as const)
+                            : ({ exact: bigDecimal(amount) } as const),
+                        },
+                      },
+                  sender: userAddress,
+                  chainId,
+                },
+              },
+            };
+            break;
+
+          default:
+            return {
+              success: false,
+              error: `Unsupported operation: ${operation}`,
+            };
+        }
+
+        // Execute the health factor preview
+        const response = await executePreview(previewRequest);
+
+        if (!response) {
+          return {
+            success: false,
+            error: "Failed to get health factor preview response",
+          };
+        }
+
+        // Extract health factors from response
+        const healthFactorBefore = response.before?.toString();
+        const healthFactorAfter = response.after?.toString();
+
+        // Check if the operation would create liquidation risk
+        // Health factor < 1 indicates liquidation risk
+        // Health factor between 1 and 1.5 is a warning zone
+        const liquidationRisk = healthFactorAfter
+          ? parseFloat(healthFactorAfter) < 1.0
+            ? "danger"
+            : parseFloat(healthFactorAfter) < 1.5
+              ? "warning"
+              : "ok"
+          : "ok";
+
+        return {
+          success: true,
+          healthFactorBefore,
+          healthFactorAfter,
+          liquidationRisk,
+        };
+      } catch (error) {
+        console.error("Health factor preview failed:", error);
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Health factor preview failed",
+        };
+      }
+    },
+    [executePreview, userWalletAddress, sourceChain],
+  );
+
+  return {
+    previewHealthFactor,
+    isLoading: loading,
+    error: typeof error === "string" ? error : null,
+  };
+};

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -35,6 +35,8 @@ import type {
   UserUsageAsCollateralTransaction,
   UserLiquidationCallTransaction,
   Signature,
+  HealthFactorPreviewRequest,
+  HealthFactorPreviewResponse,
 } from "@aave/react";
 
 /**
@@ -79,6 +81,8 @@ export type {
   UserUsageAsCollateralTransaction,
   UserLiquidationCallTransaction,
   Signature,
+  HealthFactorPreviewRequest,
+  HealthFactorPreviewResponse,
 };
 
 export interface UserSupplyPosition {
@@ -353,3 +357,10 @@ export interface CollateralState {
   loading: boolean;
   error: string | null;
 }
+
+export type HealthFactorPreviewOperation =
+  | "borrow"
+  | "supply"
+  | "repay"
+  | "withdraw";
+export type HealthFactorRiskLevel = "ok" | "warning" | "danger";


### PR DESCRIPTION
this PR adds the health factor preview hook from the aave react sdk into `useAaveInteractions.ts`, along with the `useHealthFactorPreviewOperations.ts` hook which handles all of the extra conditional logic and parameters allowing this to be very easily injected into any operation that we need.

the operations hook defines the request that will be passed to the health factor preview hook for the following interaction types: borrow, supply, withdraw, repay.

along with the current and previous health factor value, a `HealthFactorRiskLevel` will also be returned with 3 options:
1. `ok` (> 1.5)
2. `warning `(> 1)
3. `danger` (<= 1)