### PR TITLE
feat: reflect e-mode disabled status in BorrowInfo

### DIFF
--- a/src/components/ui/lending/AssetDetails/BorrowInfoTab.tsx
+++ b/src/components/ui/lending/AssetDetails/BorrowInfoTab.tsx
@@ -140,21 +140,24 @@ export const BorrowInfoTab: React.FC<{
       <div className="bg-[#1F1F23] border border-[#27272A] rounded-lg p-4">
         <h3 className="text-sm font-medium text-white mb-3">borrow status</h3>
         <div className="flex flex-wrap gap-2">
-          {borrowInfo.borrowingState === "ENABLED" && (
-            <span className="px-2 py-1 bg-green-500/20 text-green-400 text-xs rounded-full border border-green-500/30">
-              enabled
-            </span>
-          )}
           {borrowInfo.borrowingState === "DISABLED" && (
             <span className="px-2 py-1 bg-red-500/20 text-red-400 text-xs rounded-full border border-red-500/30">
               disabled
             </span>
           )}
-          {borrowInfo.borrowingState === "USER_EMODE_DISABLED_BORROW" && (
-            <span className="px-2 py-1 bg-orange-500/20 text-orange-400 text-xs rounded-full border border-orange-500/30">
+          {(borrowInfo.borrowingState === "USER_EMODE_DISABLED_BORROW" ||
+            market.emodeBorrowDisabled) && (
+            <span className="px-2 py-1 bg-purple-500/20 text-purple-400 text-xs rounded-full border border-purple-500/30">
               e-mode disabled
             </span>
           )}
+          {borrowInfo.borrowingState !== "DISABLED" &&
+            borrowInfo.borrowingState !== "USER_EMODE_DISABLED_BORROW" &&
+            !market.emodeBorrowDisabled && (
+              <span className="px-2 py-1 bg-green-500/20 text-green-400 text-xs rounded-full border border-green-500/30">
+                enabled
+              </span>
+            )}
           {market.isFrozen && (
             <span className="px-2 py-1 bg-red-500/20 text-red-400 text-xs rounded-full border border-red-500/30">
               frozen


### PR DESCRIPTION
This PR is concerned with labelling e-mode disabled borrow assets in the `BorrowInfo` tab of the lending Asset Details modal. 

The conditions to assign labels have been slightly adjusted.

- If a reserve is frozen, add the frozen label
- If a reserve is paused, add the paused label
- If a reserve either has `USER_EMODE_DISABLED_BORROW` in its borrow status OR the `UnifiedReserveData` field's `emodeBorrowDisabled` boolean is `true`, then add the `e-mode disabled` label, and only if neither of the former conditions match, add the `enabled` label
    - It no longer suffices to simply check if an asset has the `ENABLED`  borrow status to add the `enabled` label as the return from the hook has been observed to be inconsistent

---

Verification for ETH-correlated e-mode enabled:

<img width="697" height="768" alt="image" src="https://github.com/user-attachments/assets/e0bb4b56-6b3d-4f04-816f-e001a578c6a3" />

vs.

<img width="658" height="745" alt="image" src="https://github.com/user-attachments/assets/4414d195-00ea-457c-9bd1-9ec3fc5a0538" />
