### PR TITLE
feat: added health factor display to collateral toggle modal

### DIFF
--- a/src/components/ui/lending/ActionModals/ToggleCollateralModal.tsx
+++ b/src/components/ui/lending/ActionModals/ToggleCollateralModal.tsx
@@ -9,18 +9,20 @@ import {
 } from "@/components/ui/StyledDialog";
 import { BrandedButton } from "@/components/ui/BrandedButton";
 import { formatCurrency } from "@/utils/formatters";
-import { UserSupplyPosition } from "@/types/aave";
-import { Shield, ShieldOff, TrendingUp } from "lucide-react";
+import { EnhancedUserSupplyPosition } from "@/types/aave";
+import { getChainByChainId } from "@/config/chains";
+import { Shield, ShieldOff } from "lucide-react";
 import Image from "next/image";
 import SubscriptNumber from "@/components/ui/SubscriptNumber";
+import HealthFactorRiskDisplay from "@/components/ui/lending/AssetDetails/HealthFactorRiskDisplay";
 
 interface ToggleCollateralModalProps {
   isOpen: boolean;
   onClose: () => void;
-  position: UserSupplyPosition;
+  position: EnhancedUserSupplyPosition;
   onToggleCollateral: () => void;
   isLoading?: boolean;
-  healthFactor?: string | null;
+  userAddress?: string;
 }
 
 const ToggleCollateralModal: React.FC<ToggleCollateralModalProps> = ({
@@ -29,13 +31,31 @@ const ToggleCollateralModal: React.FC<ToggleCollateralModalProps> = ({
   position,
   onToggleCollateral,
   isLoading = false,
-  healthFactor,
+  userAddress,
 }) => {
   const { supply, marketName } = position;
   const balanceAmount = supply.balance.amount.value;
   const balanceUsd = parseFloat(supply.balance.usd) || 0;
   const isCurrentlyCollateral = supply.isCollateral;
   const canBeCollateral = supply.canBeCollateral;
+
+  const marketChain = getChainByChainId(
+    position.unifiedMarket.market.chain.chainId,
+  );
+
+  // Convert currency to token format
+  const sourceToken = {
+    id: supply.currency.name,
+    ticker: supply.currency.symbol,
+    chainId: position.unifiedMarket.market.chain.chainId,
+    stringChainId: marketChain.id,
+    decimals: supply.currency.decimals,
+    address: supply.currency.address,
+    symbol: supply.currency.symbol,
+    name: supply.currency.name || supply.currency.symbol,
+    imageUrl: supply.currency.imageUrl,
+    icon: supply.currency.imageUrl,
+  };
 
   const handleToggle = async () => {
     onToggleCollateral();
@@ -120,36 +140,15 @@ const ToggleCollateralModal: React.FC<ToggleCollateralModalProps> = ({
             </div>
           </div>
 
-          {/* Health Factor Impact */}
-          <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
-            <div className="flex items-center gap-2 mb-3">
-              <TrendingUp className="w-4 h-4 text-[#A1A1AA]" />
-              <span className="text-sm font-medium text-white">
-                health factor impact
-              </span>
-            </div>
-
-            {/* Current Health Factor */}
-            {healthFactor && (
-              <div className="flex justify-between items-center py-2 mb-2">
-                <div className="flex items-center gap-2">
-                  <Shield className="w-3 h-3 text-[#A1A1AA]" />
-                  <span className="text-xs text-[#A1A1AA]">
-                    current health factor
-                  </span>
-                </div>
-                <div className="text-xs font-mono font-semibold text-blue-400">
-                  {parseFloat(healthFactor).toFixed(2)}
-                </div>
-              </div>
-            )}
-
-            <div className="text-xs text-[#A1A1AA] bg-amber-500/10 border border-amber-500/20 rounded p-2">
-              {isCurrentlyCollateral
-                ? "Disabling collateral may reduce your borrowing power and affect your health factor."
-                : "Enabling collateral will increase your borrowing power and improve your health factor."}
-            </div>
-          </div>
+          {/* Health Factor Risk Display */}
+          <HealthFactorRiskDisplay
+            amount={balanceAmount}
+            sourceToken={sourceToken}
+            userAddress={userAddress}
+            market={position.unifiedMarket}
+            operation={isCurrentlyCollateral ? "withdraw" : "supply"}
+            className="mt-4"
+          />
 
           {/* Action Explanation */}
           <div className="text-xs text-[#A1A1AA] text-center px-2">

--- a/src/components/ui/lending/UserContent/UserBorrowContent.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowContent.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from "react";
 import UserBorrowCard from "@/components/ui/lending/UserContent/UserBorrowCard";
 import CardsList from "@/components/ui/CardsList";
-import { UserBorrowPosition, UnifiedMarketData } from "@/types/aave";
+import { EnhancedUserBorrowPosition, UnifiedMarketData } from "@/types/aave";
 import { TokenTransferState } from "@/types/web3";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
 
@@ -16,10 +16,6 @@ interface UserBorrowContentProps {
   onSupply: (market: UnifiedMarketData) => void;
   onBorrow: (market: UnifiedMarketData) => void;
   onRepay: (market: UnifiedMarketData, max: boolean) => void;
-}
-
-interface EnhancedUserBorrowPosition extends UserBorrowPosition {
-  unifiedMarket: UnifiedMarketData;
 }
 
 const ITEMS_PER_PAGE = 10;

--- a/src/components/ui/lending/UserContent/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyCard.tsx
@@ -13,7 +13,7 @@ import { Switch } from "@/components/ui/Switch";
 import BrandedButton from "@/components/ui/BrandedButton";
 import Image from "next/image";
 import { formatCurrency, formatPercentage } from "@/utils/formatters";
-import { UserSupplyPosition, UnifiedMarketData } from "@/types/aave";
+import { EnhancedUserSupplyPosition, UnifiedMarketData } from "@/types/aave";
 import { Shield, ShieldOff } from "lucide-react";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetailsModal";
 import ToggleCollateralModal from "@/components/ui/lending/ActionModals/ToggleCollateralModal";
@@ -21,7 +21,7 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 import { TokenTransferState } from "@/types/web3";
 
 interface UserSupplyCardProps {
-  position: UserSupplyPosition;
+  position: EnhancedUserSupplyPosition;
   unifiedMarket: UnifiedMarketData;
   userAddress: string | undefined;
   onSupply: (market: UnifiedMarketData) => void;
@@ -186,11 +186,9 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
         isOpen={isCollateralModalOpen}
         onClose={() => setIsCollateralModalOpen(false)}
         position={position}
+        userAddress={userAddress}
         onToggleCollateral={handleModalCollateralToggle}
         isLoading={isCollateralLoading}
-        healthFactor={
-          unifiedMarket.marketInfo.userState?.healthFactor?.toString() || null
-        }
       />
     </Card>
   );

--- a/src/components/ui/lending/UserContent/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyContent.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import UserSupplyCard from "@/components/ui/lending/UserContent/UserSupplyCard";
 import CardsList from "@/components/ui/CardsList";
-import { UserSupplyPosition, UnifiedMarketData } from "@/types/aave";
+import { EnhancedUserSupplyPosition, UnifiedMarketData } from "@/types/aave";
 import { TokenTransferState } from "@/types/web3";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
 
@@ -17,10 +17,6 @@ interface UserSupplyContentProps {
   onBorrow: (market: UnifiedMarketData) => void;
   onWithdraw: (market: UnifiedMarketData, max: boolean) => void;
   onCollateralToggle: (market: UnifiedMarketData) => void;
-}
-
-interface EnhancedUserSupplyPosition extends UserSupplyPosition {
-  unifiedMarket: UnifiedMarketData;
 }
 
 const ITEMS_PER_PAGE = 10;

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -92,6 +92,10 @@ export interface UserSupplyPosition {
   supply: MarketUserReserveSupplyPosition;
 }
 
+export interface EnhancedUserSupplyPosition extends UserSupplyPosition {
+  unifiedMarket: UnifiedMarketData;
+}
+
 export interface UserSupplyData {
   marketAddress: string;
   marketName: string;
@@ -124,6 +128,9 @@ export interface UserBorrowPosition {
   marketName: string;
   chainId: ChainId;
   borrow: MarketUserReserveBorrowPosition;
+}
+export interface EnhancedUserBorrowPosition extends UserBorrowPosition {
+  unifiedMarket: UnifiedMarketData;
 }
 
 export interface AggregatedUserState {


### PR DESCRIPTION
this PR adds the heath factor risk display to the `ToggleCollateralModal`. It uses the following logic:
- enabling collateral mocks a supply of the current position amount
- disabling collateral mocks a withdraw of the current position amount

In addition, I have also moved the `EnhancedUserSupplyPosition` and `EnhancedUserBorrowPosition` into the `types/aave.ts` so they can be reused in the user card components, as access to the `position.unifiedMarket` was needed in this scenario to make the `useHealthFactorPreviewOperations` hook call.

## Screenshots
<img width="2548" height="2134" alt="Screenshot 2025-09-16 at 8 05 31 pm" src="https://github.com/user-attachments/assets/05fd888d-fa75-4649-97f7-43d8295efe4e" />
<img width="2552" height="2196" alt="Screenshot 2025-09-16 at 8 15 29 pm" src="https://github.com/user-attachments/assets/c33f4012-975c-480c-a326-b42969b5b507" />
