### PR TITLE
refactor: remove repay prop

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -35,7 +35,6 @@ import HistoryContent from "@/components/ui/lending/TransactionHistoryContent/Tr
 import { useTokenTransfer } from "@/utils/swap/walletMethods";
 import { Button } from "@/components/ui/Button";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
-import { useRepayOperations } from "@/hooks/lending/useRepayOperations";
 import { useCollateralToggleOperations } from "@/hooks/lending/useCollateralToggleOperations";
 
 type LendingTabType = "markets" | "dashboard" | "staking" | "history";
@@ -98,13 +97,6 @@ export default function LendingPage() {
     onError: (error) => {
       console.error("lending swap error:", error);
     },
-  });
-
-  const { handleRepay } = useRepayOperations({
-    sourceChain,
-    sourceToken,
-    userWalletAddress: userWalletAddress || null,
-    tokenRepayState: { amount: tokenTransferState.amount || "" },
   });
 
   const { handleCollateralToggle } = useCollateralToggleOperations({
@@ -310,7 +302,6 @@ export default function LendingPage() {
                         onSubsectionChange={setCurrentSubsection}
                         refetchMarkets={refetchMarkets}
                         actions={{
-                          onRepay: handleRepay,
                           onCollateralToggle: handleCollateralToggle,
                         }}
                       />

--- a/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
@@ -7,7 +7,7 @@ import {
   DialogHeader,
   DialogTrigger,
 } from "@/components/ui/StyledDialog";
-import { UnifiedReserveData, UserBorrowPosition } from "@/types/aave";
+import { UnifiedReserveData } from "@/types/aave";
 import { TokenTransferState } from "@/types/web3";
 import TokenInputGroup from "@/components/ui/TokenInputGroup";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
@@ -40,7 +40,6 @@ interface SupplyAssetModalProps {
   market: UnifiedReserveData;
   userAddress: string | undefined;
   children: React.ReactNode;
-  onRepay?: (market: UserBorrowPosition) => void;
   tokenTransferState: TokenTransferState;
   healthFactor?: string | null;
 }

--- a/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
@@ -28,8 +28,6 @@ interface AssetDetailsModalProps {
   reserve: UnifiedReserveData;
   userAddress: string | undefined;
   children: React.ReactNode;
-  onRepay?: (market: UnifiedReserveData, max: boolean) => void;
-
   tokenTransferState: TokenTransferState;
 }
 
@@ -40,7 +38,6 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
   userAddress,
   children,
 
-  onRepay,
   tokenTransferState,
 }) => {
   const [activeTab, setActiveTab] = useState<TabType>("user");
@@ -175,7 +172,6 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                 <UserInfoTab
                   market={reserve}
                   userAddress={userAddress}
-                  onRepay={onRepay}
                   tokenTransferState={tokenTransferState}
                 />
               )}

--- a/src/components/ui/lending/AssetDetails/UserInfoTab.tsx
+++ b/src/components/ui/lending/AssetDetails/UserInfoTab.tsx
@@ -18,8 +18,6 @@ import { TokenTransferState } from "@/types/web3";
 interface UserInfoTabProps {
   market: UnifiedReserveData;
   userAddress?: string;
-
-  onRepay?: (market: UnifiedReserveData, max: boolean) => void;
   tokenTransferState?: TokenTransferState;
 }
 
