### PR TITLE
feat: persist lending tab state

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,7 +4,7 @@ set -eou pipefail
 npx prettier --write "**/*.{ts,tsx,js,jsx,json}" && git add -A
 npm run lint
 
-if git diff --staged --name-only | grep -q "src/store/web3Store.ts"; then
+if git diff --staged --name-only | grep -q '^src/store/.*\.ts$'; then
   current_version=$(grep -o 'STORE_VERSION = [0-9]\+' src/store/storeVersion.ts | grep -o '[0-9]\+')
   new_version=$((current_version + 1))
   sed -i "s/STORE_VERSION = [0-9]\+/STORE_VERSION = $new_version/" src/store/storeVersion.ts

--- a/src/app/(dapp)/lending/page.tsx
+++ b/src/app/(dapp)/lending/page.tsx
@@ -1,4 +1,6 @@
 "use client";
+
+import useUIStore from "@/store/uiStore";
 import { useState, useEffect, useMemo } from "react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 import { History, RefreshCw } from "lucide-react";
@@ -35,11 +37,11 @@ import HistoryContent from "@/components/ui/lending/TransactionHistoryContent/Tr
 import { useTokenTransfer } from "@/utils/swap/walletMethods";
 import { LendingFilters, LendingSortConfig } from "@/types/lending";
 import { Button } from "@/components/ui/Button";
-
-type LendingTabType = "markets" | "dashboard" | "staking" | "history";
+import { LendingTabType } from "@/store/uiStore";
 
 export default function LendingPage() {
-  const [activeTab, setActiveTab] = useState<LendingTabType>("markets");
+  const { lending, setLendingActiveMainTab } = useUIStore();
+  const activeTab = lending.activeMainTab;
   const [filters, setFilters] = useState<LendingFilters>({
     assetFilter: "",
   });
@@ -106,7 +108,7 @@ export default function LendingPage() {
   const handleTabChange = (value: LendingTabType) => {
     // Only update if a valid value is provided (prevents deselection)
     if (value) {
-      setActiveTab(value);
+      setLendingActiveMainTab(value);
       // Reset sort when switching tabs
       setSortConfig(null);
       setSortDropdownValue("");

--- a/src/components/ui/lending/DashboardContent/DashboardContent.tsx
+++ b/src/components/ui/lending/DashboardContent/DashboardContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import useUIStore from "@/store/uiStore";
 import { useState, useEffect } from "react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/ToggleGroup";
 import { Info } from "lucide-react";
@@ -48,9 +49,16 @@ export default function DashboardContent({
   onSubsectionChange,
   refetchMarkets,
 }: DashboardContentProps) {
-  const [isSupplyMode, setIsSupplyMode] = useState(true);
-  const [showAvailable, setShowAvailable] = useState(true);
-  const [showZeroBalance, setShowZeroBalance] = useState(false);
+  const {
+    lending,
+    setLendingDashboardSupplyMode,
+    setLendingDashboardShowAvailable,
+    setLendingDashboardShowZeroBalance,
+  } = useUIStore();
+
+  const isSupplyMode = lending.dashboardSupplyMode;
+  const showAvailable = lending.dashboardShowAvailable;
+  const showZeroBalance = lending.dashboardShowZeroBalance;
   const [isRiskDetailsModalOpen, setIsRiskDetailsModalOpen] = useState(false);
   const [isEmodeModalOpen, setIsEmodeModalOpen] = useState(false);
 
@@ -201,7 +209,9 @@ export default function DashboardContent({
             <ToggleGroup
               type="single"
               value={isSupplyMode ? "supply" : "borrow"}
-              onValueChange={(value) => setIsSupplyMode(value === "supply")}
+              onValueChange={(value) =>
+                setLendingDashboardSupplyMode(value === "supply")
+              }
             >
               <ToggleGroupItem
                 value="supply"
@@ -226,7 +236,9 @@ export default function DashboardContent({
                     ? "supplied"
                     : "borrowed"
               }
-              onValueChange={(value) => setShowAvailable(value === "available")}
+              onValueChange={(value) =>
+                setLendingDashboardShowAvailable(value === "available")
+              }
             >
               <ToggleGroupItem
                 value="available"
@@ -250,7 +262,9 @@ export default function DashboardContent({
                 <input
                   type="checkbox"
                   checked={showZeroBalance}
-                  onChange={(e) => setShowZeroBalance(e.target.checked)}
+                  onChange={(e) =>
+                    setLendingDashboardShowZeroBalance(e.target.checked)
+                  }
                   className="w-4 h-4 bg-[#27272A] border border-[#3F3F46] rounded text-amber-500"
                 />
                 <span className="text-xs text-[#A1A1AA]">

--- a/src/store/storeVersion.ts
+++ b/src/store/storeVersion.ts
@@ -1,1 +1,1 @@
-export const STORE_VERSION = 11;
+export const STORE_VERSION = 12;

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -4,6 +4,16 @@ import { Tab } from "@/types/ui";
 
 type Theme = "light" | "dark";
 
+//lending
+export type LendingTabType = "markets" | "dashboard" | "staking" | "history";
+
+interface LendingState {
+  activeMainTab: LendingTabType;
+  dashboardSupplyMode: boolean;
+  dashboardShowAvailable: boolean;
+  dashboardShowZeroBalance: boolean;
+}
+
 interface UIStoreState {
   activeTab: Tab;
   setActiveTab: (tab: Tab) => void;
@@ -14,6 +24,12 @@ interface UIStoreState {
   setSourceTokenSelectOpen: (open: boolean) => void;
   destinationTokenSelectOpen: boolean;
   setDestinationTokenSelectOpen: (open: boolean) => void;
+  // lending
+  lending: LendingState;
+  setLendingActiveMainTab: (tab: LendingTabType) => void;
+  setLendingDashboardSupplyMode: (isSupply: boolean) => void;
+  setLendingDashboardShowAvailable: (showAvailable: boolean) => void;
+  setLendingDashboardShowZeroBalance: (showZeroBalance: boolean) => void;
 }
 
 // Safely update DOM theme
@@ -53,6 +69,32 @@ const useUIStore = create<UIStoreState>()(
       setDestinationTokenSelectOpen: (open) => {
         return set({ destinationTokenSelectOpen: open });
       },
+      // lending
+      lending: {
+        activeMainTab: "markets",
+        dashboardSupplyMode: true,
+        dashboardShowAvailable: true,
+        dashboardShowZeroBalance: false,
+      },
+      setLendingActiveMainTab: (tab) =>
+        set((state) => ({
+          lending: { ...state.lending, activeMainTab: tab },
+        })),
+      setLendingDashboardSupplyMode: (isSupply) =>
+        set((state) => ({
+          lending: { ...state.lending, dashboardSupplyMode: isSupply },
+        })),
+      setLendingDashboardShowAvailable: (showAvailable) =>
+        set((state) => ({
+          lending: { ...state.lending, dashboardShowAvailable: showAvailable },
+        })),
+      setLendingDashboardShowZeroBalance: (showZeroBalance) =>
+        set((state) => ({
+          lending: {
+            ...state.lending,
+            dashboardShowZeroBalance: showZeroBalance,
+          },
+        })),
     }),
     {
       name: "altverse-storage-ui",


### PR DESCRIPTION
This PR persists tab selection between `markets` | `history` | `dashboard` and between dashboard tabs `borrow` | `supply` and `available` | `borrow`.

Unfortunately there's still a flash delay where markets gets loaded first. But on `refreshMarkets()` or page refresh not dropping state with a tiny delay is still presently preferable.

The flash delay will be fixed.