### PR TITLE
refactor: removed onBorrow prop

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -35,7 +35,6 @@ import HistoryContent from "@/components/ui/lending/TransactionHistoryContent/Tr
 import { useTokenTransfer } from "@/utils/swap/walletMethods";
 import { Button } from "@/components/ui/Button";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
-import { useBorrowOperations } from "@/hooks/lending/useBorrowOperations";
 import { useWithdrawOperations } from "@/hooks/lending/useWithdrawOperations";
 import { useRepayOperations } from "@/hooks/lending/useRepayOperations";
 import { useCollateralToggleOperations } from "@/hooks/lending/useCollateralToggleOperations";
@@ -100,13 +99,6 @@ export default function LendingPage() {
     onError: (error) => {
       console.error("lending swap error:", error);
     },
-  });
-
-  const { handleBorrow } = useBorrowOperations({
-    sourceChain,
-    sourceToken,
-    userWalletAddress: userWalletAddress || null,
-    tokenBorrowState: { amount: tokenTransferState.amount || "" },
   });
 
   const { handleWithdraw } = useWithdrawOperations({
@@ -307,7 +299,6 @@ export default function LendingPage() {
                         marketBorrowData={marketBorrowData}
                         marketSupplyData={marketSupplyData}
                         tokenTransferState={tokenTransferState}
-                        onBorrow={handleBorrow}
                         filters={filters}
                         sortConfig={sortConfig}
                       />
@@ -327,7 +318,6 @@ export default function LendingPage() {
                         onSubsectionChange={setCurrentSubsection}
                         refetchMarkets={refetchMarkets}
                         actions={{
-                          onBorrow: handleBorrow,
                           onWithdraw: handleWithdraw,
                           onRepay: handleRepay,
                           onCollateralToggle: handleCollateralToggle,

--- a/src/components/ui/lending/ActionModals/BorrowAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/BorrowAssetModal.tsx
@@ -20,12 +20,12 @@ import { BrandedButton } from "@/components/ui/BrandedButton";
 import { calculateTokenPrice } from "@/utils/common";
 import WalletConnectButton from "@/components/ui/WalletConnectButton";
 import HealthFactorRiskDisplay from "@/components/ui/lending/AssetDetails/HealthFactorRiskDisplay";
+import { useBorrowOperations } from "@/hooks/lending/useBorrowOperations";
 
 interface BorrowAssetModalProps {
   market: UnifiedReserveData;
   userAddress: string | undefined;
   children: React.ReactNode;
-  onBorrow: (market: UnifiedReserveData) => void;
   tokenTransferState: TokenTransferState;
   healthFactor?: string | null;
 }
@@ -35,12 +35,18 @@ const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
   userAddress,
   children,
   tokenTransferState,
-  onBorrow,
 }) => {
   const sourceToken = useSourceToken();
   const sourceChain = useSourceChain();
 
   const sourceWalletConnected = ensureCorrectWalletTypeForChain(sourceChain);
+
+  const { handleBorrow } = useBorrowOperations({
+    sourceChain,
+    sourceToken,
+    userWalletAddress: userAddress || null,
+    tokenBorrowState: { amount: tokenTransferState.amount || "" },
+  });
 
   return (
     <Dialog>
@@ -197,7 +203,7 @@ const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
               console.log(
                 "BorrowAssetModal: Button clicked - executing borrow",
               );
-              onBorrow(market);
+              handleBorrow(market);
             }}
             disabled={
               !tokenTransferState.amount ||

--- a/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
@@ -44,7 +44,6 @@ interface SupplyAssetModalProps {
   market: UnifiedReserveData;
   userAddress: string | undefined;
   children: React.ReactNode;
-  onBorrow: (market: UnifiedReserveData) => void;
   onRepay?: (market: UserBorrowPosition) => void;
   onWithdraw?: (market: UserSupplyPosition) => void;
   tokenTransferState: TokenTransferState;

--- a/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
@@ -28,7 +28,6 @@ interface AssetDetailsModalProps {
   reserve: UnifiedReserveData;
   userAddress: string | undefined;
   children: React.ReactNode;
-  onBorrow: (market: UnifiedReserveData) => void;
   onRepay?: (market: UnifiedReserveData, max: boolean) => void;
   onWithdraw?: (market: UnifiedReserveData, max: boolean) => void;
   tokenTransferState: TokenTransferState;
@@ -40,7 +39,6 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
   reserve,
   userAddress,
   children,
-  onBorrow,
   onWithdraw,
   onRepay,
   tokenTransferState,
@@ -261,7 +259,6 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
             <div className="flex gap-3 w-full">
               <SupplyAssetModal
                 market={reserve}
-                onBorrow={onBorrow}
                 userAddress={userAddress}
                 tokenTransferState={tokenTransferState}
                 healthFactor={
@@ -284,7 +281,6 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
               <BorrowAssetModal
                 market={reserve}
                 userAddress={userAddress}
-                onBorrow={onBorrow}
                 tokenTransferState={tokenTransferState}
                 healthFactor={
                   reserve.marketInfo.userState?.healthFactor?.toString() || null

--- a/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
@@ -27,14 +27,12 @@ import { TokenTransferState } from "@/types/web3";
 interface AvailableBorrowCardProps {
   reserve: UnifiedReserveData;
   userAddress: string | undefined;
-  onBorrow: (market: UnifiedReserveData) => void;
   tokenTransferState: TokenTransferState;
 }
 
 const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
   reserve,
   userAddress,
-  onBorrow,
   tokenTransferState,
 }) => {
   // Extract borrow data
@@ -172,7 +170,6 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
         <AssetDetailsModal
           reserve={reserve}
           userAddress={userAddress}
-          onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         >
           <BrandedButton

--- a/src/components/ui/lending/AvailableContent/AvailableBorrowContent.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowContent.tsx
@@ -13,7 +13,6 @@ interface AvailableBorrowContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
-  onBorrow: (market: UnifiedReserveData) => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -24,7 +23,6 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
-  onBorrow,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -119,7 +117,6 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           reserve={market}
           userAddress={userAddress}
-          onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         />
       )}

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
@@ -26,14 +26,13 @@ import { TokenTransferState } from "@/types/web3";
 interface AvailableSupplyCardProps {
   reserve: UnifiedReserveData;
   userAddress: string | undefined;
-  onBorrow: (market: UnifiedReserveData) => void;
   tokenTransferState: TokenTransferState;
 }
 
 const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
   reserve,
   userAddress,
-  onBorrow,
+
   tokenTransferState,
 }) => {
   // Extract supply data
@@ -151,7 +150,6 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
         <AssetDetailsModal
           reserve={reserve}
           userAddress={userAddress}
-          onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         >
           <BrandedButton

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyContent.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyContent.tsx
@@ -14,7 +14,6 @@ interface AvailableSupplyContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
-  onBorrow: (market: UnifiedReserveData) => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -26,7 +25,6 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
-  onBorrow,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -118,7 +116,6 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           reserve={market}
           userAddress={userAddress}
-          onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         />
       )}

--- a/src/components/ui/lending/DashboardContent/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent/DashboardContent.tsx
@@ -33,7 +33,6 @@ interface DashboardContentProps {
   onSubsectionChange?: (subsection: string) => void;
   refetchMarkets?: () => void;
   actions: {
-    onBorrow: (market: UnifiedReserveData) => void;
     onWithdraw: (market: UnifiedReserveData, max: boolean) => void;
     onRepay: (market: UnifiedReserveData, max: boolean) => void;
     onCollateralToggle: (market: UnifiedReserveData) => void;
@@ -288,7 +287,6 @@ export default function DashboardContent({
               tokenTransferState={tokenTransferState}
               filters={filters}
               sortConfig={sortConfig}
-              onBorrow={actions.onBorrow}
             />
           ) : (
             <AvailableBorrowContent
@@ -297,7 +295,6 @@ export default function DashboardContent({
               tokenTransferState={tokenTransferState}
               filters={filters}
               sortConfig={sortConfig}
-              onBorrow={actions.onBorrow}
             />
           )
         ) : // Show open positions
@@ -308,7 +305,6 @@ export default function DashboardContent({
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
-            onBorrow={actions.onBorrow}
             onWithdraw={actions.onWithdraw}
             onCollateralToggle={actions.onCollateralToggle}
           />
@@ -319,7 +315,6 @@ export default function DashboardContent({
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
-            onBorrow={actions.onBorrow}
             onRepay={actions.onRepay}
           />
         )}

--- a/src/components/ui/lending/MarketContent/MarketCard.tsx
+++ b/src/components/ui/lending/MarketContent/MarketCard.tsx
@@ -30,7 +30,7 @@ import { TokenTransferState } from "@/types/web3";
 interface MarketCardProps {
   market: UnifiedReserveData;
   userAddress: string | undefined;
-  onBorrow: (market: UnifiedReserveData) => void;
+
   onRepay?: (market: UserBorrowPosition) => void;
   onWithdraw?: (market: UserSupplyPosition) => void;
   onDetails?: (market: UnifiedReserveData) => void;
@@ -40,7 +40,7 @@ interface MarketCardProps {
 const MarketCard: React.FC<MarketCardProps> = ({
   market,
   userAddress,
-  onBorrow,
+
   tokenTransferState,
 }) => {
   // Extract data from unified structure
@@ -182,7 +182,6 @@ const MarketCard: React.FC<MarketCardProps> = ({
         <AssetDetailsModal
           reserve={market}
           userAddress={userAddress}
-          onBorrow={onBorrow}
           tokenTransferState={tokenTransferState}
         >
           <BrandedButton

--- a/src/components/ui/lending/MarketContent/MarketContent.tsx
+++ b/src/components/ui/lending/MarketContent/MarketContent.tsx
@@ -20,7 +20,6 @@ interface MarketContentProps {
   marketBorrowData?: Record<string, UserBorrowData>;
   marketSupplyData?: Record<string, UserSupplyData>;
   tokenTransferState: TokenTransferState;
-  onBorrow: (market: UnifiedReserveData) => void;
   filters: LendingFilters;
   sortConfig: LendingSortConfig | null;
   userAddress: string | undefined;
@@ -30,7 +29,7 @@ const MarketContent: React.FC<MarketContentProps> = ({
   unifiedReserves,
   userAddress,
   tokenTransferState,
-  onBorrow,
+
   filters,
   sortConfig,
 }) => {
@@ -120,7 +119,6 @@ const MarketContent: React.FC<MarketContentProps> = ({
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
           userAddress={userAddress}
-          onBorrow={onBorrow}
           onRepay={(market: UserBorrowPosition) => {
             console.log(market); // TODO: update me
           }}

--- a/src/components/ui/lending/UserContent/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowCard.tsx
@@ -19,7 +19,7 @@ import { TokenTransferState } from "@/types/web3";
 interface UserBorrowCardProps {
   unifiedReserve: UnifiedReserveData;
   userAddress: string | undefined;
-  onBorrow: (market: UnifiedReserveData) => void;
+
   onRepay: (market: UnifiedReserveData, max: boolean) => void;
   tokenTransferState: TokenTransferState;
 }
@@ -27,7 +27,7 @@ interface UserBorrowCardProps {
 const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
   unifiedReserve,
   userAddress,
-  onBorrow,
+
   onRepay,
   tokenTransferState,
 }) => {
@@ -104,7 +104,6 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
         <AssetDetailsModal
           reserve={unifiedReserve}
           userAddress={userAddress}
-          onBorrow={onBorrow}
           onRepay={onRepay}
           tokenTransferState={tokenTransferState}
         >

--- a/src/components/ui/lending/UserContent/UserBorrowContent.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowContent.tsx
@@ -12,7 +12,7 @@ interface UserBorrowContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
-  onBorrow: (market: UnifiedReserveData) => void;
+
   onRepay: (market: UnifiedReserveData, max: boolean) => void;
 }
 
@@ -24,7 +24,7 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
-  onBorrow,
+
   onRepay,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
@@ -109,7 +109,6 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
           key={`${reserve.market.address}-${reserve.underlyingToken.address}`}
           unifiedReserve={reserve}
           userAddress={userAddress}
-          onBorrow={onBorrow}
           onRepay={onRepay}
           tokenTransferState={tokenTransferState}
         />

--- a/src/components/ui/lending/UserContent/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyCard.tsx
@@ -23,7 +23,7 @@ import { TokenTransferState } from "@/types/web3";
 interface UserSupplyCardProps {
   unifiedReserve: UnifiedReserveData;
   userAddress: string | undefined;
-  onBorrow: (market: UnifiedReserveData) => void;
+
   onWithdraw: (market: UnifiedReserveData, max: boolean) => void;
   onCollateralToggle: (market: UnifiedReserveData) => void;
   tokenTransferState: TokenTransferState;
@@ -33,7 +33,7 @@ interface UserSupplyCardProps {
 const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
   unifiedReserve,
   userAddress,
-  onBorrow,
+
   onWithdraw,
   onCollateralToggle,
   tokenTransferState,
@@ -162,7 +162,6 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
         <AssetDetailsModal
           reserve={unifiedReserve}
           userAddress={userAddress}
-          onBorrow={onBorrow}
           onWithdraw={onWithdraw}
           tokenTransferState={tokenTransferState}
         >

--- a/src/components/ui/lending/UserContent/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyContent.tsx
@@ -13,7 +13,7 @@ interface UserSupplyContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
-  onBorrow: (market: UnifiedReserveData) => void;
+
   onWithdraw: (market: UnifiedReserveData, max: boolean) => void;
   onCollateralToggle: (market: UnifiedReserveData) => void;
 }
@@ -26,7 +26,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
-  onBorrow,
+
   onWithdraw,
   onCollateralToggle,
 }) => {
@@ -112,7 +112,6 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
           key={`${reserve.market.address}-${reserve.underlyingToken.address}`}
           unifiedReserve={reserve}
           userAddress={userAddress}
-          onBorrow={onBorrow}
           onWithdraw={onWithdraw}
           onCollateralToggle={onCollateralToggle}
           tokenTransferState={tokenTransferState}


### PR DESCRIPTION
branch off #381, #382, please see 5850d8fa02d3993e9b2976741a5f48af7be93f14

---

this PR is concerned with removing the `onBorrow` prop which is needlessly passed down from the lending `page.tsx` all the way down to the `BorrowAssetModal.tsx`.