@@ -27,7 +25,6 @@ export const UserInfoTab: React.FC<UserInfoTabProps> = ({
   market,
   userAddress,
 
-  onRepay,
   tokenTransferState,
 }) => {
   const userState = market.userState;
@@ -126,11 +123,10 @@ export const UserInfoTab: React.FC<UserInfoTabProps> = ({
                   <div className="w-2 h-2 bg-red-500 rounded-full"></div>
                   your borrow position
                 </h3>
-                {onRepay && tokenTransferState && (
+                {tokenTransferState && (
                   <RepayAssetModal
-                    market={market}
+                    reserve={market}
                     userAddress={userAddress}
-                    onRepay={onRepay}
                     tokenTransferState={tokenTransferState}
                   >
                     <BrandedButton

--- a/src/components/ui/lending/DashboardContent/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent/DashboardContent.tsx
@@ -33,7 +33,6 @@ interface DashboardContentProps {
   onSubsectionChange?: (subsection: string) => void;
   refetchMarkets?: () => void;
   actions: {
-    onRepay: (market: UnifiedReserveData, max: boolean) => void;
     onCollateralToggle: (market: UnifiedReserveData) => void;
   };
 }
@@ -313,7 +312,6 @@ export default function DashboardContent({
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
-            onRepay={actions.onRepay}
           />
         )}
       </div>

--- a/src/components/ui/lending/MarketContent/MarketCard.tsx
+++ b/src/components/ui/lending/MarketContent/MarketCard.tsx
@@ -17,7 +17,7 @@ import {
   formatPercentage,
   formatBalance,
 } from "@/utils/formatters";
-import { UnifiedReserveData, UserBorrowPosition } from "@/types/aave";
+import { UnifiedReserveData } from "@/types/aave";
 import { SquarePlus, SquareMinus, SquareEqual } from "lucide-react";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetailsModal";
@@ -27,7 +27,6 @@ interface MarketCardProps {
   market: UnifiedReserveData;
   userAddress: string | undefined;
 
-  onRepay?: (market: UserBorrowPosition) => void;
   onDetails?: (market: UnifiedReserveData) => void;
   tokenTransferState: TokenTransferState;
 }
@@ -35,7 +34,6 @@ interface MarketCardProps {
 const MarketCard: React.FC<MarketCardProps> = ({
   market,
   userAddress,
-
   tokenTransferState,
 }) => {
   // Extract data from unified structure

--- a/src/components/ui/lending/MarketContent/MarketContent.tsx
+++ b/src/components/ui/lending/MarketContent/MarketContent.tsx
@@ -6,7 +6,6 @@ import CardsList from "@/components/ui/CardsList";
 import {
   UnifiedReserveData,
   UserBorrowData,
-  UserBorrowPosition,
   UserSupplyData,
 } from "@/types/aave";
 import { TokenTransferState } from "@/types/web3";
@@ -118,9 +117,6 @@ const MarketContent: React.FC<MarketContentProps> = ({
           key={`${market.marketInfo.address}-${market.underlyingToken.address}`}
           market={market}
           userAddress={userAddress}
-          onRepay={(market: UserBorrowPosition) => {
-            console.log(market); // TODO: update me
-          }}
           tokenTransferState={tokenTransferState}
         />
       )}

--- a/src/components/ui/lending/UserContent/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowCard.tsx
@@ -20,7 +20,6 @@ interface UserBorrowCardProps {
   unifiedReserve: UnifiedReserveData;
   userAddress: string | undefined;
 
-  onRepay: (market: UnifiedReserveData, max: boolean) => void;
   tokenTransferState: TokenTransferState;
 }
 
@@ -28,7 +27,6 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
   unifiedReserve,
   userAddress,
 
-  onRepay,
   tokenTransferState,
 }) => {
   const [borrow] = unifiedReserve.userBorrowPositions;
@@ -104,7 +102,6 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
         <AssetDetailsModal
           reserve={unifiedReserve}
           userAddress={userAddress}
-          onRepay={onRepay}
           tokenTransferState={tokenTransferState}
         >
           <BrandedButton

--- a/src/components/ui/lending/UserContent/UserBorrowContent.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowContent.tsx
@@ -12,8 +12,6 @@ interface UserBorrowContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
-
-  onRepay: (market: UnifiedReserveData, max: boolean) => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -24,8 +22,6 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
-
-  onRepay,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -109,7 +105,6 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
           key={`${reserve.market.address}-${reserve.underlyingToken.address}`}
           unifiedReserve={reserve}
           userAddress={userAddress}
-          onRepay={onRepay}
           tokenTransferState={tokenTransferState}
         />
       )}


### PR DESCRIPTION
this PR is concerned with removing the `onRepay` prop which was needlessly passed all the way down from the lending `page.tsx` all the way to the `RepayAssetModal`. the operations hook is now instantiated directly in the `RepayAssetModal.tsx`. This not only majorly simplifies the entire prop chai, but ensures that repays are available from all assets with an open borrow position, whether it's a market card, available card, or user position card.