### PR TITLE
feat: display emode disabled positions in AvailableBorrowContent

### DIFF
--- a/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
@@ -58,6 +58,7 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
   const isAvailable =
     !reserve.isFrozen &&
     !reserve.isPaused &&
+    !reserve.emodeBorrowDisabled &&
     reserve.borrowInfo?.borrowingState === "ENABLED";
   const hasLiquidity = availableUsd > 0;
 
@@ -78,38 +79,26 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
-              {reserve.underlyingToken.name}
-            </CardTitle>
+            <Tooltip.Provider>
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none flex-1 min-w-0 truncate cursor-help">
+                    {reserve.underlyingToken.name}
+                  </CardTitle>
+                </Tooltip.Trigger>
+                <Tooltip.Portal>
+                  <Tooltip.Content
+                    className="bg-[#18181B] border border-[#27272A] text-white text-xs px-2 py-1 rounded shadow-lg"
+                    sideOffset={5}
+                  >
+                    {reserve.underlyingToken.name}
+                    <Tooltip.Arrow className="fill-[#27272A]" />
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              </Tooltip.Root>
+            </Tooltip.Provider>
             {(!isAvailable || !hasLiquidity) && (
-              <Tooltip.Provider>
-                <Tooltip.Root>
-                  <Tooltip.Trigger asChild>
-                    <AlertTriangle className="w-4 h-4 text-red-400" />
-                  </Tooltip.Trigger>
-                  <Tooltip.Portal>
-                    <Tooltip.Content
-                      className="bg-[#18181B] border border-[#27272A] text-white text-xs px-2 py-1 rounded shadow-lg"
-                      sideOffset={5}
-                    >
-                      {!hasLiquidity
-                        ? "No Liquidity"
-                        : reserve.isFrozen && reserve.isPaused
-                          ? "Frozen, Paused"
-                          : reserve.isFrozen
-                            ? "Frozen"
-                            : reserve.isPaused
-                              ? "Paused"
-                              : !reserve.borrowInfo?.borrowingState ||
-                                  reserve.borrowInfo?.borrowingState ===
-                                    "DISABLED"
-                                ? "Borrow Disabled"
-                                : "Not Available"}
-                      <Tooltip.Arrow className="fill-[#27272A]" />
-                    </Tooltip.Content>
-                  </Tooltip.Portal>
-                </Tooltip.Root>
-              </Tooltip.Provider>
+              <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0" />
             )}
           </div>
           <CardDescription className="text-[#A1A1AA] text-xs mt-1 flex items-center gap-1">
@@ -124,6 +113,24 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
               }}
             />
             {reserve.marketName}
+            {(!isAvailable || !hasLiquidity) && (
+              <span className="ml-1 text-red-400">
+                {!hasLiquidity
+                  ? "(No Liquidity)"
+                  : reserve.isFrozen && reserve.isPaused
+                    ? "(Frozen, Paused)"
+                    : reserve.isFrozen
+                      ? "(Frozen)"
+                      : reserve.isPaused
+                        ? "(Paused)"
+                        : reserve.emodeBorrowDisabled
+                          ? "(Emode)"
+                          : !reserve.borrowInfo?.borrowingState ||
+                              reserve.borrowInfo?.borrowingState === "DISABLED"
+                            ? "(Borrow Disabled)"
+                            : "(Not Available)"}
+              </span>
+            )}
           </CardDescription>
         </div>
       </CardHeader>
@@ -178,7 +185,6 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
           <BrandedButton
             buttonText="details"
             className="w-full text-xs py-2 h-8"
-            disabled={!isAvailable || !hasLiquidity}
           />
         </AssetDetailsModal>
       </CardFooter>

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
@@ -21,6 +21,7 @@ import { UnifiedReserveData } from "@/types/aave";
 import { SquarePlus, SquareEqual, AlertTriangle } from "lucide-react";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetailsModal";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import { TokenTransferState } from "@/types/web3";
 
 interface AvailableSupplyCardProps {
@@ -65,10 +66,27 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
-              {reserve.underlyingToken.name}
-            </CardTitle>
-            {!isAvailable && <AlertTriangle className="w-4 h-4 text-red-400" />}
+            <Tooltip.Provider>
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none flex-1 min-w-0 truncate cursor-help">
+                    {reserve.underlyingToken.name}
+                  </CardTitle>
+                </Tooltip.Trigger>
+                <Tooltip.Portal>
+                  <Tooltip.Content
+                    className="bg-[#18181B] border border-[#27272A] text-white text-xs px-2 py-1 rounded shadow-lg"
+                    sideOffset={5}
+                  >
+                    {reserve.underlyingToken.name}
+                    <Tooltip.Arrow className="fill-[#27272A]" />
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              </Tooltip.Root>
+            </Tooltip.Provider>
+            {!isAvailable && (
+              <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0" />
+            )}
           </div>
           <CardDescription className="text-[#A1A1AA] text-xs mt-1 flex items-center gap-1">
             <Image
@@ -157,7 +175,6 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
           <BrandedButton
             buttonText="details"
             className="w-full text-xs py-2 h-8"
-            disabled={!isAvailable}
           />
         </AssetDetailsModal>
       </CardFooter>


### PR DESCRIPTION
This PR is concerned with tagging emode borrow-disabled positions in the available borrow positions section.

Action buttons are no longer disabled. 

---

Verification for ETH-correlated e-mode enabled:

<img width="1141" height="751" alt="image" src="https://github.com/user-attachments/assets/f8e96e0e-79b6-4257-a396-31a459470147" />

