### PR TITLE
feat: consolidate lending types into UnifiedMarketData

### DIFF
--- a/src/components/ui/lending/AvailableContent/AvailableBorrowContent.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowContent.tsx
@@ -3,13 +3,12 @@
 import React, { useState } from "react";
 import AvailableBorrowCard from "@/components/ui/lending/AvailableContent/AvailableBorrowCard";
 import CardsList from "@/components/ui/CardsList";
-import { Market, UnifiedMarketData } from "@/types/aave";
-import { unifyMarkets } from "@/utils/lending/unifyMarkets";
+import { UnifiedMarketData } from "@/types/aave";
 import { TokenTransferState } from "@/types/web3";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
 
 interface AvailableBorrowContentProps {
-  markets: Market[] | null | undefined;
+  markets: UnifiedMarketData[];
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
@@ -29,8 +28,7 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
-  const unifiedMarkets = unifyMarkets(markets!);
-  let availableBorrowMarkets = unifiedMarkets.filter((market) => {
+  let availableBorrowMarkets = markets.filter((market) => {
     // Filter out disabled markets
     return (
       !market.isFrozen &&

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyContent.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyContent.tsx
@@ -3,13 +3,12 @@
 import React, { useState } from "react";
 import AvailableSupplyCard from "@/components/ui/lending/AvailableContent/AvailableSupplyCard";
 import CardsList from "@/components/ui/CardsList";
-import { Market, UnifiedMarketData } from "@/types/aave";
-import { unifyMarkets } from "@/utils/lending/unifyMarkets";
+import { UnifiedMarketData } from "@/types/aave";
 import { TokenTransferState } from "@/types/web3";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
 
 interface AvailableSupplyContentProps {
-  markets: Market[] | null | undefined;
+  markets: UnifiedMarketData[];
   showZeroBalance?: boolean;
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
@@ -31,8 +30,7 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
-  const unifiedMarkets = unifyMarkets(markets!);
-  let availableSupplyMarkets = unifiedMarkets.filter((market) => {
+  let availableSupplyMarkets = markets.filter((market) => {
     if (showZeroBalance) return true;
     if (!market.userState) return false;
     const userBalance = parseFloat(market.userState.balance.amount.value) || 0;

--- a/src/components/ui/lending/DashboardContent/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent/DashboardContent.tsx
@@ -23,6 +23,7 @@ import {
   HealthFactorPreviewArgs,
   HealthFactorPreviewResult,
 } from "@/hooks/lending/useHealthFactorPreviewOperations";
+import { unifyMarkets } from "@/utils/lending/unifyMarkets";
 
 interface DashboardContentProps {
   userAddress: string;
@@ -46,7 +47,6 @@ interface DashboardContentProps {
   sortConfig?: LendingSortConfig | null;
   onSubsectionChange?: (subsection: string) => void;
   refetchMarkets?: () => void;
-  // Action handlers grouped together
   actions: {
     onSupply: (market: UnifiedMarketData) => void;
     onBorrow: (market: UnifiedMarketData) => void;
@@ -81,6 +81,13 @@ export default function DashboardContent({
   const [showZeroBalance, setShowZeroBalance] = useState(false);
   const [isRiskDetailsModalOpen, setIsRiskDetailsModalOpen] = useState(false);
   const [isEmodeModalOpen, setIsEmodeModalOpen] = useState(false);
+
+  // Create unified markets with all data
+  const unifiedMarkets = unifyMarkets(
+    activeMarkets,
+    marketSupplyData,
+    marketBorrowData,
+  );
 
   // Notify parent of subsection changes
   useEffect(() => {
@@ -301,7 +308,7 @@ export default function DashboardContent({
           // Show available positions
           isSupplyMode ? (
             <AvailableSupplyContent
-              markets={activeMarkets}
+              markets={unifiedMarkets}
               showZeroBalance={showZeroBalance}
               tokenTransferState={tokenTransferState}
               filters={filters}
@@ -311,7 +318,7 @@ export default function DashboardContent({
             />
           ) : (
             <AvailableBorrowContent
-              markets={activeMarkets}
+              markets={unifiedMarkets}
               tokenTransferState={tokenTransferState}
               filters={filters}
               sortConfig={sortConfig}
@@ -322,8 +329,7 @@ export default function DashboardContent({
         ) : // Show open positions
         isSupplyMode ? (
           <UserSupplyContent
-            marketSupplyData={marketSupplyData}
-            activeMarkets={activeMarkets}
+            markets={unifiedMarkets}
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
@@ -335,9 +341,8 @@ export default function DashboardContent({
           />
         ) : (
           <UserBorrowContent
-            marketBorrowData={marketBorrowData}
+            markets={unifiedMarkets}
             showZeroBalance={showZeroBalance}
-            activeMarkets={activeMarkets}
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}

--- a/src/components/ui/lending/UserContent/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyContent.tsx
@@ -3,13 +3,7 @@
 import React, { useState } from "react";
 import UserSupplyCard from "@/components/ui/lending/UserContent/UserSupplyCard";
 import CardsList from "@/components/ui/CardsList";
-import {
-  UserSupplyData,
-  UserSupplyPosition,
-  Market,
-  UnifiedMarketData,
-} from "@/types/aave";
-import { unifyMarkets } from "@/utils/lending/unifyMarkets";
+import { UserSupplyPosition, UnifiedMarketData } from "@/types/aave";
 import { TokenTransferState } from "@/types/web3";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
 import {
@@ -18,8 +12,7 @@ import {
 } from "@/hooks/lending/useHealthFactorPreviewOperations";
 
 interface UserSupplyContentProps {
-  marketSupplyData: Record<string, UserSupplyData>;
-  activeMarkets: Market[];
+  markets: UnifiedMarketData[];
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
@@ -39,8 +32,7 @@ interface EnhancedUserSupplyPosition extends UserSupplyPosition {
 const ITEMS_PER_PAGE = 10;
 
 const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
-  marketSupplyData,
-  activeMarkets,
+  markets,
   tokenTransferState,
   filters,
   sortConfig,
@@ -52,34 +44,18 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
-  const unifiedMarkets = unifyMarkets(activeMarkets);
-
-  // lookup map for unified markets by currency address and chain
-  const unifiedMarketMap = new Map<string, UnifiedMarketData>();
-  unifiedMarkets.forEach((market) => {
-    const key = `${market.underlyingToken.address.toLowerCase()}-${market.marketInfo.chain.chainId}`;
-    unifiedMarketMap.set(key, market);
-  });
-
   const enhancedPositions: EnhancedUserSupplyPosition[] = [];
 
-  Object.values(marketSupplyData).forEach((marketData) => {
-    if (marketData.supplies && marketData.supplies.length > 0) {
-      marketData.supplies.forEach((supply) => {
-        const currencyKey = `${supply.currency.address.toLowerCase()}-${marketData.chainId}`;
-        const unifiedMarket = unifiedMarketMap.get(currencyKey);
-
-        if (unifiedMarket) {
-          enhancedPositions.push({
-            marketAddress: marketData.marketAddress,
-            marketName: marketData.marketName,
-            chainId: marketData.chainId,
-            supply,
-            unifiedMarket,
-          });
-        }
+  markets.forEach((market) => {
+    market.userSupplyPositions.forEach((supply) => {
+      enhancedPositions.push({
+        marketAddress: market.marketInfo.address,
+        marketName: market.marketName,
+        chainId: market.marketInfo.chain.chainId,
+        supply,
+        unifiedMarket: market,
       });
-    }
+    });
   });
 
   // Apply asset filter

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -175,6 +175,8 @@ export interface UnifiedMarketData extends Reserve {
   usdExchangeRate: number;
   isFrozen: boolean;
   isPaused: boolean;
+  userSupplyPositions: MarketUserReserveSupplyPosition[];
+  userBorrowPositions: MarketUserReserveBorrowPosition[];
 }
 
 export type EModeStatus = "on" | "off" | "mixed";


### PR DESCRIPTION
This PR is concerned with extending the `UnifiedMarketData` type to hold the user borrow and supply positions and passing it to all content sections in the dashboard. The unification will further be moved up so that the enriched market data with positions can be passed to the market content sections as well. The actions will also be moved up.

All functionality verified to still work.