### PR TITLE
feat: added hf risk display

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -41,6 +41,7 @@ import { useBorrowOperations } from "@/hooks/lending/useBorrowOperations";
 import { useWithdrawOperations } from "@/hooks/lending/useWithdrawOperations";
 import { useRepayOperations } from "@/hooks/lending/useRepayOperations";
 import { useCollateralToggleOperations } from "@/hooks/lending/useCollateralToggleOperations";
+import { useHealthFactorPreviewOperations } from "@/hooks/lending/useHealthFactorPreviewOperations";
 
 type LendingTabType = "markets" | "dashboard" | "staking" | "history";
 
@@ -194,6 +195,12 @@ export default function LendingPage() {
   const { handleCollateralToggle } = useCollateralToggleOperations({
     userWalletAddress: userWalletAddress || null,
     targetChain: sourceChain,
+  });
+
+  const { previewHealthFactor } = useHealthFactorPreviewOperations({
+    sourceChain,
+    sourceToken,
+    userWalletAddress: userWalletAddress || null,
   });
 
   useEffect(() => {
@@ -408,6 +415,7 @@ export default function LendingPage() {
                           onWithdraw: handleWithdraw,
                           onRepay: handleRepay,
                           onCollateralToggle: handleCollateralToggle,
+                          onHealthFactorPreview: previewHealthFactor,
                         }}
                       />
                     )}

--- a/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
@@ -29,6 +29,10 @@ import { getLendingToken } from "@/utils/lending/tokens";
 import BorrowAssetModal from "@/components/ui/lending/ActionModals/BorrowAssetModal";
 import WithdrawAssetModal from "@/components/ui/lending/ActionModals/WithdrawAssetModal";
 import RepayAssetModal from "@/components/ui/lending/ActionModals/RepayAssetModal";
