### PR TITLE
refactor: remove withdraw prop

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -35,7 +35,6 @@ import HistoryContent from "@/components/ui/lending/TransactionHistoryContent/Tr
 import { useTokenTransfer } from "@/utils/swap/walletMethods";
 import { Button } from "@/components/ui/Button";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
-import { useWithdrawOperations } from "@/hooks/lending/useWithdrawOperations";
 import { useRepayOperations } from "@/hooks/lending/useRepayOperations";
 import { useCollateralToggleOperations } from "@/hooks/lending/useCollateralToggleOperations";
 
@@ -99,13 +98,6 @@ export default function LendingPage() {
     onError: (error) => {
       console.error("lending swap error:", error);
     },
-  });
-
-  const { handleWithdraw } = useWithdrawOperations({
-    sourceChain,
-    sourceToken,
-    userWalletAddress: userWalletAddress || null,
-    tokenWithdrawState: { amount: tokenTransferState.amount || "" },
   });
 
   const { handleRepay } = useRepayOperations({
@@ -318,7 +310,6 @@ export default function LendingPage() {
                         onSubsectionChange={setCurrentSubsection}
                         refetchMarkets={refetchMarkets}
                         actions={{
-                          onWithdraw: handleWithdraw,
                           onRepay: handleRepay,
                           onCollateralToggle: handleCollateralToggle,
                         }}

--- a/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
@@ -7,11 +7,7 @@ import {
   DialogHeader,
   DialogTrigger,
 } from "@/components/ui/StyledDialog";
-import {
-  UnifiedReserveData,
-  UserBorrowPosition,
-  UserSupplyPosition,
-} from "@/types/aave";
+import { UnifiedReserveData, UserBorrowPosition } from "@/types/aave";
 import { TokenTransferState } from "@/types/web3";
 import TokenInputGroup from "@/components/ui/TokenInputGroup";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
@@ -45,7 +41,6 @@ interface SupplyAssetModalProps {
   userAddress: string | undefined;
   children: React.ReactNode;
   onRepay?: (market: UserBorrowPosition) => void;
-  onWithdraw?: (market: UserSupplyPosition) => void;
   tokenTransferState: TokenTransferState;
   healthFactor?: string | null;
 }

--- a/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
@@ -29,7 +29,7 @@ interface AssetDetailsModalProps {
   userAddress: string | undefined;
   children: React.ReactNode;
   onRepay?: (market: UnifiedReserveData, max: boolean) => void;
-  onWithdraw?: (market: UnifiedReserveData, max: boolean) => void;
+
   tokenTransferState: TokenTransferState;
 }
 
@@ -39,7 +39,7 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
   reserve,
   userAddress,
   children,
-  onWithdraw,
+
   onRepay,
   tokenTransferState,
 }) => {
@@ -175,7 +175,6 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                 <UserInfoTab
                   market={reserve}
                   userAddress={userAddress}
-                  onWithdraw={onWithdraw}
                   onRepay={onRepay}
                   tokenTransferState={tokenTransferState}
                 />

--- a/src/components/ui/lending/AssetDetails/UserInfoTab.tsx
+++ b/src/components/ui/lending/AssetDetails/UserInfoTab.tsx
@@ -18,7 +18,7 @@ import { TokenTransferState } from "@/types/web3";
 interface UserInfoTabProps {
   market: UnifiedReserveData;
   userAddress?: string;
-  onWithdraw?: (market: UnifiedReserveData, max: boolean) => void;
+
   onRepay?: (market: UnifiedReserveData, max: boolean) => void;
   tokenTransferState?: TokenTransferState;
 }
@@ -26,7 +26,7 @@ interface UserInfoTabProps {
 export const UserInfoTab: React.FC<UserInfoTabProps> = ({
   market,
   userAddress,
-  onWithdraw,
+
   onRepay,
   tokenTransferState,
 }) => {
@@ -72,11 +72,10 @@ export const UserInfoTab: React.FC<UserInfoTabProps> = ({
                   <div className="w-2 h-2 bg-green-500 rounded-full"></div>
                   your supply position
                 </h3>
-                {onWithdraw && tokenTransferState && (
+                {tokenTransferState && (
                   <WithdrawAssetModal
                     market={market}
                     userAddress={userAddress}
-                    onWithdraw={onWithdraw}
                     tokenTransferState={tokenTransferState}
                     healthFactor={
                       market.marketInfo.userState?.healthFactor?.toString() ||

--- a/src/components/ui/lending/DashboardContent/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent/DashboardContent.tsx
@@ -33,7 +33,6 @@ interface DashboardContentProps {
   onSubsectionChange?: (subsection: string) => void;
   refetchMarkets?: () => void;
   actions: {
-    onWithdraw: (market: UnifiedReserveData, max: boolean) => void;
     onRepay: (market: UnifiedReserveData, max: boolean) => void;
     onCollateralToggle: (market: UnifiedReserveData) => void;
   };
@@ -305,7 +304,6 @@ export default function DashboardContent({
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
-            onWithdraw={actions.onWithdraw}
             onCollateralToggle={actions.onCollateralToggle}
           />
         ) : (

--- a/src/components/ui/lending/MarketContent/MarketCard.tsx
+++ b/src/components/ui/lending/MarketContent/MarketCard.tsx
@@ -17,11 +17,7 @@ import {
   formatPercentage,
   formatBalance,
 } from "@/utils/formatters";
-import {
-  UnifiedReserveData,
-  UserBorrowPosition,
-  UserSupplyPosition,
-} from "@/types/aave";
+import { UnifiedReserveData, UserBorrowPosition } from "@/types/aave";
 import { SquarePlus, SquareMinus, SquareEqual } from "lucide-react";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetailsModal";
@@ -32,7 +28,6 @@ interface MarketCardProps {
   userAddress: string | undefined;
 
   onRepay?: (market: UserBorrowPosition) => void;
-  onWithdraw?: (market: UserSupplyPosition) => void;
   onDetails?: (market: UnifiedReserveData) => void;
   tokenTransferState: TokenTransferState;
 }

--- a/src/components/ui/lending/MarketContent/MarketContent.tsx
+++ b/src/components/ui/lending/MarketContent/MarketContent.tsx
@@ -8,7 +8,6 @@ import {
   UserBorrowData,
   UserBorrowPosition,
   UserSupplyData,
-  UserSupplyPosition,
 } from "@/types/aave";
 import { TokenTransferState } from "@/types/web3";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
@@ -120,9 +119,6 @@ const MarketContent: React.FC<MarketContentProps> = ({
           market={market}
           userAddress={userAddress}
           onRepay={(market: UserBorrowPosition) => {
-            console.log(market); // TODO: update me
-          }}
-          onWithdraw={(market: UserSupplyPosition) => {
             console.log(market); // TODO: update me
           }}
           tokenTransferState={tokenTransferState}

--- a/src/components/ui/lending/UserContent/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyCard.tsx
@@ -24,7 +24,6 @@ interface UserSupplyCardProps {
   unifiedReserve: UnifiedReserveData;
   userAddress: string | undefined;
 
-  onWithdraw: (market: UnifiedReserveData, max: boolean) => void;
   onCollateralToggle: (market: UnifiedReserveData) => void;
   tokenTransferState: TokenTransferState;
   isCollateralLoading?: boolean;
@@ -34,7 +33,6 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
   unifiedReserve,
   userAddress,
 
-  onWithdraw,
   onCollateralToggle,
   tokenTransferState,
   isCollateralLoading = false,
@@ -162,7 +160,6 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
         <AssetDetailsModal
           reserve={unifiedReserve}
           userAddress={userAddress}
-          onWithdraw={onWithdraw}
           tokenTransferState={tokenTransferState}
         >
           <BrandedButton

--- a/src/components/ui/lending/UserContent/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyContent.tsx
@@ -14,7 +14,6 @@ interface UserSupplyContentProps {
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
 
-  onWithdraw: (market: UnifiedReserveData, max: boolean) => void;
   onCollateralToggle: (market: UnifiedReserveData) => void;
 }
 
@@ -27,7 +26,6 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
   filters,
   sortConfig,
 
-  onWithdraw,
   onCollateralToggle,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
@@ -112,7 +110,6 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
           key={`${reserve.market.address}-${reserve.underlyingToken.address}`}
           unifiedReserve={reserve}
           userAddress={userAddress}
-          onWithdraw={onWithdraw}
           onCollateralToggle={onCollateralToggle}
           tokenTransferState={tokenTransferState}
         />


### PR DESCRIPTION
branch off #381, #382, #383, please see d4477c986e6b09288ecb4f27351d2c2aa9bc489d

---

this PR is concerned with removing the `onWithdraw` prop that is needlessly passed down from the lending `page.tsx` all the way down to the `WithdrawAssetModal.tsx`. I have also removed the`position` prop from the `WithdrawAssetModal.tsx`, now correctly utilising the `UnifiedReserveData` prop to obtain the relevant supply position.

**Note that a positive side effect of this PR is that withdrawing is now possible from all cards with an open position: Market cards, Available, and Open cards**