### PR TITLE
feat: refetchMarkets call on all successful interactions

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -277,6 +277,7 @@ export default function LendingPage() {
                         marketBorrowData={marketBorrowData}
                         marketSupplyData={marketSupplyData}
                         tokenTransferState={tokenTransferState}
+                        refetchMarkets={refetchMarkets}
                         filters={filters}
                         sortConfig={sortConfig}
                       />

--- a/src/components/ui/lending/ActionModals/BorrowAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/BorrowAssetModal.tsx
@@ -28,6 +28,7 @@ interface BorrowAssetModalProps {
   children: React.ReactNode;
   tokenTransferState: TokenTransferState;
   healthFactor?: string | null;
+  refetchMarkets: () => void;
 }
 
 const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
@@ -35,6 +36,7 @@ const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
   userAddress,
   children,
   tokenTransferState,
+  refetchMarkets,
 }) => {
   const sourceToken = useSourceToken();
   const sourceChain = useSourceChain();
@@ -46,6 +48,7 @@ const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
     sourceToken,
     userWalletAddress: userAddress || null,
     tokenBorrowState: { amount: tokenTransferState.amount || "" },
+    refetchMarkets,
   });
 
   return (

--- a/src/components/ui/lending/ActionModals/RepayAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/RepayAssetModal.tsx
@@ -41,7 +41,7 @@ interface RepayAssetModalProps {
   reserve: UnifiedReserveData;
   userAddress: string | undefined;
   children: React.ReactNode;
-
+  refetchMarkets: () => void;
   tokenTransferState: TokenTransferState;
 }
 
@@ -50,6 +50,7 @@ const RepayAssetModal: React.FC<RepayAssetModalProps> = ({
   userAddress,
   children,
   tokenTransferState,
+  refetchMarkets,
 }) => {
   const sourceToken = useSourceToken();
   const destinationToken = useDestinationToken();
@@ -74,6 +75,7 @@ const RepayAssetModal: React.FC<RepayAssetModalProps> = ({
     sourceToken,
     userWalletAddress: userAddress || null,
     tokenRepayState: { amount: tokenTransferState.amount || "" },
+    refetchMarkets,
   });
 
   const [position] = reserve.userBorrowPositions;

--- a/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
@@ -42,6 +42,7 @@ interface SupplyAssetModalProps {
   children: React.ReactNode;
   tokenTransferState: TokenTransferState;
   healthFactor?: string | null;
+  refetchMarkets: () => void;
 }
 
 const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
@@ -49,6 +50,7 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
   userAddress,
   children,
   tokenTransferState,
+  refetchMarkets,
 }) => {
   const sourceToken = useSourceToken();
   const destinationToken = useDestinationToken();
@@ -75,6 +77,7 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
     tokenTransferState: {
       amount: tokenTransferState.amount || "",
     },
+    refetchMarkets,
   });
 
   // Swap state management - using proper tracking lifecycle

--- a/src/components/ui/lending/ActionModals/WithdrawAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/WithdrawAssetModal.tsx
@@ -29,6 +29,7 @@ interface WithdrawAssetModalProps {
   children: React.ReactNode;
   tokenTransferState: TokenTransferState;
   healthFactor?: string | null;
+  refetchMarkets: () => void;
 }
 
 const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
@@ -36,6 +37,7 @@ const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
   userAddress,
   children,
   tokenTransferState,
+  refetchMarkets,
 }) => {
   const sourceToken = useSourceToken();
   const sourceChain = useSourceChain();
@@ -55,6 +57,7 @@ const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
     sourceToken,
     userWalletAddress: userAddress || null,
     tokenWithdrawState: { amount: tokenTransferState.amount || "" },
+    refetchMarkets,
   });
 
   // Track if user clicked the max button

--- a/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
+++ b/src/components/ui/lending/AssetDetails/AssetDetailsModal.tsx
@@ -29,6 +29,7 @@ interface AssetDetailsModalProps {
   userAddress: string | undefined;
   children: React.ReactNode;
   tokenTransferState: TokenTransferState;
+  refetchMarkets: () => void;
 }
 
 type TabType = "user" | "supply" | "borrow" | "emode" | "asset";
