### PR TITLE
feat: store e-mode category data in UnifiedMarketData

### DIFF
--- a/src/components/ui/lending/ActionModals/EmodeModal.tsx
+++ b/src/components/ui/lending/ActionModals/EmodeModal.tsx
@@ -51,7 +51,6 @@ export default function EmodeModal({
     hasIncompatiblePositions,
     getMarketsWithEmode,
     getCategoryOptions,
-    getCurrentEmodeCategory,
   } = useEmodeOperations({
     userAddress,
     unifiedMarkets,
@@ -87,7 +86,8 @@ export default function EmodeModal({
   }, [isOpen, marketsWithEmode, selectedMarketKey]);
 
   // Get current emode category and category options using the hook
-  const currentEmodeCategory = getCurrentEmodeCategory(selectedMarketData);
+  const currentEmodeCategory =
+    selectedMarketData?.unifiedMarket?.emodeCategory?.id;
   const categoryOptions = getCategoryOptions(selectedMarketData);
 
   const selectedCategory = categoryOptions.find(

--- a/src/hooks/lending/useEmodeOperations.ts
+++ b/src/hooks/lending/useEmodeOperations.ts
@@ -73,16 +73,6 @@ export interface EmodeOperationHook {
     category: EmodeMarketCategory;
     isCurrentlyEnabled: boolean;
   }>;
-  getCurrentEmodeCategory: (
-    selectedMarketData:
-      | {
-          key: string;
-          label: string;
-          unifiedMarket: UnifiedMarketData;
-          categories: EmodeMarketCategory[];
-        }
-      | undefined,
-  ) => number | undefined;
 }
 
 export const useEmodeOperations = (
@@ -125,25 +115,6 @@ export const useEmodeOperations = (
         return true;
       });
   }, [unifiedMarkets]);
-
-  // Get current emode category for a selected market
-  const getCurrentEmodeCategory = useCallback(
-    (
-      selectedMarketData:
-        | {
-            key: string;
-            label: string;
-            unifiedMarket: UnifiedMarketData;
-            categories: EmodeMarketCategory[];
-          }
-        | undefined,
-    ) => {
-      return selectedMarketData?.unifiedMarket.marketInfo.borrowReserves?.find(
-        (reserve) => reserve.userState?.emode?.categoryId !== undefined,
-      )?.userState?.emode?.categoryId;
-    },
-    [],
-  );
 
   // Get category options for selected market
   const getCategoryOptions = useCallback(
@@ -318,6 +289,5 @@ export const useEmodeOperations = (
     hasIncompatiblePositions,
     getMarketsWithEmode,
     getCategoryOptions,
-    getCurrentEmodeCategory,
   };
 };

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -183,6 +183,7 @@ export interface UnifiedMarketData extends Reserve {
   isPaused: boolean;
   userSupplyPositions: MarketUserReserveSupplyPosition[];
   userBorrowPositions: MarketUserReserveBorrowPosition[];
+  emodeCategory: EmodeMarketCategory | null;
 }
 
 export type EModeStatus = "on" | "off" | "mixed";

--- a/src/utils/lending/unifyMarkets.ts
+++ b/src/utils/lending/unifyMarkets.ts
@@ -5,6 +5,13 @@ import {
   UserBorrowData,
 } from "@/types/aave";
 
+// Helper function to get the active emode data for a market
+const getActiveEmodeData = (market: Market) => {
+  return market.borrowReserves?.find(
+    (reserve) => reserve.userState?.emode !== undefined,
+  )?.userState?.emode;
+};
+
 export const unifyMarkets = (
   markets: Market[],
   marketSupplyData?: Record<string, UserSupplyData>,
@@ -13,6 +20,9 @@ export const unifyMarkets = (
   return markets.flatMap((market) => {
     // Create a map of assets by their underlying token address
     const assetMap = new Map();
+
+    // Get the active emode data for this market
+    const activeEmodeData = getActiveEmodeData(market);
 
     // Find user data for this market
     const userSupplyForMarket = marketSupplyData
@@ -63,6 +73,7 @@ export const unifyMarkets = (
         incentives: reserve.incentives || [],
         userSupplyPositions,
         userBorrowPositions: [],
+        emodeCategory: activeEmodeData || null,
       });
     });
 
@@ -112,6 +123,7 @@ export const unifyMarkets = (
           incentives: reserve.incentives || [],
           userSupplyPositions: [],
           userBorrowPositions,
+          emodeCategory: activeEmodeData || null,
         });
       }
     });


### PR DESCRIPTION
This PR is concerned with storing the current e-mode category in `UnifiedMarketData` so that it is accessible for each market throughout all the lending content sections and cards. We can now compute what reserves should be labelled as unborrowable, where we should disable buttons to borrow, etc.