### PR TITLE
feature: inject health factor into lending action modals

### DIFF
--- a/src/components/ui/lending/ActionModals/BorrowAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/BorrowAssetModal.tsx
@@ -25,6 +25,7 @@ interface BorrowAssetModalProps {
   children: React.ReactNode;
   onBorrow: (market: UnifiedMarketData) => void;
   tokenTransferState: TokenTransferState;
+  healthFactor?: string | null;
 }
 
 const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
@@ -32,6 +33,7 @@ const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
   children,
   tokenTransferState,
   onBorrow,
+  healthFactor,
 }) => {
   const sourceToken = useSourceToken();
   const sourceChain = useSourceChain();
@@ -175,6 +177,21 @@ const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
                   )}
                 </div>
               </div>
+
+              {/* Current Health Factor */}
+              {healthFactor && (
+                <div className="flex justify-between items-center py-2">
+                  <div className="flex items-center gap-2">
+                    <AlertTriangle className="w-3 h-3 text-yellow-400" />
+                    <span className="text-sm text-[#A1A1AA]">
+                      current health factor
+                    </span>
+                  </div>
+                  <div className="text-sm font-mono font-semibold text-blue-400">
+                    {parseFloat(healthFactor).toFixed(2)}
+                  </div>
+                </div>
+              )}
 
               {/* Health Factor Warning */}
               <div className="flex justify-between items-center py-2">

