### PR TITLE
feat: manual refresh button

### DIFF
--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useEffect, useMemo } from "react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
-import { History } from "lucide-react";
+import { History, RefreshCw } from "lucide-react";
 import SortDropdown from "@/components/ui/lending/SortDropdown";
 import AssetFilter from "@/components/ui/AssetFilter";
 import { Chain } from "@/types/web3";
@@ -212,9 +212,9 @@ export default function LendingPage() {
                     />
                   </div>
 
-                  {/* Right Side: Sort Dropdown and Asset Filter */}
+                  {/* Right Side: Sort Dropdown, Asset Filter, and Refresh Button */}
                   <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center xl:shrink-0">
-                    {/* Sort Dropdown and Asset Filter - side by side */}
+                    {/* Sort Dropdown, Asset Filter, and Refresh Button - side by side */}
                     <div className="flex gap-4 w-full sm:w-auto">
                       <div className="flex-1 sm:flex-none">
                         <SortDropdown
@@ -237,6 +237,16 @@ export default function LendingPage() {
                           mobilePlaceholder="filter by asset"
                           className="w-full sm:w-60"
                         />
+                      </div>
+                      <div className="flex-none">
+                        <Button
+                          onClick={refetchMarkets}
+                          variant="outline"
+                          size="sm"
+                          className="bg-[#18181B] border-[#27272A] text-[#FAFAFA] hover:bg-[#1C1C1F] hover:border-[#3F3F46] h-8 px-3"
+                        >
+                          <RefreshCw className="h-4 w-4" />
+                        </Button>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
this PR adds a manual refresh button to the to right of the lending page, which is always visible. on click it calls `refetchMarkets`.

### Screenshots
## Desktop
<img width="2466" height="2360" alt="Screenshot 2025-09-17 at 9 31 34 pm" src="https://github.com/user-attachments/assets/9cfe66ef-77cc-44dc-a564-c691cf20c1b8" />

## Tablet
<img width="1934" height="2574" alt="Screenshot 2025-09-17 at 9 31 49 pm" src="https://github.com/user-attachments/assets/345a68d9-b184-4507-9a77-5cf974909855" />

## Mobile
<img width="854" height="1860" alt="Screenshot 2025-09-17 at 9 31 55 pm" src="https://github.com/user-attachments/assets/885b40ab-77d8-4889-8077-8800ae3c796f" />