+import {
+  HealthFactorPreviewArgs,
+  HealthFactorPreviewResult,
+} from "@/hooks/lending/useHealthFactorPreviewOperations";
 
 interface AssetDetailsModalProps {
   market: UnifiedMarketData;
@@ -41,6 +45,9 @@ interface AssetDetailsModalProps {
   supplyPosition?: UserSupplyPosition;
   borrowPosition?: UserBorrowPosition;
   buttonsToShow: ctaButtons[];
+  onHealthFactorPreview?: (
+    args: HealthFactorPreviewArgs,
+  ) => Promise<HealthFactorPreviewResult>;
 }
 
 type TabType = "user" | "supply" | "borrow" | "emode" | "asset";

--- a/src/components/ui/lending/AssetDetails/HealthFactorRiskDisplay.tsx
+++ b/src/components/ui/lending/AssetDetails/HealthFactorRiskDisplay.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import React from "react";
+import { ArrowRight, AlertTriangle, CheckCircle } from "lucide-react";
+import { formatHealthFactor } from "@/utils/formatters";
+
+export interface HealthFactorRiskDisplayProps {
+  healthFactorBefore?: string;
+  healthFactorAfter?: string;
+  liquidationRisk?: "ok" | "warning" | "danger";
+  className?: string;
+}
+
+export default function HealthFactorRiskDisplay({
+  healthFactorBefore,
+  healthFactorAfter,
+  liquidationRisk = "ok",
+  className = "",
+}: HealthFactorRiskDisplayProps) {
+  const getRiskIcon = (risk: "ok" | "warning" | "danger") => {
+    switch (risk) {
+      case "ok":
+        return <CheckCircle className="w-4 h-4 text-green-500" />;
+      case "warning":
+        return <AlertTriangle className="w-4 h-4 text-amber-500" />;
+      case "danger":
+        return <AlertTriangle className="w-4 h-4 text-red-500" />;
+      default:
+        return null;
+    }
+  };
+
+  const getRiskLabel = (risk: "ok" | "warning" | "danger") => {
+    switch (risk) {
+      case "ok":
+        return "safe";
+      case "warning":
+        return "caution";
+      case "danger":
+        return "liquidation risk";
+      default:
+        return "";
+    }
+  };
+
+  const getRiskColor = (risk: "ok" | "warning" | "danger") => {
+    switch (risk) {
+      case "ok":
+        return "text-green-500";
+      case "warning":
+        return "text-amber-500";
+      case "danger":
+        return "text-red-500";
+      default:
+        return "text-[#A1A1AA]";
+    }
+  };
+
+  const formattedBefore = formatHealthFactor(healthFactorBefore || null);
+  const formattedAfter = formatHealthFactor(healthFactorAfter || null);
+
+  return (
+    <div
+      className={`bg-[#1F1F23] border border-[#27272A] rounded-lg p-4 space-y-3 ${className}`}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-[#FAFAFA] font-medium text-sm">
+          health factor impact
+        </h3>
+        <div className="flex items-center gap-2">
+          {getRiskIcon(liquidationRisk)}
+          <span
+            className={`text-xs font-medium ${getRiskColor(liquidationRisk)}`}
+          >
+            {getRiskLabel(liquidationRisk)}
+          </span>
+        </div>
+      </div>
+
+      {/* Health Factor Values */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          {/* Before Value */}
+          <div className="text-center">
+            <div className="text-[#A1A1AA] text-xs mb-1">current</div>
+            <div
+              className={`text-sm font-mono font-semibold ${formattedBefore.colorClass}`}
+            >
+              {formattedBefore.value}
+            </div>
+          </div>
+
+          {/* Arrow */}
+          <ArrowRight className="w-4 h-4 text-[#A1A1AA]" />
+
+          {/* After Value */}
+          <div className="text-center">
+            <div className="text-[#A1A1AA] text-xs mb-1">new</div>
+            <div
+              className={`text-sm font-mono font-semibold ${formattedAfter.colorClass}`}
+            >
+              {formattedAfter.value}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Risk Message */}
+      <div className="text-[#A1A1AA] text-xs leading-relaxed">
+        {liquidationRisk === "danger" && (
+          <span className="text-red-400">
+            this transaction will put you at risk of liquidation.
+          </span>
+        )}
+        {liquidationRisk === "warning" && (
+          <span className="text-amber-400">
+            caution: health factor will be in the warning zone. consider the
+            risks before proceeding.
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/lending/DashboardContent/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent/DashboardContent.tsx
@@ -19,6 +19,10 @@ import RiskDetailsModal from "@/components/ui/lending/DashboardContent/RiskDetai
 import EmodeModal from "@/components/ui/lending/DashboardContent/EmodeModal";
 import { TokenTransferState } from "@/types/web3";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
+import {
+  HealthFactorPreviewArgs,
+  HealthFactorPreviewResult,
+} from "@/hooks/lending/useHealthFactorPreviewOperations";
 
 interface DashboardContentProps {
   userAddress: string;
@@ -49,6 +53,9 @@ interface DashboardContentProps {
     onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
     onRepay: (market: UnifiedMarketData, max: boolean) => void;
     onCollateralToggle: (market: UnifiedMarketData) => void;
+    onHealthFactorPreview: (
+      args: HealthFactorPreviewArgs,
+    ) => Promise<HealthFactorPreviewResult>;
   };
 }
 
@@ -324,6 +331,7 @@ export default function DashboardContent({
             onBorrow={actions.onBorrow}
             onWithdraw={actions.onWithdraw}
             onCollateralToggle={actions.onCollateralToggle}
+            onHealthFactorPreview={actions.onHealthFactorPreview}
           />
         ) : (
           <UserBorrowContent

--- a/src/components/ui/lending/UserContent/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyCard.tsx
@@ -19,6 +19,10 @@ import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetails
 import ToggleCollateralModal from "@/components/ui/lending/ActionModals/ToggleCollateralModal";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { TokenTransferState } from "@/types/web3";
+import {
+  HealthFactorPreviewArgs,
+  HealthFactorPreviewResult,
+} from "@/hooks/lending/useHealthFactorPreviewOperations";
 
 interface UserSupplyCardProps {
   position: UserSupplyPosition;
@@ -29,6 +33,9 @@ interface UserSupplyCardProps {
   onCollateralToggle: (market: UnifiedMarketData) => void;
   tokenTransferState: TokenTransferState;
   isCollateralLoading?: boolean;
+  onHealthFactorPreview?: (
+    args: HealthFactorPreviewArgs,
+  ) => Promise<HealthFactorPreviewResult>;
 }
 
 const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
@@ -40,6 +47,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
   onCollateralToggle,
   tokenTransferState,
   isCollateralLoading = false,
+  onHealthFactorPreview,
 }) => {
   const { supply, marketName } = position;
   const balanceUsd = parseFloat(supply.balance.usd) || 0;
@@ -166,6 +174,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
           onSupply={onSupply}
           onBorrow={onBorrow}
           onWithdraw={onWithdraw}
+          onHealthFactorPreview={onHealthFactorPreview}
           tokenTransferState={tokenTransferState}
           supplyPosition={position}
           buttonsToShow={["supply", "withdraw"]}

--- a/src/components/ui/lending/UserContent/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyContent.tsx
@@ -12,6 +12,10 @@ import {
 import { unifyMarkets } from "@/utils/lending/unifyMarkets";
 import { TokenTransferState } from "@/types/web3";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
+import {
+  HealthFactorPreviewArgs,
+  HealthFactorPreviewResult,
+} from "@/hooks/lending/useHealthFactorPreviewOperations";
 
 interface UserSupplyContentProps {
   marketSupplyData: Record<string, UserSupplyData>;
@@ -23,6 +27,9 @@ interface UserSupplyContentProps {
   onBorrow: (market: UnifiedMarketData) => void;
   onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
   onCollateralToggle: (market: UnifiedMarketData) => void;
+  onHealthFactorPreview?: (
+    args: HealthFactorPreviewArgs,
+  ) => Promise<HealthFactorPreviewResult>;
 }
 
 interface EnhancedUserSupplyPosition extends UserSupplyPosition {
@@ -41,6 +48,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
   onBorrow,
   onWithdraw,
   onCollateralToggle,
+  onHealthFactorPreview,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -159,6 +167,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
           onWithdraw={onWithdraw}
           onCollateralToggle={onCollateralToggle}
           tokenTransferState={tokenTransferState}
+          onHealthFactorPreview={onHealthFactorPreview}
         />
       )}
       currentPage={currentPage}


### PR DESCRIPTION
this PR adds a component for health factor risk display. this should be used to replace any current health factor visualisation placeholder that is used on cards. the component takes in the exact response we get from the preview health factor hook so is ready for direct integration.

in this PR, I have also begun the proces of passing down the `useHealthFactorPreviewOperations` hook down from `page.tsx` to the open supply `AssetDetailsModal.tsx` - starting with just this one so we can use it as our testing grounds for integration.

> [!NOTE]
> this pr does not integrate it into the `AssetDetailsModal` yet.

## Screenshots
**Different states, not device specific as these are not yet on modals**
<img width="684" height="292" alt="Screenshot 2025-09-14 at 9 08 28 pm" src="https://github.com/user-attachments/assets/73f47b32-edd6-4131-9fbd-8d8ed0b4e9ee" />
<img width="678" height="366" alt="Screenshot 2025-09-14 at 9 08 35 pm" src="https://github.com/user-attachments/assets/bd539bf5-feee-4f84-b4ed-09c72c97c919" />
<img width="680" height="308" alt="Screenshot 2025-09-14 at 9 08 40 pm" src="https://github.com/user-attachments/assets/93b279ca-ea55-4067-ab02-041b0f38e07b" />