@@ -37,8 +38,8 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
   reserve,
   userAddress,
   children,
-
   tokenTransferState,
+  refetchMarkets,
 }) => {
   const [activeTab, setActiveTab] = useState<TabType>("user");
 
@@ -173,6 +174,7 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                   market={reserve}
                   userAddress={userAddress}
                   tokenTransferState={tokenTransferState}
+                  refetchMarkets={refetchMarkets}
                 />
               )}
 
@@ -259,6 +261,7 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                 healthFactor={
                   reserve.marketInfo.userState?.healthFactor?.toString() || null
                 }
+                refetchMarkets={refetchMarkets}
               >
                 <BrandedButton
                   iconName="TrendingUp"
@@ -280,6 +283,7 @@ const AssetDetailsModal: React.FC<AssetDetailsModalProps> = ({
                 healthFactor={
                   reserve.marketInfo.userState?.healthFactor?.toString() || null
                 }
+                refetchMarkets={refetchMarkets}
               >
                 <BrandedButton
                   iconName="TrendingDown"

--- a/src/components/ui/lending/AssetDetails/UserInfoTab.tsx
+++ b/src/components/ui/lending/AssetDetails/UserInfoTab.tsx
@@ -19,12 +19,13 @@ interface UserInfoTabProps {
   market: UnifiedReserveData;
   userAddress?: string;
   tokenTransferState?: TokenTransferState;
+  refetchMarkets: () => void;
 }
 
 export const UserInfoTab: React.FC<UserInfoTabProps> = ({
   market,
   userAddress,
-
+  refetchMarkets,
   tokenTransferState,
 }) => {
   const userState = market.userState;
@@ -78,6 +79,7 @@ export const UserInfoTab: React.FC<UserInfoTabProps> = ({
                       market.marketInfo.userState?.healthFactor?.toString() ||
                       null
                     }
+                    refetchMarkets={refetchMarkets}
                   >
                     <BrandedButton
                       iconName="Coins"
@@ -128,6 +130,7 @@ export const UserInfoTab: React.FC<UserInfoTabProps> = ({
                     reserve={market}
                     userAddress={userAddress}
                     tokenTransferState={tokenTransferState}
+                    refetchMarkets={refetchMarkets}
                   >
                     <BrandedButton
                       iconName="Coins"

--- a/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
@@ -28,12 +28,14 @@ interface AvailableBorrowCardProps {
   reserve: UnifiedReserveData;
   userAddress: string | undefined;
   tokenTransferState: TokenTransferState;
+  refetchMarkets: () => void;
 }
 
 const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
   reserve,
   userAddress,
   tokenTransferState,
+  refetchMarkets,
 }) => {
   // Extract borrow data
   const baseBorrowAPY = reserve.borrowData.apy;
@@ -171,6 +173,7 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
           reserve={reserve}
           userAddress={userAddress}
           tokenTransferState={tokenTransferState}
+          refetchMarkets={refetchMarkets}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/AvailableContent/AvailableBorrowContent.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowContent.tsx
@@ -13,6 +13,7 @@ interface AvailableBorrowContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
+  refetchMarkets: () => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -23,6 +24,7 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
+  refetchMarkets,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -118,6 +120,7 @@ const AvailableBorrowContent: React.FC<AvailableBorrowContentProps> = ({
           reserve={market}
           userAddress={userAddress}
           tokenTransferState={tokenTransferState}
+          refetchMarkets={refetchMarkets}
         />
       )}
       currentPage={currentPage}

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
@@ -27,13 +27,14 @@ interface AvailableSupplyCardProps {
   reserve: UnifiedReserveData;
   userAddress: string | undefined;
   tokenTransferState: TokenTransferState;
+  refetchMarkets: () => void;
 }
 
 const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
   reserve,
   userAddress,
-
   tokenTransferState,
+  refetchMarkets,
 }) => {
   // Extract supply data
   const baseSupplyAPY = reserve.supplyData.apy;
@@ -151,6 +152,7 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
           reserve={reserve}
           userAddress={userAddress}
           tokenTransferState={tokenTransferState}
+          refetchMarkets={refetchMarkets}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyContent.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyContent.tsx
@@ -14,6 +14,7 @@ interface AvailableSupplyContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
+  refetchMarkets: () => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -25,6 +26,7 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
+  refetchMarkets,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -117,6 +119,7 @@ const AvailableSupplyContent: React.FC<AvailableSupplyContentProps> = ({
           reserve={market}
           userAddress={userAddress}
           tokenTransferState={tokenTransferState}
+          refetchMarkets={refetchMarkets}
         />
       )}
       currentPage={currentPage}

--- a/src/components/ui/lending/DashboardContent/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent/DashboardContent.tsx
@@ -31,7 +31,7 @@ interface DashboardContentProps {
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
   onSubsectionChange?: (subsection: string) => void;
-  refetchMarkets?: () => void;
+  refetchMarkets: () => void;
 }
 
 export default function DashboardContent({
@@ -281,6 +281,7 @@ export default function DashboardContent({
               tokenTransferState={tokenTransferState}
               filters={filters}
               sortConfig={sortConfig}
+              refetchMarkets={refetchMarkets}
             />
           ) : (
             <AvailableBorrowContent
@@ -289,6 +290,7 @@ export default function DashboardContent({
               tokenTransferState={tokenTransferState}
               filters={filters}
               sortConfig={sortConfig}
+              refetchMarkets={refetchMarkets}
             />
           )
         ) : // Show open positions
@@ -299,6 +301,7 @@ export default function DashboardContent({
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
+            refetchMarkets={refetchMarkets}
           />
         ) : (
           <UserBorrowContent
@@ -307,6 +310,7 @@ export default function DashboardContent({
             tokenTransferState={tokenTransferState}
             filters={filters}
             sortConfig={sortConfig}
+            refetchMarkets={refetchMarkets}
           />
         )}
       </div>

--- a/src/components/ui/lending/MarketContent/MarketCard.tsx
+++ b/src/components/ui/lending/MarketContent/MarketCard.tsx
@@ -26,14 +26,14 @@ import { TokenTransferState } from "@/types/web3";
 interface MarketCardProps {
   market: UnifiedReserveData;
   userAddress: string | undefined;
-
-  onDetails?: (market: UnifiedReserveData) => void;
+  refetchMarkets: () => void;
   tokenTransferState: TokenTransferState;
 }
 
 const MarketCard: React.FC<MarketCardProps> = ({
   market,
   userAddress,
+  refetchMarkets,
   tokenTransferState,
 }) => {
   // Extract data from unified structure
@@ -176,6 +176,7 @@ const MarketCard: React.FC<MarketCardProps> = ({
           reserve={market}
           userAddress={userAddress}
           tokenTransferState={tokenTransferState}
+          refetchMarkets={refetchMarkets}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/MarketContent/MarketContent.tsx
+++ b/src/components/ui/lending/MarketContent/MarketContent.tsx
@@ -18,6 +18,7 @@ interface MarketContentProps {
   marketBorrowData?: Record<string, UserBorrowData>;
   marketSupplyData?: Record<string, UserSupplyData>;
   tokenTransferState: TokenTransferState;
+  refetchMarkets: () => void;
   filters: LendingFilters;
   sortConfig: LendingSortConfig | null;
   userAddress: string | undefined;
@@ -27,7 +28,7 @@ const MarketContent: React.FC<MarketContentProps> = ({
   unifiedReserves,
   userAddress,
   tokenTransferState,
-
+  refetchMarkets,
   filters,
   sortConfig,
 }) => {
@@ -118,6 +119,7 @@ const MarketContent: React.FC<MarketContentProps> = ({
           market={market}
           userAddress={userAddress}
           tokenTransferState={tokenTransferState}
+          refetchMarkets={refetchMarkets}
         />
       )}
       currentPage={currentPage}

--- a/src/components/ui/lending/UserContent/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowCard.tsx
@@ -19,14 +19,14 @@ import { TokenTransferState } from "@/types/web3";
 interface UserBorrowCardProps {
   unifiedReserve: UnifiedReserveData;
   userAddress: string | undefined;
-
+  refetchMarkets: () => void;
   tokenTransferState: TokenTransferState;
 }
 
 const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
   unifiedReserve,
   userAddress,
-
+  refetchMarkets,
   tokenTransferState,
 }) => {
   const [borrow] = unifiedReserve.userBorrowPositions;
@@ -103,6 +103,7 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
           reserve={unifiedReserve}
           userAddress={userAddress}
           tokenTransferState={tokenTransferState}
+          refetchMarkets={refetchMarkets}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/UserContent/UserBorrowContent.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowContent.tsx
@@ -12,6 +12,7 @@ interface UserBorrowContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
+  refetchMarkets: () => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -22,6 +23,7 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
+  refetchMarkets,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -106,6 +108,7 @@ const UserBorrowContent: React.FC<UserBorrowContentProps> = ({
           unifiedReserve={reserve}
           userAddress={userAddress}
           tokenTransferState={tokenTransferState}
+          refetchMarkets={refetchMarkets}
         />
       )}
       currentPage={currentPage}

--- a/src/components/ui/lending/UserContent/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyCard.tsx
@@ -27,6 +27,7 @@ interface UserSupplyCardProps {
   userAddress: string | undefined;
   tokenTransferState: TokenTransferState;
   isCollateralLoading?: boolean;
+  refetchMarkets: () => void;
 }
 
 const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
@@ -34,6 +35,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
   userAddress,
   tokenTransferState,
   isCollateralLoading = false,
+  refetchMarkets,
 }) => {
   const [supply] = unifiedReserve.userSupplyPositions;
   const balanceUsd = parseFloat(supply.balance.usd) || 0;
@@ -45,6 +47,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
   const { handleCollateralToggle } = useCollateralToggleOperations({
     userWalletAddress: userAddress || null,
     targetChain: reserveChain,
+    refetchMarkets: refetchMarkets,
   });
 
   const handleToggleClick = () => {
@@ -167,6 +170,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
           reserve={unifiedReserve}
           userAddress={userAddress}
           tokenTransferState={tokenTransferState}
+          refetchMarkets={refetchMarkets}
         >
           <BrandedButton
             buttonText="details"

--- a/src/components/ui/lending/UserContent/UserSupplyContent.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyContent.tsx
@@ -13,6 +13,7 @@ interface UserSupplyContentProps {
   tokenTransferState: TokenTransferState;
   filters?: LendingFilters;
   sortConfig?: LendingSortConfig | null;
+  refetchMarkets: () => void;
 }
 
 const ITEMS_PER_PAGE = 10;
@@ -23,6 +24,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
   tokenTransferState,
   filters,
   sortConfig,
+  refetchMarkets,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -107,6 +109,7 @@ const UserSupplyContent: React.FC<UserSupplyContentProps> = ({
           unifiedReserve={reserve}
           userAddress={userAddress}
           tokenTransferState={tokenTransferState}
+          refetchMarkets={refetchMarkets}
         />
       )}
       currentPage={currentPage}

--- a/src/hooks/lending/useBorrowOperations.ts
+++ b/src/hooks/lending/useBorrowOperations.ts
@@ -19,6 +19,7 @@ export interface BorrowOperationDependencies {
   sourceToken: Token | null;
   userWalletAddress: string | null;
   tokenBorrowState: TokenBorrowState;
+  refetchMarkets: () => void;
 }
 
 export interface BorrowOperationResult {
@@ -108,6 +109,7 @@ export const useBorrowOperations = (
               result.transactionHash!,
             )}`,
           });
+          dependencies.refetchMarkets();
         } else {
           console.error("Borrow failed:", result.error);
           toast.error("Borrow failed", {
@@ -132,6 +134,7 @@ export const useBorrowOperations = (
       sourceChain,
       executeBorrow,
       switchToChain,
+      dependencies,
     ],
   );
 

--- a/src/hooks/lending/useCollateralToggleOperations.ts
+++ b/src/hooks/lending/useCollateralToggleOperations.ts
@@ -13,6 +13,7 @@ import { getChainByChainId } from "@/config/chains";
 export interface CollateralToggleOperationDependencies {
   userWalletAddress: string | null;
   targetChain: Chain | null;
+  refetchMarkets: () => void;
 }
 
 export interface CollateralToggleOperationResult {
@@ -102,6 +103,7 @@ export const useCollateralToggleOperations = (
               result.transactionHash!,
             )}`,
           });
+          dependencies.refetchMarkets();
         } else {
           console.error("Collateral toggle failed:", result.error);
           toast.error("Collateral toggle failed", {
@@ -119,7 +121,13 @@ export const useCollateralToggleOperations = (
         });
       }
     },
-    [userWalletAddress, targetChain, executeCollateralToggle, switchToChain],
+    [
+      userWalletAddress,
+      targetChain,
+      executeCollateralToggle,
+      switchToChain,
+      dependencies,
+    ],
   );
 
   return {

--- a/src/hooks/lending/useRepayOperations.ts
+++ b/src/hooks/lending/useRepayOperations.ts
@@ -20,6 +20,7 @@ export interface RepayOperationDependencies {
   sourceToken: Token | null;
   userWalletAddress: string | null;
   tokenRepayState: TokenRepayState;
+  refetchMarkets: () => void;
 }
 
 export interface RepayOperationResult {
@@ -165,6 +166,7 @@ export const useRepayOperations = (
               result.transactionHash!,
             )}`,
           });
+          dependencies.refetchMarkets();
         } else {
           console.error("Repay failed:", result.error);
           toast.error("Repay failed", {
@@ -190,6 +192,7 @@ export const useRepayOperations = (
       executeRepay,
       signPermit,
       switchToChain,
+      dependencies,
     ],
   );
 

--- a/src/hooks/lending/useSupplyOperations.ts
+++ b/src/hooks/lending/useSupplyOperations.ts
@@ -20,6 +20,7 @@ export interface SupplyOperationDependencies {
   sourceToken: Token | null;
   userWalletAddress: string | null;
   tokenTransferState: TokenTransferState;
+  refetchMarkets: () => void;
 }
 
 export interface SupplyOperationResult {
@@ -161,6 +162,7 @@ export const useSupplyOperations = (
               result.transactionHash!,
             )}`,
           });
+          dependencies.refetchMarkets();
         } else {
           console.error("Supply failed:", result.error);
           toast.error("Supply failed", {
@@ -186,6 +188,7 @@ export const useSupplyOperations = (
       executeSupply,
       signPermit,
       switchToChain,
+      dependencies,
     ],
   );
 

--- a/src/hooks/lending/useWithdrawOperations.ts
+++ b/src/hooks/lending/useWithdrawOperations.ts
@@ -19,6 +19,7 @@ export interface WithdrawOperationDependencies {
   sourceToken: Token | null;
   userWalletAddress: string | null;
   tokenWithdrawState: TokenWithdrawState;
+  refetchMarkets: () => void;
 }
 
 export interface WithdrawOperationResult {
@@ -111,6 +112,7 @@ export const useWithdrawOperations = (
               result.transactionHash!,
             )}`,
           });
+          dependencies.refetchMarkets();
         } else {
           console.error("Withdraw failed:", result.error);
           toast.error("Withdraw failed", {
@@ -135,6 +137,7 @@ export const useWithdrawOperations = (
       sourceChain,
       executeWithdraw,
       switchToChain,
+      dependencies,
     ],
   );
 


### PR DESCRIPTION
branch off #386, please see 07bbb52b0f2b3434e096d030756d510520531a81

---

this PR passes down the `refetchMarkets` hook to all modals which implement an interaction. the operations hooks have all been modified to accept `refetchMarkets` as a prop (just like in the emode operations hook already had). This kills two birds with one stone - the modal automatically closes due to the reserves data being refreshed.

all interactions have been tested with successful outcomes.