### PR TITLE
refactor: remove onsupply prop

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -35,7 +35,6 @@ import HistoryContent from "@/components/ui/lending/TransactionHistoryContent/Tr
 import { useTokenTransfer } from "@/utils/swap/walletMethods";
 import { Button } from "@/components/ui/Button";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
-import { useSupplyOperations } from "@/hooks/lending/useSupplyOperations";
 import { useBorrowOperations } from "@/hooks/lending/useBorrowOperations";
 import { useWithdrawOperations } from "@/hooks/lending/useWithdrawOperations";
 import { useRepayOperations } from "@/hooks/lending/useRepayOperations";
@@ -100,15 +99,6 @@ export default function LendingPage() {
     },
     onError: (error) => {
       console.error("lending swap error:", error);
-    },
-  });
-
-  const { handleSupply } = useSupplyOperations({
-    sourceChain,
-    sourceToken,
-    userWalletAddress: userWalletAddress || null,
-    tokenTransferState: {
-      amount: tokenTransferState.amount || "",
     },
   });
 
@@ -317,7 +307,6 @@ export default function LendingPage() {
                         marketBorrowData={marketBorrowData}
                         marketSupplyData={marketSupplyData}
                         tokenTransferState={tokenTransferState}
-                        onSupply={handleSupply}
                         onBorrow={handleBorrow}
                         filters={filters}
                         sortConfig={sortConfig}
@@ -338,7 +327,6 @@ export default function LendingPage() {
                         onSubsectionChange={setCurrentSubsection}
                         refetchMarkets={refetchMarkets}
                         actions={{
-                          onSupply: handleSupply,
                           onBorrow: handleBorrow,
                           onWithdraw: handleWithdraw,
                           onRepay: handleRepay,

--- a/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
@@ -36,6 +36,7 @@ import ProgressTracker, {
   StepState,
 } from "@/components/ui/ProgressTracker";
 import WalletConnectButton from "@/components/ui/WalletConnectButton";
+import { useSupplyOperations } from "@/hooks/lending/useSupplyOperations";
 
 import HealthFactorRiskDisplay from "@/components/ui/lending/AssetDetails/HealthFactorRiskDisplay";
 
@@ -43,7 +44,6 @@ interface SupplyAssetModalProps {
   market: UnifiedReserveData;
   userAddress: string | undefined;
   children: React.ReactNode;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
   onRepay?: (market: UserBorrowPosition) => void;
   onWithdraw?: (market: UserSupplyPosition) => void;
@@ -56,7 +56,6 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
   userAddress,
   children,
   tokenTransferState,
-  onSupply,
 }) => {
   const sourceToken = useSourceToken();
   const destinationToken = useDestinationToken();
@@ -75,6 +74,15 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
     destinationToken &&
     sourceToken.address === destinationToken.address &&
     sourceToken.chainId === destinationToken.chainId;
+
+  const { handleSupply } = useSupplyOperations({
+    sourceChain,
+    sourceToken,
+    userWalletAddress: userAddress || null,
+    tokenTransferState: {
+      amount: tokenTransferState.amount || "",
+    },
+  });
 
   // Swap state management - using proper tracking lifecycle
   const [swapInitiated, setSwapInitiated] = useState(false);
@@ -600,13 +608,13 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
 
               if (isDirectSupply && !isSwapThenSupplyFlow) {
                 console.log("SupplyAssetModal: Direct supply");
-                onSupply(market);
+                handleSupply(market);
               } else if (
                 swapCompleted ||
                 (isDirectSupply && isSwapThenSupplyFlow)
               ) {
                 console.log("SupplyAssetModal: Supply after swap completion");
-                onSupply(market);
+                handleSupply(market);
                 // Clear the swap-then-supply flag after supply action
                 setIsSwapThenSupplyFlow(false);
               } else if (!swapInitiated) {

--- a/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
@@ -28,7 +28,6 @@ interface AssetDetailsModalProps {
   reserve: UnifiedReserveData;
   userAddress: string | undefined;
   children: React.ReactNode;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
   onRepay?: (market: UnifiedReserveData, max: boolean) => void;
   onWithdraw?: (market: UnifiedReserveData, max: boolean) => void;
@@ -41,7 +40,6 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
   reserve,
   userAddress,
   children,
-  onSupply,
   onBorrow,
   onWithdraw,
   onRepay,
@@ -263,7 +261,6 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
             <div className="flex gap-3 w-full">
               <SupplyAssetModal
                 market={reserve}
-                onSupply={onSupply}
                 onBorrow={onBorrow}
                 userAddress={userAddress}
                 tokenTransferState={tokenTransferState}

--- a/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
@@ -27,7 +27,6 @@ import { TokenTransferState } from "@/types/web3";
 interface AvailableBorrowCardProps {
   reserve: UnifiedReserveData;
   userAddress: string | undefined;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
   tokenTransferState: TokenTransferState;
 }
@@ -35,7 +34,6 @@ interface AvailableBorrowCardProps {
 const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
   reserve,
   userAddress,
-  onSupply,
   onBorrow,
   tokenTransferState,
 }) => {
@@ -174,7 +172,6 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
         <AssetDetailsModal
           reserve={reserve}
           userAddress={userAddress}
-          onSupply={onSupply}
           onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         >

--- a/src/components/ui/lending/AvailableContent/AvailableBorrowContent.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowContent.tsx
@@ -13,7 +13,6 @@ interface AvailableBorrowContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
 }
 
@@ -25,7 +24,6 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
-  onSupply,
   onBorrow,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
@@ -121,7 +119,6 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           reserve={market}
           userAddress={userAddress}
-          onSupply={onSupply}
           onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         />

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
@@ -26,7 +26,6 @@ import { TokenTransferState } from "@/types/web3";
 interface AvailableSupplyCardProps {
   reserve: UnifiedReserveData;
   userAddress: string | undefined;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
   tokenTransferState: TokenTransferState;
 }
@@ -34,7 +33,6 @@ interface AvailableSupplyCardProps {
 const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
   reserve,
   userAddress,
-  onSupply,
   onBorrow,
   tokenTransferState,
 }) => {
@@ -153,7 +151,6 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
         <AssetDetailsModal
           reserve={reserve}
           userAddress={userAddress}
-          onSupply={onSupply}
           onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         >

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyContent.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyContent.tsx
@@ -14,7 +14,6 @@ interface AvailableSupplyContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
 }
 
@@ -27,7 +26,6 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
-  onSupply,
   onBorrow,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
@@ -120,7 +118,6 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           reserve={market}
           userAddress={userAddress}
-          onSupply={onSupply}
           onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         />

--- a/src/components/ui/lending/DashboardContent/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent/DashboardContent.tsx
@@ -33,7 +33,6 @@ interface DashboardContentProps {
   onSubsectionChange?: (subsection: string) => void;
   refetchMarkets?: () => void;
   actions: {
-    onSupply: (market: UnifiedReserveData) => void;
     onBorrow: (market: UnifiedReserveData) => void;
     onWithdraw: (market: UnifiedReserveData, max: boolean) => void;
     onRepay: (market: UnifiedReserveData, max: boolean) => void;
@@ -289,7 +288,6 @@ export default function DashboardContent({
               tokenTransferState={tokenTransferState}
               filters={filters}
               sortConfig={sortConfig}
-              onSupply={actions.onSupply}
               onBorrow={actions.onBorrow}
             />
           ) : (
@@ -299,7 +297,6 @@ export default function DashboardContent({
               tokenTransferState={tokenTransferState}
               filters={filters}
               sortConfig={sortConfig}
-              onSupply={actions.onSupply}
               onBorrow={actions.onBorrow}
             />
           )
@@ -311,7 +308,6 @@ export default function DashboardContent({
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
-            onSupply={actions.onSupply}
             onBorrow={actions.onBorrow}
             onWithdraw={actions.onWithdraw}
             onCollateralToggle={actions.onCollateralToggle}
@@ -323,7 +319,6 @@ export default function DashboardContent({
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
-            onSupply={actions.onSupply}
             onBorrow={actions.onBorrow}
             onRepay={actions.onRepay}
           />

--- a/src/components/ui/lending/MarketContent/MarketCard.tsx
+++ b/src/components/ui/lending/MarketContent/MarketCard.tsx
@@ -30,7 +30,6 @@ import { TokenTransferState } from "@/types/web3";
 interface MarketCardProps {
   market: UnifiedReserveData;
   userAddress: string | undefined;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
   onRepay?: (market: UserBorrowPosition) => void;
   onWithdraw?: (market: UserSupplyPosition) => void;
@@ -41,7 +40,6 @@ interface MarketCardProps {
 const MarketCard: React.FC<MarketCardProps> = ({
   market,
   userAddress,
-  onSupply,
   onBorrow,
   tokenTransferState,
 }) => {
@@ -184,7 +182,6 @@ const MarketCard: React.FC<MarketCardProps> = ({
         <AssetDetailsModal
           reserve={market}
           userAddress={userAddress}
-          onSupply={onSupply}
           onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         >

--- a/src/components/ui/lending/MarketContent/MarketContent.tsx
+++ b/src/components/ui/lending/MarketContent/MarketContent.tsx
@@ -20,7 +20,6 @@ interface MarketContentProps {
   marketBorrowData?: Record<string, UserBorrowData>;
   marketSupplyData?: Record<string, UserSupplyData>;
   tokenTransferState: TokenTransferState;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
   filters: LendingFilters;
   sortConfig: LendingSortConfig | null;
@@ -31,7 +30,6 @@ const MarketContent: React.FC<MarketContentProps> = ({
   unifiedReserves,
   userAddress,
   tokenTransferState,
-  onSupply,
   onBorrow,
   filters,
   sortConfig,
@@ -122,7 +120,6 @@ const MarketContent: React.FC<MarketContentProps> = ({
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
           userAddress={userAddress}
-          onSupply={onSupply}
           onBorrow={onBorrow}
           onRepay={(market: UserBorrowPosition) => {
             console.log(market); // TODO: update me

--- a/src/components/ui/lending/UserContent/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowCard.tsx
@@ -19,7 +19,6 @@ import { TokenTransferState } from "@/types/web3";
 interface UserBorrowCardProps {
   unifiedReserve: UnifiedReserveData;
   userAddress: string | undefined;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
   onRepay: (market: UnifiedReserveData, max: boolean) => void;
   tokenTransferState: TokenTransferState;
@@ -28,7 +27,6 @@ interface UserBorrowCardProps {
 const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
   unifiedReserve,
   userAddress,
-  onSupply,
   onBorrow,
   onRepay,
   tokenTransferState,
@@ -106,7 +104,6 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
         <AssetDetailsModal
           reserve={unifiedReserve}
           userAddress={userAddress}
-          onSupply={onSupply}
           onBorrow={onBorrow}
           onRepay={onRepay}
           tokenTransferState={tokenTransferState}

--- a/src/components/ui/lending/UserContent/UserBorrowContent.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowContent.tsx
@@ -12,7 +12,6 @@ interface UserBorrowContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
   onRepay: (market: UnifiedReserveData, max: boolean) => void;
 }
@@ -25,7 +24,6 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
-  onSupply,
   onBorrow,
   onRepay,
 }) => {
@@ -111,7 +109,6 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
           key={`${reserve.market.address}-${reserve.underlyingToken.address}`}
           unifiedReserve={reserve}
           userAddress={userAddress}
-          onSupply={onSupply}
           onBorrow={onBorrow}
           onRepay={onRepay}
           tokenTransferState={tokenTransferState}

--- a/src/components/ui/lending/UserContent/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyCard.tsx
@@ -23,7 +23,6 @@ import { TokenTransferState } from "@/types/web3";
 interface UserSupplyCardProps {
   unifiedReserve: UnifiedReserveData;
   userAddress: string | undefined;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
   onWithdraw: (market: UnifiedReserveData, max: boolean) => void;
   onCollateralToggle: (market: UnifiedReserveData) => void;
@@ -34,7 +33,6 @@ interface UserSupplyCardProps {
 const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
   unifiedReserve,
   userAddress,
-  onSupply,
   onBorrow,
   onWithdraw,
   onCollateralToggle,
@@ -164,7 +162,6 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
         <AssetDetailsModal
           reserve={unifiedReserve}
           userAddress={userAddress}
-          onSupply={onSupply}
           onBorrow={onBorrow}
           onWithdraw={onWithdraw}
           tokenTransferState={tokenTransferState}

--- a/src/components/ui/lending/UserContent/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyContent.tsx
@@ -13,7 +13,6 @@ interface UserSupplyContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
-  onSupply: (market: UnifiedReserveData) => void;
   onBorrow: (market: UnifiedReserveData) => void;
   onWithdraw: (market: UnifiedReserveData, max: boolean) => void;
   onCollateralToggle: (market: UnifiedReserveData) => void;
@@ -27,7 +26,6 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
-  onSupply,
   onBorrow,
   onWithdraw,
   onCollateralToggle,
@@ -114,7 +112,6 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
           key={`${reserve.market.address}-${reserve.underlyingToken.address}`}
           unifiedReserve={reserve}
           userAddress={userAddress}
-          onSupply={onSupply}
           onBorrow={onBorrow}
           onWithdraw={onWithdraw}
           onCollateralToggle={onCollateralToggle}


### PR DESCRIPTION
branch off #381, please see f438c27ab266cbc02c9c8b542c1dea700e6e35b0

this PR is concerned with removing the `onSupply` prop which was needlessly passed down from the lending `page.tsx` all the way to the interaction modal `SupplyAssetModal.tsx`. This causes unnecessary upkeep and complexity for when we want to be able to execute these interactions throughout the dapp. Subsequent PRs for other interactions to come.