### PR TITLE
chore: removed old health factor display

### DIFF
--- a/src/components/ui/lending/ActionModals/BorrowAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/BorrowAssetModal.tsx
@@ -12,7 +12,7 @@ import { TokenTransferState } from "@/types/web3";
 import TokenInputGroup from "@/components/ui/TokenInputGroup";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import { formatCurrency, formatPercentage } from "@/utils/formatters";
-import { TrendingDown, AlertTriangle, Percent } from "lucide-react";
+import { TrendingDown, Percent } from "lucide-react";
 import { useSourceToken, useSourceChain } from "@/store/web3Store";
 import { ensureCorrectWalletTypeForChain } from "@/utils/swap/walletMethods";
 import { TokenImage } from "@/components/ui/TokenImage";
@@ -36,7 +36,6 @@ const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
   children,
   tokenTransferState,
   onBorrow,
-  healthFactor,
 }) => {
   const sourceToken = useSourceToken();
   const sourceChain = useSourceChain();
@@ -178,34 +177,6 @@ const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
                       market.incentives,
                     ).finalBorrowAPY,
                   )}
-                </div>
-              </div>
-
-              {/* Current Health Factor */}
-              {healthFactor && (
-                <div className="flex justify-between items-center py-2">
-                  <div className="flex items-center gap-2">
-                    <AlertTriangle className="w-3 h-3 text-yellow-400" />
-                    <span className="text-sm text-[#A1A1AA]">
-                      current health factor
-                    </span>
-                  </div>
-                  <div className="text-sm font-mono font-semibold text-blue-400">
-                    {parseFloat(healthFactor).toFixed(2)}
-                  </div>
-                </div>
-              )}
-
-              {/* Health Factor Warning */}
-              <div className="flex justify-between items-center py-2">
-                <div className="flex items-center gap-2">
-                  <AlertTriangle className="w-3 h-3 text-yellow-400" />
-                  <span className="text-sm text-[#A1A1AA]">
-                    requires collateral
-                  </span>
-                </div>
-                <div className="text-sm font-mono font-semibold text-yellow-400">
-                  check health factor
                 </div>
               </div>
             </div>

--- a/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
@@ -57,7 +57,6 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
   children,
   tokenTransferState,
   onSupply,
-  healthFactor,
 }) => {
   const sourceToken = useSourceToken();
   const destinationToken = useDestinationToken();
@@ -574,21 +573,6 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
                   {market.supplyInfo.canBeCollateral ? "yes" : "no"}
                 </div>
               </div>
-
-              {/* Current Health Factor */}
-              {healthFactor && (
-                <div className="flex justify-between items-center py-2">
-                  <div className="flex items-center gap-2">
-                    <Shield className="w-3 h-3 text-[#A1A1AA]" />
-                    <span className="text-sm text-[#A1A1AA]">
-                      current health factor
-                    </span>
-                  </div>
-                  <div className="text-sm font-mono font-semibold text-blue-400">
-                    {parseFloat(healthFactor).toFixed(2)}
-                  </div>
-                </div>
-              )}
             </div>
           </div>
 

--- a/src/components/ui/lending/ActionModals/WithdrawAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/WithdrawAssetModal.tsx
@@ -12,7 +12,7 @@ import { TokenTransferState } from "@/types/web3";
 import TokenInputGroup from "@/components/ui/TokenInputGroup";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import { formatCurrency, formatPercentage } from "@/utils/formatters";
-import { TrendingUp, AlertTriangle, Percent, Shield } from "lucide-react";
+import { TrendingUp, Percent } from "lucide-react";
 import { useSourceToken, useSourceChain } from "@/store/web3Store";
 import { ensureCorrectWalletTypeForChain } from "@/utils/swap/walletMethods";
 import { TokenImage } from "@/components/ui/TokenImage";
@@ -40,7 +40,6 @@ const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
   children,
   tokenTransferState,
   onWithdraw,
-  healthFactor,
 }) => {
   const sourceToken = useSourceToken();
   const sourceChain = useSourceChain();
@@ -211,36 +210,6 @@ const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
                   )}
                 </div>
               </div>
-
-              {/* Current Health Factor */}
-              {healthFactor && (
-                <div className="flex justify-between items-center py-2">
-                  <div className="flex items-center gap-2">
-                    <Shield className="w-3 h-3 text-[#A1A1AA]" />
-                    <span className="text-sm text-[#A1A1AA]">
-                      current health factor
-                    </span>
-                  </div>
-                  <div className="text-sm font-mono font-semibold text-blue-400">
-                    {parseFloat(healthFactor).toFixed(2)}
-                  </div>
-                </div>
-              )}
-
-              {/* Health Factor Warning (if applicable) */}
-              {position?.supply.isCollateral && (
-                <div className="flex justify-between items-center py-2">
-                  <div className="flex items-center gap-2">
-                    <AlertTriangle className="w-3 h-3 text-yellow-400" />
-                    <span className="text-sm text-[#A1A1AA]">
-                      monitor health factor
-                    </span>
-                  </div>
-                  <div className="text-sm font-mono font-semibold text-yellow-400">
-                    affects collateral
-                  </div>
-                </div>
-              )}
             </div>
           </div>
 


### PR DESCRIPTION
this PR removes the old health factor display information (the current health factor and static warning message).

Modals are now much more concise.

## Screenshots
**Supply**
<img width="1598" height="1720" alt="Screenshot 2025-09-16 at 8 27 57 pm" src="https://github.com/user-attachments/assets/e67f7f7e-4acd-47b9-9ea5-1d61c439ca58" />
**Borrow**
<img width="1612" height="1774" alt="Screenshot 2025-09-16 at 8 28 07 pm" src="https://github.com/user-attachments/assets/b780d266-593d-4581-b69a-a51a1b50616f" />
**Withdraw**
<img width="1584" height="1724" alt="Screenshot 2025-09-16 at 8 28 19 pm" src="https://github.com/user-attachments/assets/abdf755b-1c9f-4766-8684-c7466d46a9aa" />
**Repay**
<img width="1464" height="1846" alt="Screenshot 2025-09-16 at 8 28 34 pm" src="https://github.com/user-attachments/assets/95dce980-5983-48bf-996b-65e442938314" />
