### PR TITLE
chore: normalised dashboard cards

### DIFF
--- a/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableBorrowCard.tsx
@@ -21,7 +21,6 @@ import { UnifiedReserveData } from "@/types/aave";
 import { SquareMinus, SquareEqual, AlertTriangle } from "lucide-react";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetailsModal";
-import * as Tooltip from "@radix-ui/react-tooltip";
 import { TokenTransferState } from "@/types/web3";
 
 interface AvailableBorrowCardProps {
@@ -79,24 +78,12 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <Tooltip.Provider>
-              <Tooltip.Root>
-                <Tooltip.Trigger asChild>
-                  <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none flex-1 min-w-0 truncate cursor-help">
-                    {reserve.underlyingToken.name}
-                  </CardTitle>
-                </Tooltip.Trigger>
-                <Tooltip.Portal>
-                  <Tooltip.Content
-                    className="bg-[#18181B] border border-[#27272A] text-white text-xs px-2 py-1 rounded shadow-lg"
-                    sideOffset={5}
-                  >
-                    {reserve.underlyingToken.name}
-                    <Tooltip.Arrow className="fill-[#27272A]" />
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-              </Tooltip.Root>
-            </Tooltip.Provider>
+            <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
+              <TruncatedText
+                text={reserve.underlyingToken.name}
+                maxLength={19}
+              />
+            </CardTitle>
             {(!isAvailable || !hasLiquidity) && (
               <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0" />
             )}
@@ -112,7 +99,7 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
                 e.currentTarget.src = "/images/markets/default.svg";
               }}
             />
-            {reserve.marketName}
+            <TruncatedText text={reserve.marketName} maxLength={25} />
             {(!isAvailable || !hasLiquidity) && (
               <span className="ml-1 text-red-400">
                 {!hasLiquidity
@@ -159,7 +146,7 @@ const AvailableBorrowCard: React.FC<AvailableBorrowCardProps> = ({
             <div
               className={`text-sm font-semibold font-mono ${hasLiquidity ? "text-[#FAFAFA]" : "text-red-400"}`}
             >
-              {formatBalance(availableTokens)}{" "}
+              {formatBalance(availableTokens, 3)}{" "}
               <TruncatedText
                 text={reserve.underlyingToken.symbol}
                 maxLength={6}

--- a/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
+++ b/src/components/ui/lending/AvailableContent/AvailableSupplyCard.tsx
@@ -21,7 +21,6 @@ import { UnifiedReserveData } from "@/types/aave";
 import { SquarePlus, SquareEqual, AlertTriangle } from "lucide-react";
 import { calculateApyWithIncentives } from "@/utils/lending/incentives";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetailsModal";
-import * as Tooltip from "@radix-ui/react-tooltip";
 import { TokenTransferState } from "@/types/web3";
 
 interface AvailableSupplyCardProps {
@@ -66,24 +65,12 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <Tooltip.Provider>
-              <Tooltip.Root>
-                <Tooltip.Trigger asChild>
-                  <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none flex-1 min-w-0 truncate cursor-help">
-                    {reserve.underlyingToken.name}
-                  </CardTitle>
-                </Tooltip.Trigger>
-                <Tooltip.Portal>
-                  <Tooltip.Content
-                    className="bg-[#18181B] border border-[#27272A] text-white text-xs px-2 py-1 rounded shadow-lg"
-                    sideOffset={5}
-                  >
-                    {reserve.underlyingToken.name}
-                    <Tooltip.Arrow className="fill-[#27272A]" />
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-              </Tooltip.Root>
-            </Tooltip.Provider>
+            <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
+              <TruncatedText
+                text={reserve.underlyingToken.name}
+                maxLength={19}
+              />
+            </CardTitle>
             {!isAvailable && (
               <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0" />
             )}
@@ -99,7 +86,7 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
                 e.currentTarget.src = "/images/markets/default.svg";
               }}
             />
-            {reserve.marketName}
+            <TruncatedText text={reserve.marketName} maxLength={25} />
             {!isAvailable && (
               <span className="ml-1 text-red-400">
                 {reserve.isFrozen && reserve.isPaused
@@ -135,7 +122,7 @@ const AvailableSupplyCard: React.FC<AvailableSupplyCardProps> = ({
           <div className="text-[#A1A1AA] text-sm">total supplied</div>
           <div className="text-right">
             <div className="text-[#FAFAFA] text-sm font-semibold font-mono">
-              {formatBalance(totalSupplied)}{" "}
+              {formatBalance(totalSupplied, 3)}{" "}
               <TruncatedText
                 text={reserve.underlyingToken.symbol}
                 maxLength={6}

--- a/src/components/ui/lending/UserContent/UserBorrowCard.tsx
+++ b/src/components/ui/lending/UserContent/UserBorrowCard.tsx
@@ -15,6 +15,7 @@ import { formatCurrency, formatPercentage } from "@/utils/formatters";
 import { UnifiedReserveData } from "@/types/aave";
 import AssetDetailsModal from "@/components/ui/lending/AssetDetails/AssetDetailsModal";
 import { TokenTransferState } from "@/types/web3";
+import TruncatedText from "@/components/ui/TruncatedText";
 
 interface UserBorrowCardProps {
   unifiedReserve: UnifiedReserveData;
@@ -65,7 +66,7 @@ const UserBorrowCard: React.FC<UserBorrowCardProps> = ({
                 e.currentTarget.src = "/images/markets/default.svg";
               }}
             />
-            {borrow.market.name}
+            <TruncatedText text={borrow.market.name} maxLength={25} />
           </CardDescription>
         </div>
       </CardHeader>

--- a/src/components/ui/lending/UserContent/UserSupplyCard.tsx
+++ b/src/components/ui/lending/UserContent/UserSupplyCard.tsx
@@ -21,6 +21,7 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 import { TokenTransferState } from "@/types/web3";
 import { useCollateralToggleOperations } from "@/hooks/lending/useCollateralToggleOperations";
 import { getChainByChainId } from "@/config/chains";
+import TruncatedText from "@/components/ui/TruncatedText";
 
 interface UserSupplyCardProps {
   unifiedReserve: UnifiedReserveData;
@@ -78,7 +79,7 @@ const UserSupplyCard: React.FC<UserSupplyCardProps> = ({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <CardTitle className="text-sm font-semibold text-[#FAFAFA] leading-none">
-              {supply.currency.name}
+              <TruncatedText text={supply.currency.name} maxLength={28} />
             </CardTitle>
             <div className="flex items-center gap-2">
               <Tooltip.Provider>


### PR DESCRIPTION
this PR normalises the dashboard cards (in a similar exercise to what I did in #398) to ensure there aren't any stragglers with extra height.

I have applied the same restrictions as done with the Market cards - I have also removed the ugly Tooltip implementation in the available supply/borrow cards and replaced it with `<TruncatedText />`.