--- a/src/components/ui/lending/ActionModals/RepayAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/RepayAssetModal.tsx
@@ -40,6 +40,7 @@ interface RepayAssetModalProps {
   children: React.ReactNode;
   onRepay: (market: UnifiedMarketData, max: boolean) => void;
   tokenTransferState: TokenTransferState;
+  healthFactor?: string | null;
 }
 
 const RepayAssetModal: React.FC<RepayAssetModalProps> = ({
@@ -48,6 +49,7 @@ const RepayAssetModal: React.FC<RepayAssetModalProps> = ({
   children,
   tokenTransferState,
   onRepay,
+  healthFactor,
 }) => {
   const sourceToken = useSourceToken();
   const destinationToken = useDestinationToken();
@@ -620,16 +622,31 @@ const RepayAssetModal: React.FC<RepayAssetModalProps> = ({
                 </div>
               </div>
 
+              {/* Current Health Factor */}
+              {healthFactor && (
+                <div className="flex justify-between items-center py-1">
+                  <div className="flex items-center gap-2">
+                    <TrendingUp className="w-3 h-3 text-blue-400" />
+                    <span className="text-sm text-[#A1A1AA]">
+                      current health factor
+                    </span>
+                  </div>
+                  <div className="text-sm font-mono font-semibold text-blue-400">
+                    {parseFloat(healthFactor).toFixed(2)}
+                  </div>
+                </div>
+              )}
+
               {/* Health Factor Improvement */}
               <div className="flex justify-between items-center py-1">
                 <div className="flex items-center gap-2">
                   <TrendingUp className="w-3 h-3 text-green-400" />
                   <span className="text-sm text-[#A1A1AA]">
-                    health factor calculation
+                    repaying improves factor
                   </span>
                 </div>
                 <div className="text-sm font-mono font-semibold text-green-400">
-                  %x -&gt; %y
+                  reduces risk
                 </div>
               </div>
             </div>

--- a/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
@@ -45,6 +45,7 @@ interface SupplyAssetModalProps {
   onRepay?: (market: UserBorrowPosition) => void;
   onWithdraw?: (market: UserSupplyPosition) => void;
   tokenTransferState: TokenTransferState;
+  healthFactor?: string | null;
 }
 
 const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
@@ -52,6 +53,7 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
   children,
   tokenTransferState,
   onSupply,
+  healthFactor,
 }) => {
   const sourceToken = useSourceToken();
   const destinationToken = useDestinationToken();
@@ -568,6 +570,21 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
                   {market.supplyInfo.canBeCollateral ? "yes" : "no"}
                 </div>
               </div>
+
+              {/* Current Health Factor */}
+              {healthFactor && (
+                <div className="flex justify-between items-center py-2">
+                  <div className="flex items-center gap-2">
+                    <Shield className="w-3 h-3 text-[#A1A1AA]" />
+                    <span className="text-sm text-[#A1A1AA]">
+                      current health factor
+                    </span>
+                  </div>
+                  <div className="text-sm font-mono font-semibold text-blue-400">
+                    {parseFloat(healthFactor).toFixed(2)}
+                  </div>
+                </div>
+              )}
             </div>
           </div>
           <BrandedButton

--- a/src/components/ui/lending/ActionModals/ToggleCollateralModal.tsx
+++ b/src/components/ui/lending/ActionModals/ToggleCollateralModal.tsx
@@ -20,6 +20,7 @@ interface ToggleCollateralModalProps {
   position: UserSupplyPosition;
   onToggleCollateral: () => void;
   isLoading?: boolean;
+  healthFactor?: string | null;
 }
 
 const ToggleCollateralModal: React.FC<ToggleCollateralModalProps> = ({
@@ -28,6 +29,7 @@ const ToggleCollateralModal: React.FC<ToggleCollateralModalProps> = ({
   position,
   onToggleCollateral,
   isLoading = false,
+  healthFactor,
 }) => {
   const { supply, marketName } = position;
   const balanceAmount = supply.balance.amount.value;
@@ -126,6 +128,22 @@ const ToggleCollateralModal: React.FC<ToggleCollateralModalProps> = ({
                 health factor impact
               </span>
             </div>
+
+            {/* Current Health Factor */}
+            {healthFactor && (
+              <div className="flex justify-between items-center py-2 mb-2">
+                <div className="flex items-center gap-2">
+                  <Shield className="w-3 h-3 text-[#A1A1AA]" />
+                  <span className="text-xs text-[#A1A1AA]">
+                    current health factor
+                  </span>
+                </div>
+                <div className="text-xs font-mono font-semibold text-blue-400">
+                  {parseFloat(healthFactor).toFixed(2)}
+                </div>
+              </div>
+            )}
+
             <div className="text-xs text-[#A1A1AA] bg-amber-500/10 border border-amber-500/20 rounded p-2">
               {isCurrentlyCollateral
                 ? "Disabling collateral may reduce your borrowing power and affect your health factor."

--- a/src/components/ui/lending/ActionModals/WithdrawAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/WithdrawAssetModal.tsx
@@ -12,7 +12,7 @@ import { TokenTransferState } from "@/types/web3";
 import TokenInputGroup from "@/components/ui/TokenInputGroup";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import { formatCurrency, formatPercentage } from "@/utils/formatters";
-import { TrendingUp, AlertTriangle, Percent } from "lucide-react";
+import { TrendingUp, AlertTriangle, Percent, Shield } from "lucide-react";
 import { useSourceToken, useSourceChain } from "@/store/web3Store";
 import { ensureCorrectWalletTypeForChain } from "@/utils/swap/walletMethods";
 import { TokenImage } from "@/components/ui/TokenImage";
@@ -27,6 +27,7 @@ interface WithdrawAssetModalProps {
   children: React.ReactNode;
   onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
   tokenTransferState: TokenTransferState;
+  healthFactor?: string | null;
 }
 
 const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
@@ -35,6 +36,7 @@ const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
   children,
   tokenTransferState,
   onWithdraw,
+  healthFactor,
 }) => {
   const sourceToken = useSourceToken();
   const sourceChain = useSourceChain();
@@ -205,6 +207,21 @@ const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
                   )}
                 </div>
               </div>
+
+              {/* Current Health Factor */}
+              {healthFactor && (
+                <div className="flex justify-between items-center py-2">
+                  <div className="flex items-center gap-2">
+                    <Shield className="w-3 h-3 text-[#A1A1AA]" />
+                    <span className="text-sm text-[#A1A1AA]">
+                      current health factor
+                    </span>
+                  </div>
+                  <div className="text-sm font-mono font-semibold text-blue-400">
+                    {parseFloat(healthFactor).toFixed(2)}
+                  </div>
+                </div>
+              )}
 
               {/* Health Factor Warning (if applicable) */}
               {position?.supply.isCollateral && (

--- a/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
@@ -269,6 +269,9 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                 onSupply={onSupply}
                 onBorrow={onBorrow}
                 tokenTransferState={tokenTransferState}
+                healthFactor={
+                  market.marketInfo.userState?.healthFactor?.toString() || null
+                }
               >
                 <BrandedButton
                   iconName="TrendingUp"
@@ -289,6 +292,9 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                 market={market}
                 onBorrow={onBorrow}
                 tokenTransferState={tokenTransferState}
+                healthFactor={
+                  market.marketInfo.userState?.healthFactor?.toString() || null
+                }
               >
                 <BrandedButton
                   iconName="TrendingDown"
@@ -310,6 +316,9 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                 position={supplyPosition}
                 onWithdraw={onWithdraw}
                 tokenTransferState={tokenTransferState}
+                healthFactor={
+                  market.marketInfo.userState?.healthFactor?.toString() || null
+                }
               >
                 <BrandedButton
                   iconName="Coins"
@@ -331,6 +340,9 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                 position={borrowPosition}
                 onRepay={onRepay}
                 tokenTransferState={tokenTransferState}
+                healthFactor={
+                  market.marketInfo.userState?.healthFactor?.toString() || null
+                }
               >
                 <BrandedButton
                   iconName="Coins"

--- a/src/components/ui/lending/UserContent/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyCard.tsx
@@ -185,6 +185,9 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
         position={position}
         onToggleCollateral={handleModalCollateralToggle}
         isLoading={isCollateralLoading}
+        healthFactor={
+          unifiedMarket.marketInfo.userState?.healthFactor?.toString() || null
+        }
       />
     </Card>
   );


### PR DESCRIPTION
This PR is concerned with injecting the current health factor into lending action modals. This is a requirement of the health preview hooks as it is a parameter.

Responsivity of modals unaffected.

---

#### Verification & UI:

Market Cards  - Supply:

<img width="666" height="626" alt="image" src="https://github.com/user-attachments/assets/035f775f-9d69-47e2-a8e8-161e15ef6972" />

Market Cards - Borrow:

<img width="517" height="617" alt="image" src="https://github.com/user-attachments/assets/8753e803-cafc-4a7f-9db5-020b98c08824" />

Dashboard Cards - Supply:

<img width="510" height="518" alt="image" src="https://github.com/user-attachments/assets/5a6fab2a-de24-4093-8642-93b44b6a3b88" />

Dashboard Cards - Borrow:

<img width="487" height="611" alt="image" src="https://github.com/user-attachments/assets/060c94e6-6581-41f3-982f-31fabe468028" />

Dashboard Cards - Repay:

<img width="484" height="569" alt="image" src="https://github.com/user-attachments/assets/35985399-3f53-4a7a-a677-3396b2de57e7" />

Dashboard Cards - Withdraw:

<img width="484" height="616" alt="image" src="https://github.com/user-attachments/assets/1c3cc68e-521c-469e-b38e-7c8c19f59a1c" />

Dashboard Cards - Toggle Collateral:

<img width="436" height="495" alt="image" src="https://github.com/user-attachments/assets/291d9463-5ef8-455c-aad2-23ecf34af9a2" />