### PR TITLE
fix: missing DialogTitle in lending modals

### DIFF
--- a/src/components/ui/lending/ActionModals/BorrowAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/BorrowAssetModal.tsx
@@ -5,6 +5,7 @@ import {
   Dialog,
   DialogContent,
   DialogHeader,
+  DialogTitle,
   DialogTrigger,
 } from "@/components/ui/StyledDialog";
 import { UnifiedReserveData } from "@/types/aave";
@@ -56,9 +57,9 @@ const BorrowAssetModal: React.FC<BorrowAssetModalProps> = ({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="max-w-m max-h-[80vh] overflow-hidden bg-[#18181B] border border-[#27272A] text-white flex flex-col">
         <DialogHeader className="border-b border-[#27272A] pb-4 flex-shrink-0 text-left">
-          <h2 className="text-lg font-semibold">
+          <DialogTitle className="text-lg font-semibold">
             borrow {market.underlyingToken.symbol}
-          </h2>
+          </DialogTitle>
         </DialogHeader>
 
         <div className="flex-1 overflow-y-auto">

--- a/src/components/ui/lending/ActionModals/RepayAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/RepayAssetModal.tsx
@@ -5,6 +5,7 @@ import {
   Dialog,
   DialogContent,
   DialogHeader,
+  DialogTitle,
   DialogTrigger,
 } from "@/components/ui/StyledDialog";
 import { UnifiedReserveData } from "@/types/aave";
@@ -326,9 +327,9 @@ const RepayAssetModal: React.FC<RepayAssetModalProps> = ({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="max-w-m max-h-[80vh] overflow-hidden bg-[#18181B] border border-[#27272A] text-white flex flex-col">
         <DialogHeader className="border-b border-[#27272A] pb-4 flex-shrink-0 text-left">
-          <h2 className="text-lg font-semibold">
+          <DialogTitle className="text-lg font-semibold">
             repay {reserve.underlyingToken.symbol}
-          </h2>
+          </DialogTitle>
         </DialogHeader>
 
         <div className="flex-1 overflow-y-auto">

--- a/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/SupplyAssetModal.tsx
@@ -5,6 +5,7 @@ import {
   Dialog,
   DialogContent,
   DialogHeader,
+  DialogTitle,
   DialogTrigger,
 } from "@/components/ui/StyledDialog";
 import { UnifiedReserveData } from "@/types/aave";
@@ -318,9 +319,9 @@ const SupplyAssetModal: React.FC<SupplyAssetModalProps> = ({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="max-w-m max-h-[80vh] overflow-hidden bg-[#18181B] border border-[#27272A] text-white flex flex-col">
         <DialogHeader className="border-b border-[#27272A] pb-4 flex-shrink-0 text-left">
-          <h2 className="text-lg font-semibold">
+          <DialogTitle className="text-lg font-semibold">
             supply {market.underlyingToken.symbol}
-          </h2>
+          </DialogTitle>
         </DialogHeader>
 
         <div className="flex-1 overflow-y-auto">

--- a/src/components/ui/lending/ActionModals/WithdrawAssetModal.tsx
+++ b/src/components/ui/lending/ActionModals/WithdrawAssetModal.tsx
@@ -5,6 +5,7 @@ import {
   Dialog,
   DialogContent,
   DialogHeader,
+  DialogTitle,
   DialogTrigger,
 } from "@/components/ui/StyledDialog";
 import { UnifiedReserveData } from "@/types/aave";
@@ -82,9 +83,9 @@ const WithdrawAssetModal: React.FC<WithdrawAssetModalProps> = ({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="max-w-m max-h-[80vh] overflow-hidden bg-[#18181B] border border-[#27272A] text-white flex flex-col">
         <DialogHeader className="border-b border-[#27272A] pb-4 flex-shrink-0 text-left">
-          <h2 className="text-lg font-semibold">
+          <DialogTitle className="text-lg font-semibold">
             withdraw {market.underlyingToken.symbol}
-          </h2>
+          </DialogTitle>
         </DialogHeader>
 
         <div className="flex-1 overflow-y-auto">


### PR DESCRIPTION
This PR addresses the requirement for `Dialog` components to have a `DialogTitle`. there is a rather aggressive crashing error user-side otherwise!