### PR TITLE
feat: major refactor on handling reserves

### DIFF
--- a/src/components/ui/lending/AssetDetails/UserInfoTab.tsx
+++ b/src/components/ui/lending/AssetDetails/UserInfoTab.tsx
@@ -6,11 +6,48 @@ import {
   formatPercentage,
 } from "@/utils/formatters";
 import { InfoRow } from "@/components/ui/lending/AssetDetails/InfoRow";
+import { BrandedButton } from "@/components/ui/BrandedButton";
+import WithdrawAssetModal from "@/components/ui/lending/ActionModals/WithdrawAssetModal";
+import RepayAssetModal from "@/components/ui/lending/ActionModals/RepayAssetModal";
+import SubscriptNumber from "@/components/ui/SubscriptNumber";
+import { getChainByChainId } from "@/config/chains";
+import useWeb3Store from "@/store/web3Store";
+import { getLendingToken } from "@/utils/lending/tokens";
+import { TokenTransferState } from "@/types/web3";
 
-export const UserInfoTab: React.FC<{ market: UnifiedReserveData }> = ({
+interface UserInfoTabProps {
+  market: UnifiedReserveData;
+  userAddress?: string;
+  onWithdraw?: (market: UnifiedReserveData, max: boolean) => void;
+  onRepay?: (market: UnifiedReserveData, max: boolean) => void;
+  tokenTransferState?: TokenTransferState;
+}
+
+export const UserInfoTab: React.FC<UserInfoTabProps> = ({
   market,
+  userAddress,
+  onWithdraw,
+  onRepay,
+  tokenTransferState,
 }) => {
   const userState = market.userState;
+  const [supplyPosition] = market.userSupplyPositions;
+  const [borrowPosition] = market.userBorrowPositions;
+
+  // Web3 store setup for modals
+  const tokensByCompositeKey = useWeb3Store(
+    (state) => state.tokensByCompositeKey,
+  );
+  const lendingToken = getLendingToken(market, tokensByCompositeKey);
+  const lendingChain = getChainByChainId(lendingToken.chainId);
+  const setSourceToken = useWeb3Store((state) => state.setSourceToken);
+  const setDestinationToken = useWeb3Store(
+    (state) => state.setDestinationToken,
+  );
+  const setSourceChain = useWeb3Store((state) => state.setSourceChain);
+  const setDestinationChain = useWeb3Store(
+    (state) => state.setDestinationChain,
+  );
 
   if (!userState) {
     return (
@@ -24,6 +61,116 @@ export const UserInfoTab: React.FC<{ market: UnifiedReserveData }> = ({
 
   return (
     <div className="space-y-4">
+      {/* User Positions */}
+      {(supplyPosition || borrowPosition) && (
+        <div className="space-y-3">
+          {/* Supply Position */}
+          {supplyPosition && (
+            <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-medium text-green-300 flex items-center gap-2">
+                  <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                  your supply position
+                </h3>
+                {onWithdraw && tokenTransferState && (
+                  <WithdrawAssetModal
+                    market={market}
+                    userAddress={userAddress}
+                    onWithdraw={onWithdraw}
+                    tokenTransferState={tokenTransferState}
+                    healthFactor={
+                      market.marketInfo.userState?.healthFactor?.toString() ||
+                      null
+                    }
+                  >
+                    <BrandedButton
+                      iconName="Coins"
+                      buttonText="withdraw"
+                      onClick={() => {
+                        setSourceChain(lendingChain);
+                        setDestinationChain(lendingChain);
+                        setSourceToken(lendingToken);
+                        setDestinationToken(lendingToken);
+                      }}
+                      className="text-sm px-3 py-1 h-1/2 bg-amber-500/20 hover:bg-amber-500/30 hover:text-amber-300 text-amber-300 border-amber-500/50 hover:border-amber-500 transition-all duration-200 w-1/4"
+                      iconClassName="h-3 w-3"
+                    />
+                  </WithdrawAssetModal>
+                )}
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-[#A1A1AA]">amount</span>
+                  <div className="text-right">
+                    <div className="text-sm font-mono font-semibold text-white">
+                      <SubscriptNumber
+                        value={supplyPosition.balance.amount.value}
+                      />{" "}
+                      <span className="text-xs">
+                        {market.underlyingToken.symbol}
+                      </span>
+                    </div>
+                    <div className="text-xs text-[#71717A] font-mono">
+                      {formatCurrency(supplyPosition.balance.usd)}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Borrow Position */}
+          {borrowPosition && (
+            <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-medium text-red-300 flex items-center gap-2">
+                  <div className="w-2 h-2 bg-red-500 rounded-full"></div>
+                  your borrow position
+                </h3>
+                {onRepay && tokenTransferState && (
+                  <RepayAssetModal
+                    market={market}
+                    userAddress={userAddress}
+                    onRepay={onRepay}
+                    tokenTransferState={tokenTransferState}
+                  >
+                    <BrandedButton
+                      iconName="Coins"
+                      buttonText="repay"
+                      onClick={() => {
+                        setSourceChain(lendingChain);
+                        setDestinationChain(lendingChain);
+                        setSourceToken(lendingToken);
+                        setDestinationToken(lendingToken);
+                      }}
+                      className="text-sm px-3 py-1 h-1/2 bg-sky-500/20 hover:bg-sky-500/30 hover:text-sky-300 text-sky-300 border-sky-500/50 hover:border-sky-500 transition-all duration-200 w-1/4"
+                      iconClassName="h-3 w-3"
+                    />
+                  </RepayAssetModal>
+                )}
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-[#A1A1AA]">amount</span>
+                  <div className="text-right">
+                    <div className="text-sm font-mono font-semibold text-white">
+                      <SubscriptNumber
+                        value={borrowPosition.debt.amount.value}
+                      />{" "}
+                      <span className="text-xs">
+                        {market.underlyingToken.symbol}
+                      </span>
+                    </div>
+                    <div className="text-xs text-[#71717A] font-mono">
+                      {formatCurrency(borrowPosition.debt.usd)}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
       <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
         <h3 className="text-sm font-medium text-white mb-3 flex items-center gap-2">
           <TrendingUp className="w-4 h-4" />

--- a/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
@@ -25,7 +25,7 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 import { TokenTransferState } from "@/types/web3";
 
 interface AvailableBorrowCardProps {
-  market: UnifiedReserveData;
+  reserve: UnifiedReserveData;
   userAddress: string | undefined;
   onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
@@ -33,18 +33,18 @@ interface AvailableBorrowCardProps {
 }
 
 const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
-  market,
+  reserve,
   userAddress,
   onSupply,
   onBorrow,
   tokenTransferState,
 }) => {
   // Extract borrow data
-  const baseBorrowAPY = market.borrowData.apy;
-  const totalSupplied = market.supplyData.totalSupplied;
-  const totalBorrowed = market.borrowData.totalBorrowed;
-  const totalSuppliedUsd = market.supplyData.totalSuppliedUsd;
-  const totalBorrowedUsd = market.borrowData.totalBorrowedUsd;
+  const baseBorrowAPY = reserve.borrowData.apy;
+  const totalSupplied = reserve.supplyData.totalSupplied;
+  const totalBorrowed = reserve.borrowData.totalBorrowed;
+  const totalSuppliedUsd = reserve.supplyData.totalSuppliedUsd;
+  const totalBorrowedUsd = reserve.borrowData.totalBorrowedUsd;
 
   // Calculate available liquidity for borrowing
   const availableUsd = totalSuppliedUsd - totalBorrowedUsd;
@@ -54,13 +54,13 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
 
   // Calculate final borrow APY with incentives
   const { finalBorrowAPY, hasBorrowBonuses, hasMixedIncentives } =
-    calculateApyWithIncentives(0, baseBorrowAPY, market.incentives);
+    calculateApyWithIncentives(0, baseBorrowAPY, reserve.incentives);
 
   // Check if market is available for borrowing
   const isAvailable =
-    !market.isFrozen &&
-    !market.isPaused &&
-    market.borrowInfo?.borrowingState === "ENABLED";
+    !reserve.isFrozen &&
+    !reserve.isPaused &&
+    reserve.borrowInfo?.borrowingState === "ENABLED";
   const hasLiquidity = availableUsd > 0;
 
   return (
@@ -68,8 +68,8 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
       <CardHeader className="flex flex-row items-start p-4 pb-2 space-y-0">
         <div className="w-8 h-8 rounded-full overflow-hidden flex items-center justify-center mr-3 flex-shrink-0">
           <Image
-            src={market.underlyingToken.imageUrl}
-            alt={market.underlyingToken.symbol}
+            src={reserve.underlyingToken.imageUrl}
+            alt={reserve.underlyingToken.symbol}
             width={32}
             height={32}
             className="object-contain"
@@ -81,7 +81,7 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
-              {market.underlyingToken.name}
+              {reserve.underlyingToken.name}
             </CardTitle>
             {(!isAvailable || !hasLiquidity) && (
               <Tooltip.Provider>
@@ -96,14 +96,14 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
                     >
                       {!hasLiquidity
                         ? "No Liquidity"
-                        : market.isFrozen && market.isPaused
+                        : reserve.isFrozen && reserve.isPaused
                           ? "Frozen, Paused"
-                          : market.isFrozen
+                          : reserve.isFrozen
                             ? "Frozen"
-                            : market.isPaused
+                            : reserve.isPaused
                               ? "Paused"
-                              : !market.borrowInfo?.borrowingState ||
-                                  market.borrowInfo?.borrowingState ===
+                              : !reserve.borrowInfo?.borrowingState ||
+                                  reserve.borrowInfo?.borrowingState ===
                                     "DISABLED"
                                 ? "Borrow Disabled"
                                 : "Not Available"}
@@ -116,8 +116,8 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
           </div>
           <CardDescription className="text-[#A1A1AA] text-xs mt-1 flex items-center gap-1">
             <Image
-              src={market.marketInfo.icon}
-              alt={market.marketName}
+              src={reserve.marketInfo.icon}
+              alt={reserve.marketName}
               width={16}
               height={16}
               className="object-contain rounded-full"
@@ -125,7 +125,7 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
                 e.currentTarget.src = "/images/markets/default.svg";
               }}
             />
-            {market.marketName}
+            {reserve.marketName}
           </CardDescription>
         </div>
       </CardHeader>
@@ -156,7 +156,7 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
             >
               {formatBalance(availableTokens)}{" "}
               <TruncatedText
-                text={market.underlyingToken.symbol}
+                text={reserve.underlyingToken.symbol}
                 maxLength={6}
                 className={`text-sm font-semibold font-mono ${hasLiquidity ? "text-[#FAFAFA]" : "text-red-400"}`}
               />
@@ -172,12 +172,11 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
 
       <CardFooter className="flex justify-center p-4 pt-0">
         <AssetDetailsModal
-          market={market}
+          reserve={reserve}
           userAddress={userAddress}
           onSupply={onSupply}
           onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
-          buttonsToShow={["supply", "borrow"]}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/AvailableContent/AvailableBorrowContent.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowContent.tsx
@@ -119,7 +119,7 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
       renderCard={(market) => (
         <AvailableBorrowCard
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
-          market={market}
+          reserve={market}
           userAddress={userAddress}
           onSupply={onSupply}
           onBorrow={onBorrow}

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
@@ -24,7 +24,7 @@ import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetails
 import { TokenTransferState } from "@/types/web3";
 
 interface AvailableSupplyCardProps {
-  market: UnifiedReserveData;
+  reserve: UnifiedReserveData;
   userAddress: string | undefined;
   onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
@@ -32,31 +32,31 @@ interface AvailableSupplyCardProps {
 }
 
 const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
-  market,
+  reserve,
   userAddress,
   onSupply,
   onBorrow,
   tokenTransferState,
 }) => {
   // Extract supply data
-  const baseSupplyAPY = market.supplyData.apy;
-  const totalSupplied = market.supplyData.totalSupplied;
-  const totalSuppliedUsd = market.supplyData.totalSuppliedUsd;
+  const baseSupplyAPY = reserve.supplyData.apy;
+  const totalSupplied = reserve.supplyData.totalSupplied;
+  const totalSuppliedUsd = reserve.supplyData.totalSuppliedUsd;
 
   // Calculate final supply APY with incentives
   const { finalSupplyAPY, hasSupplyBonuses, hasMixedIncentives } =
-    calculateApyWithIncentives(baseSupplyAPY, 0, market.incentives);
+    calculateApyWithIncentives(baseSupplyAPY, 0, reserve.incentives);
 
   // Check if market is available for supply
-  const isAvailable = !market.isFrozen && !market.isPaused;
+  const isAvailable = !reserve.isFrozen && !reserve.isPaused;
 
   return (
     <Card className="text-white border border-[#27272A] bg-[#18181B] rounded-lg shadow-none hover:bg-[#1C1C1F] transition-colors">
       <CardHeader className="flex flex-row items-start p-4 pb-2 space-y-0">
         <div className="w-8 h-8 rounded-full overflow-hidden flex items-center justify-center mr-3 flex-shrink-0">
           <Image
-            src={market.underlyingToken.imageUrl}
-            alt={market.underlyingToken.symbol}
+            src={reserve.underlyingToken.imageUrl}
+            alt={reserve.underlyingToken.symbol}
             width={32}
             height={32}
             className="object-contain"
@@ -68,14 +68,14 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
-              {market.underlyingToken.name}
+              {reserve.underlyingToken.name}
             </CardTitle>
             {!isAvailable && <AlertTriangle className="w-4 h-4 text-red-400" />}
           </div>
           <CardDescription className="text-[#A1A1AA] text-xs mt-1 flex items-center gap-1">
             <Image
-              src={market.marketInfo.icon}
-              alt={market.marketName}
+              src={reserve.marketInfo.icon}
+              alt={reserve.marketName}
               width={16}
               height={16}
               className="object-contain rounded-full"
@@ -83,12 +83,12 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
                 e.currentTarget.src = "/images/markets/default.svg";
               }}
             />
-            {market.marketName}
+            {reserve.marketName}
             {!isAvailable && (
               <span className="ml-1 text-red-400">
-                {market.isFrozen && market.isPaused
+                {reserve.isFrozen && reserve.isPaused
                   ? "(Frozen, Paused)"
-                  : market.isFrozen
+                  : reserve.isFrozen
                     ? "(Frozen)"
                     : "(Paused)"}
               </span>
@@ -121,7 +121,7 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
             <div className="text-[#FAFAFA] text-sm font-semibold font-mono">
               {formatBalance(totalSupplied)}{" "}
               <TruncatedText
-                text={market.underlyingToken.symbol}
+                text={reserve.underlyingToken.symbol}
                 maxLength={6}
                 className="text-[#FAFAFA] text-sm font-semibold font-mono"
               />
@@ -138,12 +138,12 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
           <div className="flex items-center gap-1">
             <span
               className={`text-xs font-medium ${
-                market.supplyInfo.canBeCollateral
+                reserve.supplyInfo.canBeCollateral
                   ? "text-green-500"
                   : "text-[#A1A1AA]"
               }`}
             >
-              {market.supplyInfo.canBeCollateral ? "enabled" : "disabled"}
+              {reserve.supplyInfo.canBeCollateral ? "enabled" : "disabled"}
             </span>
           </div>
         </div>
@@ -151,12 +151,11 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
 
       <CardFooter className="flex justify-center p-4 pt-0">
         <AssetDetailsModal
-          market={market}
+          reserve={reserve}
           userAddress={userAddress}
           onSupply={onSupply}
           onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
-          buttonsToShow={["supply", "borrow"]}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyContent.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyContent.tsx
@@ -118,7 +118,7 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
       renderCard={(market) => (
         <AvailableSupplyCard
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
-          market={market}
+          reserve={market}
           userAddress={userAddress}
           onSupply={onSupply}
           onBorrow={onBorrow}

--- a/src/components/ui/lending/DashboardContent/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent/DashboardContent.tsx
@@ -320,7 +320,6 @@ export default function DashboardContent({
           <UserBorrowContent
             markets={unifiedReserves}
             userAddress={userAddress}
-            showZeroBalance={showZeroBalance}
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}

--- a/src/components/ui/lending/MarketContent/MarketCard.tsx
+++ b/src/components/ui/lending/MarketContent/MarketCard.tsx
@@ -182,12 +182,11 @@ const MarketCard: React.FC<MarketCardProps> = ({
 
       <CardFooter className="flex justify-center p-4 pt-0">
         <AssetDetailsModal
-          market={market}
+          reserve={market}
           userAddress={userAddress}
           onSupply={onSupply}
           onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
-          buttonsToShow={["supply", "borrow"]}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/UserContent/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowCard.tsx
@@ -12,12 +12,11 @@ import {
 import BrandedButton from "@/components/ui/BrandedButton";
 import Image from "next/image";
 import { formatCurrency, formatPercentage } from "@/utils/formatters";
-import { UnifiedReserveData, UserBorrowPosition } from "@/types/aave";
+import { UnifiedReserveData } from "@/types/aave";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetailsModal";
 import { TokenTransferState } from "@/types/web3";
 
 interface UserBorrowCardProps {
-  position: UserBorrowPosition;
   unifiedReserve: UnifiedReserveData;
   userAddress: string | undefined;
   onSupply: (market: UnifiedReserveData) => void;
@@ -27,7 +26,6 @@ interface UserBorrowCardProps {
 }
 
 const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
-  position,
   unifiedReserve,
   userAddress,
   onSupply,
@@ -35,7 +33,7 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
   onRepay,
   tokenTransferState,
 }) => {
-  const { borrow, marketName } = position;
+  const [borrow] = unifiedReserve.userBorrowPositions;
   const balanceUsd = parseFloat(borrow.debt.usd) || 0;
   const apy = parseFloat(borrow.apy.value) || 0;
 
@@ -63,7 +61,7 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
           <CardDescription className="text-[#A1A1AA] text-xs mt-1 flex items-center gap-1">
             <Image
               src={borrow.market.icon}
-              alt={marketName}
+              alt={borrow.market.name}
               width={16}
               height={16}
               className="object-contain rounded-full"
@@ -71,7 +69,7 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
                 e.currentTarget.src = "/images/markets/default.svg";
               }}
             />
-            {marketName}
+            {borrow.market.name}
           </CardDescription>
         </div>
       </CardHeader>
@@ -106,14 +104,12 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
 
       <CardFooter className="flex gap-2 p-4 pt-0">
         <AssetDetailsModal
-          market={unifiedReserve}
+          reserve={unifiedReserve}
           userAddress={userAddress}
-          borrowPosition={position}
           onSupply={onSupply}
           onBorrow={onBorrow}
           onRepay={onRepay}
           tokenTransferState={tokenTransferState}
-          buttonsToShow={["borrow", "repay"]}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/UserContent/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyCard.tsx
@@ -13,7 +13,7 @@ import { Switch } from "@/components/ui/Switch";
 import BrandedButton from "@/components/ui/BrandedButton";
 import Image from "next/image";
 import { formatCurrency, formatPercentage } from "@/utils/formatters";
-import { UserSupplyPosition, UnifiedReserveData } from "@/types/aave";
+import { UnifiedReserveData } from "@/types/aave";
 import { Shield, ShieldOff } from "lucide-react";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetailsModal";
 import ToggleCollateralModal from "@/components/ui/lending/ActionModals/ToggleCollateralModal";
@@ -21,7 +21,6 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 import { TokenTransferState } from "@/types/web3";
 
 interface UserSupplyCardProps {
-  position: UserSupplyPosition;
   unifiedReserve: UnifiedReserveData;
   userAddress: string | undefined;
   onSupply: (market: UnifiedReserveData) => void;
@@ -33,7 +32,6 @@ interface UserSupplyCardProps {
 }
 
 const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
-  position,
   unifiedReserve,
   userAddress,
   onSupply,
@@ -43,7 +41,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
   tokenTransferState,
   isCollateralLoading = false,
 }) => {
-  const { supply, marketName } = position;
+  const [supply] = unifiedReserve.userSupplyPositions;
   const balanceUsd = parseFloat(supply.balance.usd) || 0;
   const apy = parseFloat(supply.apy.value) || 0;
 
@@ -108,7 +106,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
           <CardDescription className="text-[#A1A1AA] text-xs mt-1 flex items-center gap-1">
             <Image
               src={supply.market.icon}
-              alt={marketName}
+              alt={supply.market.name}
               width={16}
               height={16}
               className="object-contain rounded-full"
@@ -116,7 +114,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
                 e.currentTarget.src = "/images/markets/default.svg";
               }}
             />
-            {marketName}
+            {supply.market.name}
           </CardDescription>
         </div>
       </CardHeader>
@@ -164,14 +162,12 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
 
       <CardFooter className="flex gap-2 p-4 pt-0">
         <AssetDetailsModal
-          market={unifiedReserve}
+          reserve={unifiedReserve}
           userAddress={userAddress}
           onSupply={onSupply}
           onBorrow={onBorrow}
           onWithdraw={onWithdraw}
           tokenTransferState={tokenTransferState}
-          supplyPosition={position}
-          buttonsToShow={["supply", "withdraw"]}
         >
           <BrandedButton
             buttonText="details"
@@ -185,12 +181,10 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
       <ToggleCollateralModal
         isOpen={isCollateralModalOpen}
         onClose={() => setIsCollateralModalOpen(false)}
-        position={position}
+        reserve={unifiedReserve}
+        userAddress={userAddress}
         onToggleCollateral={handleModalCollateralToggle}
         isLoading={isCollateralLoading}
-        healthFactor={
-          unifiedReserve.marketInfo.userState?.healthFactor?.toString() || null
-        }
       />
     </Card>
   );

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -91,7 +91,6 @@ export interface UserSupplyPosition {
   chainId: ChainId;
   supply: MarketUserReserveSupplyPosition;
 }
-
 export interface UserSupplyData {
   marketAddress: string;
   marketName: string;


### PR DESCRIPTION
apologies for the PR size - this is the minimal changes I could make to both: A. keep this change buildable without errors/linting warnings & B. not massively destroy any functionality

this PR starts the process of a major refactor to handle getting everything we need for user supply and user borrow positions using ONLY the `UnifiedReserveData` objects which are passed into the User/Available Supply/Borrow Content components.

Changes include:
- mass rename of props from `market` to `reserve`
- removal of `supplyPosition` and `borrowPosition` props, in favour of `reserve.userSupplyPositions` and `reserve.userBorrowPositions`
- shifting the `AssetDetailsModal` towards parity across all instances by removing the `buttonsToShow` and instead deciding what to show based on the open positions
- adding **Withdraw** and **Repay** CTA buttons directly next to the users positions

> [!IMPORTANT]
> As mentioned, this is only part of the massive refactor required. The next steps are to further bring full parity and consistency to the `AssetDetailsModal.tsx`, ensuring that positions are available and shown from EVERYWHERE the modal is accessed. Additionally, the `onSupply`, `onBorrow`, `onWithdraw`, and `onRepay` hooks should be removed as props and instead instantiated from the interaction modals themselves.

## Screenshots
**The only UI component that has notably changed in this PR is the `AssetDetailsModal`** - this is still not fully complete as positions are only shown when accessing from the open supply or borrow positions.

### Desktop
<img width="2756" height="1990" alt="Screenshot 2025-09-17 at 6 27 10 am" src="https://github.com/user-attachments/assets/80b01fbd-6b01-4bf5-8c6b-5ad722db8000" />
<img width="3088" height="2086" alt="Screenshot 2025-09-17 at 6 27 48 am" src="https://github.com/user-attachments/assets/c82ab3cc-72e2-42e0-a5c5-df427fc4b58a" />

### Tablet
<img width="1024" height="1364" alt="Screenshot 2025-09-17 at 6 27 59 am" src="https://github.com/user-attachments/assets/95323bba-7a51-4426-a759-7c98956b67f3" />

### Mobile
<img width="856" height="1852" alt="Screenshot 2025-09-17 at 6 28 13 am" src="https://github.com/user-attachments/assets/8467375e-6c95-486c-b6b1-d0c8367c72b9" />
