### PR TITLE
feat: add emodeBorrowDisabled property to UnifiedReserveData

### DIFF
--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -183,6 +183,7 @@ export interface UnifiedReserveData extends Reserve {
   userSupplyPositions: MarketUserReserveSupplyPosition[];
   userBorrowPositions: MarketUserReserveBorrowPosition[];
   emodeCategory: EmodeMarketCategory | null;
+  emodeBorrowDisabled: boolean;
 }
 
 export type EModeStatus = "on" | "off" | "mixed";


### PR DESCRIPTION
This PR adds a property to `UnifiedReserveData` to ascertain whether it is disabled for borrowing due to the currently enabled e-mode category.

It has been implemented as part of `unifyMarkets`. It appears twice because one check is for supply reserves and one is for borrow reserves.

---

Verification when ETH-correlated e-mode is enabled:

<img width="936" height="927" alt="image" src="https://github.com/user-attachments/assets/e4d566ba-34c3-46f8-8dc6-6a1019cc7b7d" />
